### PR TITLE
Fix AU915 and US915 LR-FHSS channels max data rate indices

### DIFF
--- a/pkg/band/au_915_928.go
+++ b/pkg/band/au_915_928.go
@@ -41,19 +41,19 @@ var (
 		{9, 8, 8, 8, 8, 8},
 	}
 
-	au915928UplinkChannels = func(delta ttnpb.DataRateIndex) []Channel {
+	au915928UplinkChannels = func(commonDelta, wideChannelDelta ttnpb.DataRateIndex) []Channel {
 		uplinkChannels := make([]Channel, 0, 72)
 		for i := 0; i < 64; i++ {
 			uplinkChannels = append(uplinkChannels, Channel{
 				Frequency:   uint64(915200000 + 200000*i),
-				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5 + delta,
+				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5 + commonDelta,
 			})
 		}
 		for i := 0; i < 8; i++ {
 			uplinkChannels = append(uplinkChannels, Channel{
 				Frequency:   uint64(915900000 + 1600000*i),
-				MinDataRate: ttnpb.DataRateIndex_DATA_RATE_6 + delta,
-				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_6 + delta,
+				MinDataRate: ttnpb.DataRateIndex_DATA_RATE_6 + commonDelta,
+				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_6 + commonDelta + wideChannelDelta,
 			})
 		}
 		return uplinkChannels

--- a/pkg/band/au_915_928_rp1_v1_0_2.go
+++ b/pkg/band/au_915_928_rp1_v1_0_2.go
@@ -23,7 +23,7 @@ var AU_915_928_RP1_v1_0_2 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    au915928UplinkChannels(-2),
+	UplinkChannels:    au915928UplinkChannels(-2, 0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    au915928DownlinkChannels,

--- a/pkg/band/au_915_928_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/au_915_928_rp1_v1_0_2_rev_b.go
@@ -23,7 +23,7 @@ var AU_915_928_RP1_v1_0_2_RevB = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    au915928UplinkChannels(0),
+	UplinkChannels:    au915928UplinkChannels(0, 0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    au915928DownlinkChannels,

--- a/pkg/band/au_915_928_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/au_915_928_rp1_v1_0_3_rev_a.go
@@ -23,7 +23,7 @@ var AU_915_928_RP1_v1_0_3_RevA = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    au915928UplinkChannels(0),
+	UplinkChannels:    au915928UplinkChannels(0, 0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    au915928DownlinkChannels,

--- a/pkg/band/au_915_928_rp1_v1_1_rev_a.go
+++ b/pkg/band/au_915_928_rp1_v1_1_rev_a.go
@@ -23,7 +23,7 @@ var AU_915_928_RP1_v1_1_RevA = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    au915928UplinkChannels(0),
+	UplinkChannels:    au915928UplinkChannels(0, 0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    au915928DownlinkChannels,

--- a/pkg/band/au_915_928_rp1_v1_1_rev_b.go
+++ b/pkg/band/au_915_928_rp1_v1_1_rev_b.go
@@ -23,7 +23,7 @@ var AU_915_928_RP1_v1_1_RevB = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    au915928UplinkChannels(0),
+	UplinkChannels:    au915928UplinkChannels(0, 0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    au915928DownlinkChannels,

--- a/pkg/band/au_915_928_rp2_v1_0_0.go
+++ b/pkg/band/au_915_928_rp2_v1_0_0.go
@@ -23,7 +23,7 @@ var AU_915_928_RP2_v1_0_0 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    au915928UplinkChannels(0),
+	UplinkChannels:    au915928UplinkChannels(0, 0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    au915928DownlinkChannels,

--- a/pkg/band/au_915_928_rp2_v1_0_1.go
+++ b/pkg/band/au_915_928_rp2_v1_0_1.go
@@ -23,7 +23,7 @@ var AU_915_928_RP2_v1_0_1 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    au915928UplinkChannels(0),
+	UplinkChannels:    au915928UplinkChannels(0, 0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    au915928DownlinkChannels,

--- a/pkg/band/au_915_928_rp2_v1_0_2.go
+++ b/pkg/band/au_915_928_rp2_v1_0_2.go
@@ -23,7 +23,7 @@ var AU_915_928_RP2_v1_0_2 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    au915928UplinkChannels(0),
+	UplinkChannels:    au915928UplinkChannels(0, 1),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    au915928DownlinkChannels,

--- a/pkg/band/au_915_928_rp2_v1_0_3.go
+++ b/pkg/band/au_915_928_rp2_v1_0_3.go
@@ -23,7 +23,7 @@ var AU_915_928_RP2_v1_0_3 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    au915928UplinkChannels(0),
+	UplinkChannels:    au915928UplinkChannels(0, 1),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    au915928DownlinkChannels,

--- a/pkg/band/au_915_928_ts1_v1_0_1.go
+++ b/pkg/band/au_915_928_ts1_v1_0_1.go
@@ -23,7 +23,7 @@ var AU_915_928_TS1_v1_0_1 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    au915928UplinkChannels(-2),
+	UplinkChannels:    au915928UplinkChannels(-2, 0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    au915928DownlinkChannels,

--- a/pkg/band/band_test.go
+++ b/pkg/band/band_test.go
@@ -673,3 +673,30 @@ func TestBeacon(t *testing.T) {
 		})
 	}
 }
+
+func TestChannelsWellDefined(t *testing.T) {
+	t.Parallel()
+
+	for name, versions := range All {
+		for version, b := range versions {
+			b := b
+			t.Run(fmt.Sprintf("%v/%v", name, version), func(t *testing.T) {
+				t.Parallel()
+
+				a := assertions.New(t)
+				assertCh := func(ch Channel) {
+					a.So(ch.MinDataRate, should.BeLessThanOrEqualTo, ch.MaxDataRate)
+					a.So(b.DataRates, should.ContainKey, ch.MinDataRate)
+					a.So(b.DataRates, should.ContainKey, ch.MaxDataRate)
+				}
+
+				for _, ch := range b.UplinkChannels {
+					assertCh(ch)
+				}
+				for _, ch := range b.DownlinkChannels {
+					assertCh(ch)
+				}
+			})
+		}
+	}
+}

--- a/pkg/band/cn_470_510_20_a.go
+++ b/pkg/band/cn_470_510_20_a.go
@@ -22,12 +22,13 @@ const (
 )
 
 var (
-	cn47051020AUplinkChannels = func() []Channel {
+	cn47051020AUplinkChannels = func(minDataRateIndex ttnpb.DataRateIndex) []Channel {
 		uplinkChannels := make([]Channel, 0, 64)
 		// 20 MHz Type A Group 1
 		for i := 0; i < 32; i++ {
 			uplinkChannels = append(uplinkChannels, Channel{
 				Frequency:   uint64(470300000 + 200000*i),
+				MinDataRate: minDataRateIndex,
 				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5,
 			})
 		}
@@ -35,18 +36,20 @@ var (
 		for i := 0; i < 32; i++ {
 			uplinkChannels = append(uplinkChannels, Channel{
 				Frequency:   uint64(503500000 + 200000*i),
+				MinDataRate: minDataRateIndex,
 				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5,
 			})
 		}
 		return uplinkChannels
-	}()
+	}
 
-	cn47051020ADownlinkChannels = func() []Channel {
+	cn47051020ADownlinkChannels = func(minDataRateIndex ttnpb.DataRateIndex) []Channel {
 		downlinkChannels := make([]Channel, 0, 64)
 		// 20 MHz Type A Group 1
 		for i := 0; i < 32; i++ {
 			downlinkChannels = append(downlinkChannels, Channel{
 				Frequency:   uint64(483900000 + 200000*i),
+				MinDataRate: minDataRateIndex,
 				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5,
 			})
 		}
@@ -54,9 +57,10 @@ var (
 		for i := 0; i < 32; i++ {
 			downlinkChannels = append(downlinkChannels, Channel{
 				Frequency:   uint64(490300000 + 200000*i),
+				MinDataRate: minDataRateIndex,
 				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5,
 			})
 		}
 		return downlinkChannels
-	}()
+	}
 )

--- a/pkg/band/cn_470_510_20_a_rp2_v1_0_0.go
+++ b/pkg/band/cn_470_510_20_a_rp2_v1_0_0.go
@@ -23,10 +23,10 @@ var CN_470_510_20_A_RP2_v1_0_0 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
-	UplinkChannels:    cn47051020AUplinkChannels,
+	UplinkChannels:    cn47051020AUplinkChannels(0),
 
 	MaxDownlinkChannels: 64,
-	DownlinkChannels:    cn47051020ADownlinkChannels,
+	DownlinkChannels:    cn47051020ADownlinkChannels(0),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_20_a_rp2_v1_0_1.go
+++ b/pkg/band/cn_470_510_20_a_rp2_v1_0_1.go
@@ -23,10 +23,10 @@ var CN_470_510_20_A_RP2_v1_0_1 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
-	UplinkChannels:    cn47051020AUplinkChannels,
+	UplinkChannels:    cn47051020AUplinkChannels(1),
 
 	MaxDownlinkChannels: 64,
-	DownlinkChannels:    cn47051020ADownlinkChannels,
+	DownlinkChannels:    cn47051020ADownlinkChannels(1),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_20_a_rp2_v1_0_2.go
+++ b/pkg/band/cn_470_510_20_a_rp2_v1_0_2.go
@@ -23,10 +23,10 @@ var CN_470_510_20_A_RP2_v1_0_2 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
-	UplinkChannels:    cn47051020AUplinkChannels,
+	UplinkChannels:    cn47051020AUplinkChannels(1),
 
 	MaxDownlinkChannels: 64,
-	DownlinkChannels:    cn47051020ADownlinkChannels,
+	DownlinkChannels:    cn47051020ADownlinkChannels(1),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_20_a_rp2_v1_0_3.go
+++ b/pkg/band/cn_470_510_20_a_rp2_v1_0_3.go
@@ -23,10 +23,10 @@ var CN_470_510_20_A_RP2_v1_0_3 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
-	UplinkChannels:    cn47051020AUplinkChannels,
+	UplinkChannels:    cn47051020AUplinkChannels(1),
 
 	MaxDownlinkChannels: 64,
-	DownlinkChannels:    cn47051020ADownlinkChannels,
+	DownlinkChannels:    cn47051020ADownlinkChannels(1),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_20_b.go
+++ b/pkg/band/cn_470_510_20_b.go
@@ -22,12 +22,13 @@ const (
 )
 
 var (
-	cn47051020BUplinkChannels = func() []Channel {
+	cn47051020BUplinkChannels = func(minDataRateIndex ttnpb.DataRateIndex) []Channel {
 		uplinkChannels := make([]Channel, 0, 64)
 		// 20 MHz Type B Group 1
 		for i := 0; i < 32; i++ {
 			uplinkChannels = append(uplinkChannels, Channel{
 				Frequency:   uint64(476900000 + 200000*i),
+				MinDataRate: minDataRateIndex,
 				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5,
 			})
 		}
@@ -35,18 +36,20 @@ var (
 		for i := 0; i < 32; i++ {
 			uplinkChannels = append(uplinkChannels, Channel{
 				Frequency:   uint64(496900000 + 200000*i),
+				MinDataRate: minDataRateIndex,
 				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5,
 			})
 		}
 		return uplinkChannels
-	}()
+	}
 
-	cn47051020BDownlinkChannels = func() []Channel {
+	cn47051020BDownlinkChannels = func(minDataRateIndex ttnpb.DataRateIndex) []Channel {
 		downlinkChannels := make([]Channel, 0, 64)
 		// 20 MHz Type B Group 1
 		for i := 0; i < 32; i++ {
 			downlinkChannels = append(downlinkChannels, Channel{
 				Frequency:   uint64(476900000 + 200000*i),
+				MinDataRate: minDataRateIndex,
 				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5,
 			})
 		}
@@ -54,9 +57,10 @@ var (
 		for i := 0; i < 32; i++ {
 			downlinkChannels = append(downlinkChannels, Channel{
 				Frequency:   uint64(496900000 + 200000*i),
+				MinDataRate: minDataRateIndex,
 				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5,
 			})
 		}
 		return downlinkChannels
-	}()
+	}
 )

--- a/pkg/band/cn_470_510_20_b_rp2_v1_0_0.go
+++ b/pkg/band/cn_470_510_20_b_rp2_v1_0_0.go
@@ -23,10 +23,10 @@ var CN_470_510_20_B_RP2_v1_0_0 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
-	UplinkChannels:    cn47051020BUplinkChannels,
+	UplinkChannels:    cn47051020BUplinkChannels(0),
 
 	MaxDownlinkChannels: 64,
-	DownlinkChannels:    cn47051020BDownlinkChannels,
+	DownlinkChannels:    cn47051020BDownlinkChannels(0),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_20_b_rp2_v1_0_1.go
+++ b/pkg/band/cn_470_510_20_b_rp2_v1_0_1.go
@@ -23,10 +23,10 @@ var CN_470_510_20_B_RP2_v1_0_1 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
-	UplinkChannels:    cn47051020BUplinkChannels,
+	UplinkChannels:    cn47051020BUplinkChannels(1),
 
 	MaxDownlinkChannels: 64,
-	DownlinkChannels:    cn47051020BDownlinkChannels,
+	DownlinkChannels:    cn47051020BDownlinkChannels(1),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_20_b_rp2_v1_0_2.go
+++ b/pkg/band/cn_470_510_20_b_rp2_v1_0_2.go
@@ -23,10 +23,10 @@ var CN_470_510_20_B_RP2_v1_0_2 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
-	UplinkChannels:    cn47051020BUplinkChannels,
+	UplinkChannels:    cn47051020BUplinkChannels(1),
 
 	MaxDownlinkChannels: 64,
-	DownlinkChannels:    cn47051020BDownlinkChannels,
+	DownlinkChannels:    cn47051020BDownlinkChannels(1),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_20_b_rp2_v1_0_3.go
+++ b/pkg/band/cn_470_510_20_b_rp2_v1_0_3.go
@@ -23,10 +23,10 @@ var CN_470_510_20_B_RP2_v1_0_3 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
-	UplinkChannels:    cn47051020BUplinkChannels,
+	UplinkChannels:    cn47051020BUplinkChannels(1),
 
 	MaxDownlinkChannels: 64,
-	DownlinkChannels:    cn47051020BDownlinkChannels,
+	DownlinkChannels:    cn47051020BDownlinkChannels(1),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_26_a.go
+++ b/pkg/band/cn_470_510_26_a.go
@@ -22,27 +22,29 @@ const (
 )
 
 var (
-	cn47051026AUplinkChannels = func() []Channel {
+	cn47051026AUplinkChannels = func(minDataRateIndex ttnpb.DataRateIndex) []Channel {
 		uplinkChannels := make([]Channel, 0, 48)
 		// 26 MHz Type A
 		for i := 0; i < 48; i++ {
 			uplinkChannels = append(uplinkChannels, Channel{
 				Frequency:   uint64(470300000 + 200000*i),
+				MinDataRate: minDataRateIndex,
 				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5,
 			})
 		}
 		return uplinkChannels
-	}()
+	}
 
-	cn47051026ADownlinkChannels = func() []Channel {
+	cn47051026ADownlinkChannels = func(minDataRateIndex ttnpb.DataRateIndex) []Channel {
 		downlinkChannels := make([]Channel, 0, 24)
 		// 26 MHz Type A
 		for i := 0; i < 24; i++ {
 			downlinkChannels = append(downlinkChannels, Channel{
 				Frequency:   uint64(490100000 + 200000*i),
+				MinDataRate: minDataRateIndex,
 				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5,
 			})
 		}
 		return downlinkChannels
-	}()
+	}
 )

--- a/pkg/band/cn_470_510_26_a_rp2_v1_0_0.go
+++ b/pkg/band/cn_470_510_26_a_rp2_v1_0_0.go
@@ -23,10 +23,10 @@ var CN_470_510_26_A_RP2_v1_0_0 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
-	UplinkChannels:    cn47051026AUplinkChannels,
+	UplinkChannels:    cn47051026AUplinkChannels(0),
 
 	MaxDownlinkChannels: 24,
-	DownlinkChannels:    cn47051026ADownlinkChannels,
+	DownlinkChannels:    cn47051026ADownlinkChannels(0),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_26_a_rp2_v1_0_1.go
+++ b/pkg/band/cn_470_510_26_a_rp2_v1_0_1.go
@@ -23,10 +23,10 @@ var CN_470_510_26_A_RP2_v1_0_1 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
-	UplinkChannels:    cn47051026AUplinkChannels,
+	UplinkChannels:    cn47051026AUplinkChannels(1),
 
 	MaxDownlinkChannels: 24,
-	DownlinkChannels:    cn47051026ADownlinkChannels,
+	DownlinkChannels:    cn47051026ADownlinkChannels(1),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_26_a_rp2_v1_0_2.go
+++ b/pkg/band/cn_470_510_26_a_rp2_v1_0_2.go
@@ -23,10 +23,10 @@ var CN_470_510_26_A_RP2_v1_0_2 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
-	UplinkChannels:    cn47051026AUplinkChannels,
+	UplinkChannels:    cn47051026AUplinkChannels(1),
 
 	MaxDownlinkChannels: 24,
-	DownlinkChannels:    cn47051026ADownlinkChannels,
+	DownlinkChannels:    cn47051026ADownlinkChannels(1),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_26_a_rp2_v1_0_3.go
+++ b/pkg/band/cn_470_510_26_a_rp2_v1_0_3.go
@@ -23,10 +23,10 @@ var CN_470_510_26_A_RP2_v1_0_3 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
-	UplinkChannels:    cn47051026AUplinkChannels,
+	UplinkChannels:    cn47051026AUplinkChannels(1),
 
 	MaxDownlinkChannels: 24,
-	DownlinkChannels:    cn47051026ADownlinkChannels,
+	DownlinkChannels:    cn47051026ADownlinkChannels(1),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_26_b.go
+++ b/pkg/band/cn_470_510_26_b.go
@@ -22,27 +22,29 @@ const (
 )
 
 var (
-	cn47051026BUplinkChannels = func() []Channel {
+	cn47051026BUplinkChannels = func(minDataRateIndex ttnpb.DataRateIndex) []Channel {
 		uplinkChannels := make([]Channel, 0, 48)
 		// 26 MHz Type B
 		for i := 0; i < 48; i++ {
 			uplinkChannels = append(uplinkChannels, Channel{
 				Frequency:   uint64(480300000 + 200000*i),
+				MinDataRate: minDataRateIndex,
 				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5,
 			})
 		}
 		return uplinkChannels
-	}()
+	}
 
-	cn47051026BDownlinkChannels = func() []Channel {
+	cn47051026BDownlinkChannels = func(minDataRateIndex ttnpb.DataRateIndex) []Channel {
 		downlinkChannels := make([]Channel, 0, 24)
 		// 26 MHz Type B
 		for i := 0; i < 24; i++ {
 			downlinkChannels = append(downlinkChannels, Channel{
 				Frequency:   uint64(500100000 + 200000*i),
+				MinDataRate: minDataRateIndex,
 				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_5,
 			})
 		}
 		return downlinkChannels
-	}()
+	}
 )

--- a/pkg/band/cn_470_510_26_b_rp2_v1_0_0.go
+++ b/pkg/band/cn_470_510_26_b_rp2_v1_0_0.go
@@ -23,10 +23,10 @@ var CN_470_510_26_B_RP2_v1_0_0 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
-	UplinkChannels:    cn47051026BUplinkChannels,
+	UplinkChannels:    cn47051026BUplinkChannels(0),
 
 	MaxDownlinkChannels: 24,
-	DownlinkChannels:    cn47051026BDownlinkChannels,
+	DownlinkChannels:    cn47051026BDownlinkChannels(0),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_26_b_rp2_v1_0_1.go
+++ b/pkg/band/cn_470_510_26_b_rp2_v1_0_1.go
@@ -23,10 +23,10 @@ var CN_470_510_26_B_RP2_v1_0_1 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
-	UplinkChannels:    cn47051026BUplinkChannels,
+	UplinkChannels:    cn47051026BUplinkChannels(1),
 
 	MaxDownlinkChannels: 24,
-	DownlinkChannels:    cn47051026BDownlinkChannels,
+	DownlinkChannels:    cn47051026BDownlinkChannels(1),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_26_b_rp2_v1_0_2.go
+++ b/pkg/band/cn_470_510_26_b_rp2_v1_0_2.go
@@ -23,10 +23,10 @@ var CN_470_510_26_B_RP2_v1_0_2 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
-	UplinkChannels:    cn47051026BUplinkChannels,
+	UplinkChannels:    cn47051026BUplinkChannels(1),
 
 	MaxDownlinkChannels: 24,
-	DownlinkChannels:    cn47051026BDownlinkChannels,
+	DownlinkChannels:    cn47051026BDownlinkChannels(1),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/cn_470_510_26_b_rp2_v1_0_3.go
+++ b/pkg/band/cn_470_510_26_b_rp2_v1_0_3.go
@@ -23,10 +23,10 @@ var CN_470_510_26_B_RP2_v1_0_3 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
-	UplinkChannels:    cn47051026BUplinkChannels,
+	UplinkChannels:    cn47051026BUplinkChannels(1),
 
 	MaxDownlinkChannels: 24,
-	DownlinkChannels:    cn47051026BDownlinkChannels,
+	DownlinkChannels:    cn47051026BDownlinkChannels(1),
 
 	// See IEEE 11-11/0972r0
 	SubBands: []SubBandParameters{

--- a/pkg/band/testdata/AU_915_928_RP002_V1_0_2.json
+++ b/pkg/band/testdata/AU_915_928_RP002_V1_0_2.json
@@ -349,42 +349,42 @@
     {
       "Frequency": 915900000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 917500000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 919100000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 920700000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 922300000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 923900000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 925500000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 927100000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     }
   ],
   "MaxDownlinkChannels": 8,

--- a/pkg/band/testdata/AU_915_928_RP002_V1_0_3.json
+++ b/pkg/band/testdata/AU_915_928_RP002_V1_0_3.json
@@ -349,42 +349,42 @@
     {
       "Frequency": 915900000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 917500000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 919100000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 920700000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 922300000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 923900000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 925500000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     },
     {
       "Frequency": 927100000,
       "MinDataRate": 6,
-      "MaxDataRate": 6
+      "MaxDataRate": 7
     }
   ],
   "MaxDownlinkChannels": 8,

--- a/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_1.json
@@ -10,322 +10,322 @@
   "UplinkChannels": [
     {
       "Frequency": 470300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 509100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 509300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 509500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 509700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],
@@ -333,322 +333,322 @@
   "DownlinkChannels": [
     {
       "Frequency": 483900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],

--- a/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_2.json
@@ -10,322 +10,322 @@
   "UplinkChannels": [
     {
       "Frequency": 470300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 509100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 509300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 509500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 509700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],
@@ -333,322 +333,322 @@
   "DownlinkChannels": [
     {
       "Frequency": 483900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],

--- a/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_3.json
@@ -10,322 +10,322 @@
   "UplinkChannels": [
     {
       "Frequency": 470300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 505900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 506900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 507900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 508900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 509100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 509300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 509500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 509700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],
@@ -333,322 +333,322 @@
   "DownlinkChannels": [
     {
       "Frequency": 483900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 495900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],

--- a/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_1.json
@@ -10,322 +10,322 @@
   "UplinkChannels": [
     {
       "Frequency": 476900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],
@@ -333,322 +333,322 @@
   "DownlinkChannels": [
     {
       "Frequency": 476900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],

--- a/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_2.json
@@ -10,322 +10,322 @@
   "UplinkChannels": [
     {
       "Frequency": 476900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],
@@ -333,322 +333,322 @@
   "DownlinkChannels": [
     {
       "Frequency": 476900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],

--- a/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_3.json
@@ -10,322 +10,322 @@
   "UplinkChannels": [
     {
       "Frequency": 476900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],
@@ -333,322 +333,322 @@
   "DownlinkChannels": [
     {
       "Frequency": 476900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 496900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 497900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 498900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 499900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],

--- a/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_1.json
@@ -10,242 +10,242 @@
   "UplinkChannels": [
     {
       "Frequency": 470300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],
@@ -253,122 +253,122 @@
   "DownlinkChannels": [
     {
       "Frequency": 490100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],

--- a/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_2.json
@@ -10,242 +10,242 @@
   "UplinkChannels": [
     {
       "Frequency": 470300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],
@@ -253,122 +253,122 @@
   "DownlinkChannels": [
     {
       "Frequency": 490100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],

--- a/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_3.json
@@ -10,242 +10,242 @@
   "UplinkChannels": [
     {
       "Frequency": 470300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 470900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 471900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 472900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 473900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 474900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 475900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 476900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 477900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 478900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 479700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],
@@ -253,122 +253,122 @@
   "DownlinkChannels": [
     {
       "Frequency": 490100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 490900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 491900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 492900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 493900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 494700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],

--- a/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_1.json
@@ -10,242 +10,242 @@
   "UplinkChannels": [
     {
       "Frequency": 480300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],
@@ -253,122 +253,122 @@
   "DownlinkChannels": [
     {
       "Frequency": 500100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],

--- a/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_2.json
@@ -10,242 +10,242 @@
   "UplinkChannels": [
     {
       "Frequency": 480300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],
@@ -253,122 +253,122 @@
   "DownlinkChannels": [
     {
       "Frequency": 500100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],

--- a/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_3.json
@@ -10,242 +10,242 @@
   "UplinkChannels": [
     {
       "Frequency": 480300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 480900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 481900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 482900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 483900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 484900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 485900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 486900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 487900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 488900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 489700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],
@@ -253,122 +253,122 @@
   "DownlinkChannels": [
     {
       "Frequency": 500100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 500900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 501900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 502900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 503900000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504100000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504300000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504500000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     },
     {
       "Frequency": 504700000,
-      "MinDataRate": 0,
+      "MinDataRate": 1,
       "MaxDataRate": 5
     }
   ],

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_2.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_2.json
@@ -349,42 +349,42 @@
     {
       "Frequency": 903000000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 904600000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 906200000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 907800000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 909400000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 911000000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 912600000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 914200000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     }
   ],
   "MaxDownlinkChannels": 8,

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_3.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_3.json
@@ -349,42 +349,42 @@
     {
       "Frequency": 903000000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 904600000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 906200000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 907800000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 909400000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 911000000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 912600000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     },
     {
       "Frequency": 914200000,
       "MinDataRate": 4,
-      "MaxDataRate": 4
+      "MaxDataRate": 6
     }
   ],
   "MaxDownlinkChannels": 8,

--- a/pkg/band/us_902_928.go
+++ b/pkg/band/us_902_928.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	us902928UplinkChannels = func() []Channel {
+	us902928UplinkChannels = func(wideChannelDelta ttnpb.DataRateIndex) []Channel {
 		uplinkChannels := make([]Channel, 0, 72)
 		for i := 0; i < 64; i++ {
 			uplinkChannels = append(uplinkChannels, Channel{
@@ -34,11 +34,11 @@ var (
 			uplinkChannels = append(uplinkChannels, Channel{
 				Frequency:   uint64(903000000 + 1600000*i),
 				MinDataRate: ttnpb.DataRateIndex_DATA_RATE_4,
-				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_4,
+				MaxDataRate: ttnpb.DataRateIndex_DATA_RATE_4 + wideChannelDelta,
 			})
 		}
 		return uplinkChannels
-	}()
+	}
 
 	us902928DownlinkChannels = func() []Channel {
 		downlinkChannels := make([]Channel, 0, 8)

--- a/pkg/band/us_902_928_rp1_v1_0_2.go
+++ b/pkg/band/us_902_928_rp1_v1_0_2.go
@@ -23,7 +23,7 @@ var US_902_928_RP1_V1_0_2 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    us902928UplinkChannels,
+	UplinkChannels:    us902928UplinkChannels(0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    us902928DownlinkChannels,

--- a/pkg/band/us_902_928_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/us_902_928_rp1_v1_0_2_rev_b.go
@@ -23,7 +23,7 @@ var US_902_928_RP1_V1_0_2_Rev_B = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    us902928UplinkChannels,
+	UplinkChannels:    us902928UplinkChannels(0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    us902928DownlinkChannels,

--- a/pkg/band/us_902_928_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/us_902_928_rp1_v1_0_3_rev_a.go
@@ -23,7 +23,7 @@ var US_902_928_RP1_V1_0_3_Rev_A = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    us902928UplinkChannels,
+	UplinkChannels:    us902928UplinkChannels(0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    us902928DownlinkChannels,

--- a/pkg/band/us_902_928_rp1_v1_1_rev_a.go
+++ b/pkg/band/us_902_928_rp1_v1_1_rev_a.go
@@ -23,7 +23,7 @@ var US_902_928_RP1_V1_1_Rev_A = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    us902928UplinkChannels,
+	UplinkChannels:    us902928UplinkChannels(0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    us902928DownlinkChannels,

--- a/pkg/band/us_902_928_rp1_v1_1_rev_b.go
+++ b/pkg/band/us_902_928_rp1_v1_1_rev_b.go
@@ -23,7 +23,7 @@ var US_902_928_RP1_V1_1_Rev_B = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    us902928UplinkChannels,
+	UplinkChannels:    us902928UplinkChannels(0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    us902928DownlinkChannels,

--- a/pkg/band/us_902_928_rp2_v1_0_0.go
+++ b/pkg/band/us_902_928_rp2_v1_0_0.go
@@ -23,7 +23,7 @@ var US_902_928_RP2_V1_0_0 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    us902928UplinkChannels,
+	UplinkChannels:    us902928UplinkChannels(0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    us902928DownlinkChannels,

--- a/pkg/band/us_902_928_rp2_v1_0_1.go
+++ b/pkg/band/us_902_928_rp2_v1_0_1.go
@@ -23,7 +23,7 @@ var US_902_928_RP2_V1_0_1 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    us902928UplinkChannels,
+	UplinkChannels:    us902928UplinkChannels(0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    us902928DownlinkChannels,

--- a/pkg/band/us_902_928_rp2_v1_0_2.go
+++ b/pkg/band/us_902_928_rp2_v1_0_2.go
@@ -23,7 +23,7 @@ var US_902_928_RP2_V1_0_2 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    us902928UplinkChannels,
+	UplinkChannels:    us902928UplinkChannels(2),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    us902928DownlinkChannels,

--- a/pkg/band/us_902_928_rp2_v1_0_3.go
+++ b/pkg/band/us_902_928_rp2_v1_0_3.go
@@ -23,7 +23,7 @@ var US_902_928_RP2_V1_0_3 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    us902928UplinkChannels,
+	UplinkChannels:    us902928UplinkChannels(2),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    us902928DownlinkChannels,

--- a/pkg/band/us_902_928_ts1_v1_0.go
+++ b/pkg/band/us_902_928_ts1_v1_0.go
@@ -23,7 +23,7 @@ var US_902_928_TS1_V1_0 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    us902928UplinkChannels,
+	UplinkChannels:    us902928UplinkChannels(0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    us902928DownlinkChannels,

--- a/pkg/band/us_902_928_ts1_v1_0_1.go
+++ b/pkg/band/us_902_928_ts1_v1_0_1.go
@@ -23,7 +23,7 @@ var US_902_928_TS1_V1_0_1 = Band{
 	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
-	UplinkChannels:    us902928UplinkChannels,
+	UplinkChannels:    us902928UplinkChannels(0),
 
 	MaxDownlinkChannels: 8,
 	DownlinkChannels:    us902928DownlinkChannels,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the max data rate index used by the 500kHz channels in the US915 and AU915. Starting with RP002-1.0.2 (when LR-FHSS was first introduced), these channels are no longer only meant for SF7BW500, but also for LR-FHSS - see the second paragraph:

<img width="746" alt="image" src="https://user-images.githubusercontent.com/36161392/187663331-64ae5554-c3fb-4ab5-b78d-18207825402c.png">

<img width="716" alt="image" src="https://user-images.githubusercontent.com/36161392/187663466-4f035c47-4f7d-4d2f-a2e5-767c27660e4b.png">


#### Changes
<!-- What are the changes made in this pull request? -->

- Fix US915 and AU915 max data rate indices for the wide channels.
- Fix CN470-510 channel min data rate index.
  - I've added a sanity test that checks if the data rate range of a channel is well defined for a band, and caught this error.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing and also tested with a physical device the data rate changes.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This is bleeding edge.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
