### PR TITLE
Treat normalized payload validation errors as warnings

### DIFF
--- a/pkg/messageprocessors/javascript/javascript.go
+++ b/pkg/messageprocessors/javascript/javascript.go
@@ -310,13 +310,14 @@ func (*host) decodeUplink(
 		return errOutput.WithCause(err)
 	}
 	msg.DecodedPayload, msg.DecodedPayloadWarnings = decodedPayload, output.Decoded.Warnings
+	msg.NormalizedPayload, msg.NormalizedPayloadWarnings = nil, nil
 
 	if normalized := output.Normalized; normalized != nil {
 		if errs := normalized.Errors; len(errs) > 0 {
 			return errOutputErrors.WithAttributes("errors", strings.Join(errs, ", "))
 		}
 		if normalized.Data == nil {
-			return errOutput.New()
+			return nil
 		}
 		// The returned data can be an array of measurements or a single measurement object.
 		var measurements []map[string]interface{}

--- a/pkg/messageprocessors/javascript/javascript.go
+++ b/pkg/messageprocessors/javascript/javascript.go
@@ -261,6 +261,24 @@ func (h *host) DecodeUplink(
 	return h.decodeUplink(ctx, msg, run)
 }
 
+func appendValidationErrors(dst []string, measurements []normalizedpayload.ParsedMeasurement) []string {
+	for i, m := range measurements {
+		for _, err := range m.ValidationErrors {
+			var (
+				errString string
+				ttnErr    *errors.Error
+			)
+			if errors.As(err, &ttnErr) {
+				errString = ttnErr.FormatMessage(ttnErr.PublicAttributes())
+			} else {
+				errString = err.Error()
+			}
+			dst = append(dst, fmt.Sprintf("measurement %d: %s", i+1, errString))
+		}
+	}
+	return dst
+}
+
 func (*host) decodeUplink(
 	ctx context.Context,
 	msg *ttnpb.ApplicationUplink,
@@ -327,11 +345,17 @@ func (*host) decodeUplink(
 			normalizedPayload[i] = pb
 		}
 		// Validate the normalized payload.
-		_, err := normalizedpayload.Parse(normalizedPayload)
+		normalizedMeasurements, err := normalizedpayload.Parse(normalizedPayload)
 		if err != nil {
 			return errOutput.WithCause(err)
 		}
-		msg.NormalizedPayload, msg.NormalizedPayloadWarnings = normalizedPayload, normalized.Warnings
+		msg.NormalizedPayload = make([]*pbtypes.Struct, len(normalizedMeasurements))
+		for i, measurement := range normalizedMeasurements {
+			msg.NormalizedPayload[i] = measurement.Valid
+		}
+		msg.NormalizedPayloadWarnings = make([]string, 0, len(normalized.Warnings))
+		msg.NormalizedPayloadWarnings = append(msg.NormalizedPayloadWarnings, normalized.Warnings...)
+		msg.NormalizedPayloadWarnings = appendValidationErrors(msg.NormalizedPayloadWarnings, normalizedMeasurements)
 	} else {
 		// If the normalizer is not set, the decoder may return already normalized payload.
 		// This is a best effort attempt to parse the decoded payload as normalized payload.
@@ -339,9 +363,13 @@ func (*host) decodeUplink(
 		normalizedPayload := []*pbtypes.Struct{
 			decodedPayload,
 		}
-		_, err := normalizedpayload.Parse(normalizedPayload)
+		normalizedMeasurements, err := normalizedpayload.Parse(normalizedPayload)
 		if err == nil {
-			msg.NormalizedPayload, msg.NormalizedPayloadWarnings = normalizedPayload, nil
+			msg.NormalizedPayload = make([]*pbtypes.Struct, len(normalizedMeasurements))
+			for i, measurement := range normalizedMeasurements {
+				msg.NormalizedPayload[i] = measurement.Valid
+			}
+			msg.NormalizedPayloadWarnings = appendValidationErrors(msg.NormalizedPayloadWarnings, normalizedMeasurements)
 		}
 	}
 	return nil

--- a/pkg/messageprocessors/javascript/javascript_test.go
+++ b/pkg/messageprocessors/javascript/javascript_test.go
@@ -640,6 +640,49 @@ func TestDecodeUplink(t *testing.T) {
 		a.So(errors.IsAborted(err), should.BeTrue)
 	}
 
+	// Return no normalized payload (data is nil).
+	{
+		script := `
+			function decodeUplink(input) {
+				return {
+					data: {
+						state: input.bytes[0]
+					}
+				}
+			}
+
+			function normalizeUplink(input) {
+				return {
+					data: null
+				}
+			}
+			`
+		err := host.DecodeUplink(ctx, ids, nil, message, script)
+		a.So(err, should.BeNil)
+		a.So(message.NormalizedPayload, should.BeNil)
+		a.So(message.NormalizedPayloadWarnings, should.BeEmpty)
+	}
+
+	// Return no normalized payload (no return value).
+	{
+		script := `
+			function decodeUplink(input) {
+				return {
+					data: {
+						state: input.bytes[0]
+					}
+				}
+			}
+	
+			function normalizeUplink(input) {
+			}
+			`
+		err := host.DecodeUplink(ctx, ids, nil, message, script)
+		a.So(err, should.BeNil)
+		a.So(message.NormalizedPayload, should.BeNil)
+		a.So(message.NormalizedPayloadWarnings, should.BeEmpty)
+	}
+
 	// Decode and normalize a single measurement with out-of-range value.
 	{
 		message := &ttnpb.ApplicationUplink{

--- a/pkg/messageprocessors/javascript/javascript_test.go
+++ b/pkg/messageprocessors/javascript/javascript_test.go
@@ -377,7 +377,7 @@ func TestDecodeUplink(t *testing.T) {
 		a.So(message.NormalizedPayload, should.HaveLength, 1)
 		measurements, err := normalizedpayload.Parse(message.NormalizedPayload)
 		a.So(err, should.BeNil)
-		a.So(measurements[0], should.Resemble, normalizedpayload.Measurement{
+		a.So(measurements[0].Measurement, should.Resemble, normalizedpayload.Measurement{
 			Air: &normalizedpayload.Air{
 				Temperature: float64Ptr(-21.3),
 			},
@@ -405,7 +405,7 @@ func TestDecodeUplink(t *testing.T) {
 
 		measurements, err := normalizedpayload.Parse(message.NormalizedPayload)
 		a.So(err, should.BeNil)
-		a.So(measurements[0], should.Resemble, normalizedpayload.Measurement{
+		a.So(measurements[0].Measurement, should.Resemble, normalizedpayload.Measurement{
 			Air: &normalizedpayload.Air{
 				Temperature: float64Ptr(-21.3),
 			},
@@ -450,8 +450,12 @@ func TestDecodeUplink(t *testing.T) {
 		})
 
 		a.So(message.NormalizedPayload, should.HaveLength, 2)
-		measurements, err := normalizedpayload.Parse(message.NormalizedPayload)
+		parsedMeasurements, err := normalizedpayload.Parse(message.NormalizedPayload)
 		a.So(err, should.BeNil)
+		measurements := make([]normalizedpayload.Measurement, len(parsedMeasurements))
+		for i, m := range parsedMeasurements {
+			measurements[i] = m.Measurement
+		}
 		a.So(measurements, should.Resemble, []normalizedpayload.Measurement{
 			{
 				Air: &normalizedpayload.Air{
@@ -539,8 +543,23 @@ func TestDecodeUplink(t *testing.T) {
 			}
 			`
 		err := host.DecodeUplink(ctx, ids, nil, message, script)
-		a.So(err, should.NotBeNil)
-		a.So(errors.IsInvalidArgument(err), should.BeTrue)
+		a.So(err, should.BeNil)
+
+		a.So(message.NormalizedPayload, should.HaveLength, 1)
+		parsedMeasurements, err := normalizedpayload.Parse(message.NormalizedPayload)
+		a.So(err, should.BeNil)
+		measurements := make([]normalizedpayload.Measurement, len(parsedMeasurements))
+		for i, m := range parsedMeasurements {
+			measurements[i] = m.Measurement
+		}
+		a.So(measurements, should.Resemble, []normalizedpayload.Measurement{
+			{
+				Air: &normalizedpayload.Air{},
+			},
+		})
+		a.So(message.NormalizedPayloadWarnings, should.Resemble, []string{
+			"measurement 1: `air.temperature` should be equal or greater than `-273.15`",
+		})
 	}
 
 	// The Things Node example.

--- a/pkg/messageprocessors/normalizedpayload/uplink_internal_test.go
+++ b/pkg/messageprocessors/normalizedpayload/uplink_internal_test.go
@@ -1,0 +1,22 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package normalizedpayload
+
+var (
+	ErrFieldMinimum          = errFieldMinimum
+	ErrFieldExclusiveMinimum = errFieldExclusiveMinimum
+	ErrFieldMaximum          = errFieldMaximum
+	ErrFieldExclusiveMaximum = errFieldExclusiveMaximum
+)

--- a/pkg/messageprocessors/normalizedpayload/uplink_test.go
+++ b/pkg/messageprocessors/normalizedpayload/uplink_test.go
@@ -37,10 +37,11 @@ func TestUplink(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		name              string
-		normalizedPayload []*pbtypes.Struct
-		expected          []normalizedpayload.Measurement
-		errorAssertion    func(error) bool
+		name                     string
+		normalizedPayload        []*pbtypes.Struct
+		expected                 []normalizedpayload.Measurement
+		expectedValidationErrors [][]error
+		errorAssertion           func(error) bool
 	}{
 		{
 			name: "single timestamp",
@@ -133,7 +134,19 @@ func TestUplink(t *testing.T) {
 					},
 				},
 			},
-			errorAssertion: errors.IsInvalidArgument,
+			expected: []normalizedpayload.Measurement{
+				{
+					Air: &normalizedpayload.Air{},
+				},
+			},
+			expectedValidationErrors: [][]error{
+				{
+					normalizedpayload.ErrFieldMinimum.WithAttributes(
+						"path", "air.temperature",
+						"minimum", -273.15,
+					),
+				},
+			},
 		},
 		{
 			name: "invalid direction",
@@ -156,7 +169,19 @@ func TestUplink(t *testing.T) {
 					},
 				},
 			},
-			errorAssertion: errors.IsInvalidArgument,
+			expected: []normalizedpayload.Measurement{
+				{
+					Wind: &normalizedpayload.Wind{},
+				},
+			},
+			expectedValidationErrors: [][]error{
+				{
+					normalizedpayload.ErrFieldExclusiveMaximum.WithAttributes(
+						"path", "wind.direction",
+						"maximum", 360.0,
+					),
+				},
+			},
 		},
 		{
 			name: "invalid type",
@@ -216,7 +241,19 @@ func TestUplink(t *testing.T) {
 				a.So(tc.errorAssertion(err), should.BeTrue)
 			} else {
 				a.So(err, should.BeNil)
-				a.So(measurements, should.Resemble, tc.expected)
+				if !a.So(measurements, should.HaveLength, len(tc.expected)) {
+					t.FailNow()
+				}
+				for i, parsed := range measurements {
+					if len(parsed.ValidationErrors) > 0 {
+						a.So(len(tc.expectedValidationErrors), should.BeGreaterThanOrEqualTo, i+1)
+						a.So(parsed.ValidationErrors, should.HaveLength, len(tc.expectedValidationErrors[i]))
+						for j, err := range parsed.ValidationErrors {
+							a.So(err, should.EqualErrorOrDefinition, tc.expectedValidationErrors[i][j])
+						}
+					}
+					a.So(parsed.Measurement, should.Resemble, tc.expected[i])
+				}
 			}
 		})
 	}

--- a/pkg/messageprocessors/normalizedpayload/uplink_test.go
+++ b/pkg/messageprocessors/normalizedpayload/uplink_test.go
@@ -102,12 +102,12 @@ func TestUplink(t *testing.T) {
 			},
 			expected: []normalizedpayload.Measurement{
 				{
-					Air: &normalizedpayload.Air{
+					Air: normalizedpayload.Air{
 						Temperature: float64Ptr(20.42),
 					},
 				},
 				{
-					Air: &normalizedpayload.Air{
+					Air: normalizedpayload.Air{
 						Temperature: float64Ptr(19.61),
 					},
 				},
@@ -135,9 +135,7 @@ func TestUplink(t *testing.T) {
 				},
 			},
 			expected: []normalizedpayload.Measurement{
-				{
-					Air: &normalizedpayload.Air{},
-				},
+				{},
 			},
 			expectedValidationErrors: [][]error{
 				{
@@ -170,9 +168,7 @@ func TestUplink(t *testing.T) {
 				},
 			},
 			expected: []normalizedpayload.Measurement{
-				{
-					Wind: &normalizedpayload.Wind{},
-				},
+				{},
 			},
 			expectedValidationErrors: [][]error{
 				{

--- a/pkg/webui/console/components/payload-formatters-form/test-form/index.js
+++ b/pkg/webui/console/components/payload-formatters-form/test-form/index.js
@@ -86,8 +86,9 @@ const TestForm = props => {
     uplink,
     testResult,
     testResult: {
-      decoded_payload: payload,
-      decoded_payload_warnings: warnings,
+      decoded_payload: decodedPayload,
+      decoded_payload_warnings: decodedPayloadWarnings,
+      normalized_payload_warnings: normalizedPayloadWarnings,
       frm_payload: framePayload,
     },
   } = props
@@ -104,8 +105,10 @@ const TestForm = props => {
 
   const hasTestError = isBackend(testResult)
   const hasFatalError = !isOutputError(testResult)
-  const hasTestWarning = warnings instanceof Array && warnings.length !== 0
-  const hasPayload = payload !== undefined
+  const hasTestWarning =
+    (decodedPayloadWarnings instanceof Array && decodedPayloadWarnings.length !== 0) ||
+    (normalizedPayloadWarnings instanceof Array && normalizedPayloadWarnings.length !== 0)
+  const hasPayload = decodedPayload !== undefined
 
   const showTestError = hasTestError
   const showTestWarning = !hasTestError && hasTestWarning
@@ -200,7 +203,7 @@ const TestForm = props => {
             {!showTestError && (
               <Form.InfoField title={m.decodedPayload}>
                 <CodeEditor
-                  value={JSON.stringify(payload, null, 2)}
+                  value={JSON.stringify(decodedPayload, null, 2)}
                   language="json"
                   name="test_result"
                   minLines={12}
@@ -274,6 +277,8 @@ TestForm.propTypes = {
   testResult: PropTypes.shape({
     decoded_payload: PropTypes.PropTypes.shape({}),
     decoded_payload_warnings: PropTypes.arrayOf(PropTypes.message),
+    normalized_payload: PropTypes.arrayOf(PropTypes.PropTypes.shape({})),
+    normalized_payload_warnings: PropTypes.arrayOf(PropTypes.message),
     frm_payload: PropTypes.string,
   }).isRequired,
   uplink: PropTypes.bool.isRequired,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Follow up on #5730 
References https://github.com/TheThingsNetwork/lorawan-stack/issues/5429
References https://github.com/TheThingsNetwork/lorawan-devices/issues/395

cc @pablojimpas

#### Changes
<!-- What are the changes made in this pull request? -->

This changes the way field validation errors are treated. Before, the error was propagated to the caller and the entire payload wouldn't be considered normalized. This means that one out-of-bounds field renders the entire payload invalid. I think this isn't a nice developer experience: we should still not set these fields to out-of-bounds values but we should accept the rest of the fields and set the errors as warnings.

There's also a small unrelated change to see the `normalized_payload{_warnings}` in the payload simulation view.

#### Testing

<!-- How did you verify that this change works? -->

CI and simulated uplink:
<img width="1560" alt="Screen Shot 2022-08-31 at 17 59 13" src="https://user-images.githubusercontent.com/13334001/187725068-07f03e93-8940-4509-b371-cb5666d0fe8e.png">

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- No need for changelog entry because this is still unreleased
- @kschiffer only review code owned files. I didn't add a code editor for the normalized payload. I think that would be nice though (although it's in the complete payload too), but just putting another editor in there didn't feel right UX wise so I'll leave this up to you. I consider this out of scope for this PR though

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
