### PR TITLE
Allow empty end device CAC values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ For details about compatibility between different releases, see the **Commitment
 - Console data rate rendering of non-LoRa modulations.
 - End device network layer form crashing in some situations in the Console device general settings.
 - End device overview crashing in some situations in the Console.
+- QRG can generate QR Codes without the claim authentication code.
 
 ### Security
 

--- a/pkg/identityserver/bunstore/end_device_store.go
+++ b/pkg/identityserver/bunstore/end_device_store.go
@@ -667,7 +667,7 @@ func (s *endDeviceStore) updateEndDeviceModel( //nolint:gocyclo
 			} else {
 				// If not, allow setting each value separately.
 				// For example, this allows the updating only the valid_to field without clearing the other fields.
-				if pb.ClaimAuthenticationCode.GetValue() != "" {
+				if pb.ClaimAuthenticationCode.Value != "" {
 					model.ClaimAuthenticationCodeSecret = []byte(pb.ClaimAuthenticationCode.Value)
 				}
 				if pb.ClaimAuthenticationCode.ValidFrom != nil {

--- a/pkg/identityserver/bunstore/end_device_store.go
+++ b/pkg/identityserver/bunstore/end_device_store.go
@@ -117,6 +117,10 @@ func endDeviceToPB(m *EndDevice, fieldMask ...string) (*ttnpb.EndDevice, error) 
 		JoinServerAddress:        m.JoinServerAddress,
 
 		ClaimAuthenticationCode: func() *ttnpb.EndDeviceAuthenticationCode {
+			// Only set the CAC wrapper if the secret has a value.
+			if len(m.ClaimAuthenticationCodeSecret) == 0 {
+				return nil
+			}
 			return &ttnpb.EndDeviceAuthenticationCode{
 				Value:     string(m.ClaimAuthenticationCodeSecret),
 				ValidFrom: ttnpb.ProtoTime(m.ClaimAuthenticationCodeValidFrom),
@@ -655,10 +659,24 @@ func (s *endDeviceStore) updateEndDeviceModel( //nolint:gocyclo
 			columns = append(columns, "last_seen_at")
 
 		case "claim_authentication_code":
-			// NOTE: The old implementation didn't allow for updating the sub-fields, so we don't either.
-			model.ClaimAuthenticationCodeSecret = []byte(pb.ClaimAuthenticationCode.GetValue())
-			model.ClaimAuthenticationCodeValidFrom = cleanTimePtr(ttnpb.StdTime(pb.ClaimAuthenticationCode.GetValidFrom()))
-			model.ClaimAuthenticationCodeValidTo = cleanTimePtr(ttnpb.StdTime(pb.ClaimAuthenticationCode.GetValidTo()))
+			// If the CAC wrapper is nil but the path is set in the fieldmask, then we clear the values.
+			if pb.ClaimAuthenticationCode == nil {
+				model.ClaimAuthenticationCodeSecret = nil
+				model.ClaimAuthenticationCodeValidFrom = nil
+				model.ClaimAuthenticationCodeValidTo = nil
+			} else {
+				// If not, allow setting each value separately.
+				// For example, this allows the updating only the valid_to field without clearing the other fields.
+				if pb.ClaimAuthenticationCode.GetValue() != "" {
+					model.ClaimAuthenticationCodeSecret = []byte(pb.ClaimAuthenticationCode.Value)
+				}
+				if pb.ClaimAuthenticationCode.ValidFrom != nil {
+					model.ClaimAuthenticationCodeValidFrom = ttnpb.StdTime(pb.ClaimAuthenticationCode.ValidFrom)
+				}
+				if pb.ClaimAuthenticationCode.ValidTo != nil {
+					model.ClaimAuthenticationCodeValidTo = ttnpb.StdTime(pb.ClaimAuthenticationCode.ValidTo)
+				}
+			}
 			columns = append(
 				columns,
 				"claim_authentication_code_secret",

--- a/pkg/identityserver/bunstore/store_test.go
+++ b/pkg/identityserver/bunstore/store_test.go
@@ -89,6 +89,7 @@ func TestEndDeviceStore(t *testing.T) {
 	st.TestEndDeviceStoreCRUD(t)
 	st.TestEndDeviceStorePagination(t)
 	st.TestEndDeviceBatchUpdate(t)
+	st.TestEndDeviceCAC(t)
 }
 
 func TestGatewayStore(t *testing.T) {

--- a/pkg/identityserver/gormstore/end_device.go
+++ b/pkg/identityserver/gormstore/end_device.go
@@ -244,7 +244,7 @@ var deviceModelSetters = map[string]func(*EndDevice, *ttnpb.EndDevice){
 		} else {
 			// If not, allow setting each value separately.
 			// For example, this allows the updating only the valid_to field without clearing the other fields.
-			if pb.ClaimAuthenticationCode.GetValue() != "" {
+			if pb.ClaimAuthenticationCode.Value != "" {
 				dev.ClaimAuthenticationCodeSecret = []byte(pb.ClaimAuthenticationCode.Value)
 			}
 			if pb.ClaimAuthenticationCode.ValidFrom != nil {

--- a/pkg/identityserver/gormstore/end_device.go
+++ b/pkg/identityserver/gormstore/end_device.go
@@ -157,10 +157,13 @@ var devicePBSetters = map[string]func(*ttnpb.EndDevice, *EndDevice){
 		pb.LastSeenAt = ttnpb.ProtoTime(dev.LastSeenAt)
 	},
 	claimAuthenticationCodeField: func(pb *ttnpb.EndDevice, dev *EndDevice) {
-		pb.ClaimAuthenticationCode = &ttnpb.EndDeviceAuthenticationCode{
-			Value:     string(dev.ClaimAuthenticationCodeSecret),
-			ValidFrom: ttnpb.ProtoTime(dev.ClaimAuthenticationCodeValidFrom),
-			ValidTo:   ttnpb.ProtoTime(dev.ClaimAuthenticationCodeValidTo),
+		// Only set the CAC wrapper if the secret has a value.
+		if len(dev.ClaimAuthenticationCodeSecret) != 0 {
+			pb.ClaimAuthenticationCode = &ttnpb.EndDeviceAuthenticationCode{
+				Value:     string(dev.ClaimAuthenticationCodeSecret),
+				ValidFrom: ttnpb.ProtoTime(dev.ClaimAuthenticationCodeValidFrom),
+				ValidTo:   ttnpb.ProtoTime(dev.ClaimAuthenticationCodeValidTo),
+			}
 		}
 	},
 }
@@ -233,8 +236,17 @@ var deviceModelSetters = map[string]func(*EndDevice, *ttnpb.EndDevice){
 		dev.LastSeenAt = ttnpb.StdTime(pb.LastSeenAt)
 	},
 	claimAuthenticationCodeField: func(dev *EndDevice, pb *ttnpb.EndDevice) {
-		if pb.ClaimAuthenticationCode != nil {
-			dev.ClaimAuthenticationCodeSecret = []byte(pb.ClaimAuthenticationCode.Value)
+		// If the CAC wrapper is nil but the path is set in the fieldmask, then we clear the values.
+		if pb.ClaimAuthenticationCode == nil {
+			dev.ClaimAuthenticationCodeSecret = nil
+			dev.ClaimAuthenticationCodeValidFrom = nil
+			dev.ClaimAuthenticationCodeValidTo = nil
+		} else {
+			// If not, allow setting each value separately.
+			// For example, this allows the updating only the valid_to field without clearing the other fields.
+			if pb.ClaimAuthenticationCode.GetValue() != "" {
+				dev.ClaimAuthenticationCodeSecret = []byte(pb.ClaimAuthenticationCode.Value)
+			}
 			if pb.ClaimAuthenticationCode.ValidFrom != nil {
 				dev.ClaimAuthenticationCodeValidFrom = ttnpb.StdTime(pb.ClaimAuthenticationCode.ValidFrom)
 			}

--- a/pkg/identityserver/gormstore/store_test.go
+++ b/pkg/identityserver/gormstore/store_test.go
@@ -106,6 +106,7 @@ func TestEndDeviceStore(t *testing.T) {
 	st.TestEndDeviceStoreCRUD(t)
 	st.TestEndDeviceStorePagination(t)
 	st.TestEndDeviceBatchUpdate(t)
+	st.TestEndDeviceCAC(t)
 }
 
 func TestGatewayStore(t *testing.T) {

--- a/pkg/identityserver/storetest/end_device_store.go
+++ b/pkg/identityserver/storetest/end_device_store.go
@@ -661,7 +661,10 @@ func (st *StoreTest) TestEndDeviceCAC(t *T) { //nolint:revive
 		}
 
 		// Update CAC validity fields individually.
-		validFrom := time.Now().Add(-1 * time.Hour)
+		// Truncate to avoid nanosecond precision issues.
+		now := time.Unix(time.Now().Unix(), 0)
+
+		validFrom := now.Add(-1 * time.Hour)
 		updated, err = s.UpdateEndDevice(ctx, &ttnpb.EndDevice{
 			Ids: created.GetIds(),
 			ClaimAuthenticationCode: &ttnpb.EndDeviceAuthenticationCode{
@@ -675,7 +678,7 @@ func (st *StoreTest) TestEndDeviceCAC(t *T) { //nolint:revive
 			})
 		}
 
-		validTo := time.Now().Add(-1 * time.Hour)
+		validTo := now.Add(-1 * time.Hour)
 		updated, err = s.UpdateEndDevice(ctx, &ttnpb.EndDevice{
 			Ids: created.GetIds(),
 			ClaimAuthenticationCode: &ttnpb.EndDeviceAuthenticationCode{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refs; https://github.com/TheThingsIndustries/lorawan-stack-support/issues/830

Allow the End Device CAC value to be empty. This does two things
1. It allows us to generate QR Codes without a CAC (valid according to TR005).
2. It allows us to clear CACs.

#### Changes
<!-- What are the changes made in this pull request? -->

- Update Regex and test

#### Testing

<!-- How did you verify that this change works? -->

- [x] Generate QR Code without CAC
```
1. Create end device without CAC
$ tti-lw-cli end-devices create --application-id test-app --device-id test-dev --join-eui 1111111111111111 --dev-eui 1111111111111111 --root-keys.app-key.key 11111111111111111111111111111111  --net-id 000013 --lorawan-version 1.0.2 --lorawan-phy-version 1.0.2-b --frequency-plan-id EU_863_870 --mac-settings.desired-rx1-delay RX_DELAY_2 --supports-join
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
{
  "ids": {
    "device_id": "test-dev",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "1111111111111111",
    "join_eui": "1111111111111111"
  },
  "created_at": "2022-09-01T08:17:16.924Z",
  "updated_at": "2022-09-01T08:17:17.215528Z",
  "attributes": {},
  "network_server_address": "localhost",
  "application_server_address": "localhost",
  "join_server_address": "localhost",
  "lorawan_version": "MAC_V1_0_2",
  "lorawan_phy_version": "PHY_V1_0_2_REV_B",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "11111111111111111111111111111111"
    }
  },
  "net_id": "000013",
  "mac_settings": {
    "desired_rx1_delay": 2
  }
}

2. Generate QR Code
$ tti-lw-cli end-devices generate-qr test-app  test-dev --format-id tr005
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
WARN	Storage of claim authentication code in the Join Server registry is deprecated. Use the Identity Server registry instead	{"grpc.method": "Get", "grpc.service": "ttn.lorawan.v3.JsEndDeviceRegistry", "namespace": "grpc"}
INFO	Generated QR code	{"filename": "<path>/test-dev.png", "value": "LW:D0:1111111111111111:1111111111111111:00000000"}
INFO	New patch version available	{"current": "3.21.0", "docs_url": "https://www.thethingsindustries.com/docs/getting-started/upgrading/", "latest": "3.21.1"}

3. Set CAC and generate QR Code
$ tti-lw-cli end-devices set test-app test-dev --claim-aut
hentication-code.value 12345678
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
{
  "ids": {
    "device_id": "test-dev",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "1111111111111111",
    "join_eui": "1111111111111111"
  },
  "created_at": "2022-09-01T08:17:16.924Z",
  "updated_at": "2022-09-01T08:19:27.029Z",
  "claim_authentication_code": {
    "value": "12345678"
  }
}

$ tti-lw-cli end-devices get test-app test-dev --claim-authentication-code.value
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
{
  "ids": {
    "device_id": "test-dev",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "1111111111111111",
    "join_eui": "1111111111111111"
  },
  "created_at": "2022-09-01T08:17:16.924Z",
  "updated_at": "2022-09-01T08:19:27.029Z",
  "join_server_address": "localhost",
  "claim_authentication_code": {
    "value": "12345678"
  }
}

$ tti-lw-cli end-devices generate-qr test-app  test-dev --format-id tr005
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
INFO	Generated QR code	{"filename": "<path>/test-dev.png", "value": "LW:D0:1111111111111111:1111111111111111:00000000:O12345678"}
INFO	New patch version available	{"current": "3.21.0", "docs_url": "https://www.thethingsindustries.com/docs/getting-started/upgrading/", "latest": "3.21.1"}
```


- [x] Unset CAC
```
~ » tti-lw-cli end-devices set test-app test-dev --claim-authentication-code.value ""
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
{
  "ids": {
    "device_id": "test-dev",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "1111111111111111",
    "join_eui": "1111111111111111"
  },
  "created_at": "2022-09-01T08:17:16.924Z",
  "updated_at": "2022-09-01T08:25:52.425Z",
  "claim_authentication_code": {
    "value": "test-key:c1df5ddec943e5d72750d74f215f3722e2785b0182a387c6ba485614" #encyrpted empty value
  }
}
INFO	New patch version available	{"current": "3.21.0", "docs_url": "https://www.thethingsindustries.com/docs/getting-started/upgrading/", "latest": "3.21.1"}

$ tti-lw-cli end-devices get test-app test-dev --claim-authentication-code.value
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
WARN	Storage of claim authentication code in the Join Server registry is deprecated. Use the Identity Server registry instead	{"grpc.method": "Get", "grpc.service": "ttn.lorawan.v3.JsEndDeviceRegistry", "namespace": "grpc"}
{
  "ids": {
    "device_id": "test-dev",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "1111111111111111",
    "join_eui": "1111111111111111"
  },
  "created_at": "2022-09-01T08:17:16.924Z",
  "updated_at": "2022-09-01T08:25:52.425Z",
  "join_server_address": "localhost",
  "claim_authentication_code": {}
}

$ tti-lw-cli end-devices generate-qr test-app  test-dev --format-id tr005
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
WARN	Storage of claim authentication code in the Join Server registry is deprecated. Use the Identity Server registry instead	{"grpc.method": "Get", "grpc.service": "ttn.lorawan.v3.JsEndDeviceRegistry", "namespace": "grpc"}
INFO	Generated QR code	{"filename": "<path>/test-dev.png", "value": "LW:D0:1111111111111111:1111111111111111:00000000"}
INFO	New patch version available	{"current": "3.21.0", "docs_url": "https://www.thethingsindustries.com/docs/getting-started/upgrading/", "latest": "3.21.1"}

```
##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Tested for it (see above)
- Generating QR Codes with the CAC

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The QR Claiming app needs a tiny change that's added here; https://github.com/TheThingsIndustries/lorawan-stack/pull/3411

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
