### PR TITLE
Don't disconnect LBS gateway on deep validation failure

### DIFF
--- a/pkg/gatewayserver/io/ws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream.go
@@ -583,7 +583,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids *ttnpb.GatewayIde
 		updateSessionID(ctx, SessionIDFromXTime(jreq.UpInfo.XTime))
 		ct := recordTime(jreq.RefTime, jreq.UpInfo.XTime, jreq.UpInfo.GPSTime, jreq.UpInfo.RxTime)
 		if err := conn.HandleUp(up, ct); err != nil {
-			log.FromContext(ctx).WithError(err).Warn("Invalid Join Request")
+			logger.WithError(err).Warn("Failed to handle upstream message")
 		}
 
 	case TypeUpstreamUplinkDataFrame:
@@ -604,7 +604,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids *ttnpb.GatewayIde
 		updateSessionID(ctx, SessionIDFromXTime(updf.UpInfo.XTime))
 		ct := recordTime(updf.RefTime, updf.UpInfo.XTime, updf.UpInfo.GPSTime, updf.UpInfo.RxTime)
 		if err := conn.HandleUp(up, ct); err != nil {
-			log.FromContext(ctx).WithError(err).Warn("Invalid uplink message")
+			logger.WithError(err).Warn("Failed to handle upstream message")
 		}
 
 	case TypeUpstreamTxConfirmation:

--- a/pkg/gatewayserver/io/ws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream.go
@@ -583,18 +583,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids *ttnpb.GatewayIde
 		updateSessionID(ctx, SessionIDFromXTime(jreq.UpInfo.XTime))
 		ct := recordTime(jreq.RefTime, jreq.UpInfo.XTime, jreq.UpInfo.GPSTime, jreq.UpInfo.RxTime)
 		if err := conn.HandleUp(up, ct); err != nil {
-			// HandleUp calls uplink.ValidateFields which is a deep validation of the payload fields.
-			// jreq.toUplinkMessage already validates that the gateway is sending sane messages.
-			// Ex: The MHDR of a `jreq` message is valid LoRaWAN Join type.
-			// But beyond these basic checks, LBS gateways do not perform a deep validation of the message.
-			// Ex: Checking that the RFU fields are not used is out of scope for the gateway and the Gateway Server.
-			// In such cases, we won't process the uplink message but we shouldn't disconnect the gateway.
-			// This prevents a spamming device from DOSing the gateway.
-			if !errors.IsInvalidArgument(err) {
-				logger.WithError(err).Warn("Failed to handle upstream message")
-				return nil, err
-			}
-			log.FromContext(ctx).WithError(err).Warn("Invalid join request")
+			log.FromContext(ctx).WithError(err).Warn("Invalid Join Request")
 		}
 
 	case TypeUpstreamUplinkDataFrame:
@@ -615,17 +604,6 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids *ttnpb.GatewayIde
 		updateSessionID(ctx, SessionIDFromXTime(updf.UpInfo.XTime))
 		ct := recordTime(updf.RefTime, updf.UpInfo.XTime, updf.UpInfo.GPSTime, updf.UpInfo.RxTime)
 		if err := conn.HandleUp(up, ct); err != nil {
-			// HandleUp calls uplink.ValidateFields which is a deep validation of the payload fields.
-			// updf.toUplinkMessage already validates that the gateway is sending sane messages.
-			// Ex: The MHDR of a `updf` message is valid LoRaWAN uplink type.
-			// But beyond these basic checks, LBS gateways do not perform a deep validation of the message.
-			// Ex: Checking that the RFU fields are not used is out of scope for the gateway and the Gateway Server.
-			// In such cases, we won't process the uplink message but we shouldn't disconnect the gateway.
-			// This prevents a spamming device from DOSing the gateway.
-			if !errors.IsInvalidArgument(err) {
-				logger.WithError(err).Warn("Failed to handle upstream message")
-				return nil, err
-			}
 			log.FromContext(ctx).WithError(err).Warn("Invalid uplink message")
 		}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Don't disconnect LBS gateway on deep validation failure. Refs; https://github.com/TheThingsIndustries/lorawan-stack-support/issues/810

#### Changes
<!-- What are the changes made in this pull request? -->

- Don't disconnect gateway if some deep validation of message fields fail
- Log a warning instead.

#### Testing

<!-- How did you verify that this change works? -->

Local stack

Message
```
{ "msgtype": "updf", "MHdr": 155, "upinfo": { "rctx": 0, "xtime": 12666373963464220, "gpstime": 0, "rssi": -39, "snr": 7.75, "rxtime": 1546596145.625515 }}
```

Before:
```
WARN	Task failed	{"endpoint": "/traffic/{id}", "error": "invalid UplinkMessage.payload: embedded message failed validation | caused by: invalid Message.m_hdr: embedded message failed validation | caused by: invalid MHDR.major: value must be one of the defined enum values", "gateway_ip_address": "127.0.0.1", "gateway_uid": "test-gtw", "http.method": "GET", "http.path": "/traffic/eui-1111111111111111", "invocation": 1, "namespace": "web", "peer.address": "127.0.0.1:52517", "peer.real_ip": "127.0.0.1", "protocol": "ws", "remote_addr": "127.0.0.1:52517", "request_id": "01GBW9S0SRC8F9AN9TSZFBP8PD", "task_id": "cluster_connect_gateway_test-gtw", "upstream_handler": "cluster"}
DEBUG	Delete connection stats	{"endpoint": "/traffic/{id}", "gateway_ip_address": "127.0.0.1", "gateway_uid": "test-gtw", "http.method": "GET", "http.path": "/traffic/eui-1111111111111111", "namespace": "web", "peer.address": "127.0.0.1:52517", "peer.real_ip": "127.0.0.1", "protocol": "ws", "remote_addr": "127.0.0.1:52517", "request_id": "01GBW9S0SRC8F9AN9TSZFBP8PD"}
```


After:
```
WARN	Invalid uplink message	{"endpoint": "/traffic/{id}", "error": "invalid UplinkMessage.payload: embedded message failed validation | caused by: invalid Message.m_hdr: embedded message failed validation | caused by: invalid MHDR.major: value must be one of the defined enum values", "gateway_uid": "test-gtw", "http.method": "GET", "http.path": "/traffic/eui-1111111111111111", "namespace": "web", "peer.address": "127.0.0.1:52449", "peer.real_ip": "127.0.0.1", "remote_addr": "127.0.0.1:52449", "request_id": "01GBW9CH6GFWH9ZNFXJZ6SY1PC"}
(Gateway still connected)
```


##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Validation will still work if gateway message level failures are detected.

Ex: The following message has a wrong MTYPE for an `updf` message

```
{ "msgtype": "updf", "MHdr": 255, "upinfo": { "rctx": 0, "xtime": 12666373963464220, "gpstime": 0, "rssi": -39, "snr": 7.75, "rxtime": 1546596145.625515 }}

WARN	Failed to parse uplink message	{"endpoint": "/traffic/{id}", "error": "error:pkg/gatewayserver/io/ws/lbslns:mhdr (invalid MHDR `m_type:PROPRIETARY major:3 ` received)", "gateway_uid": "test-gtw", "http.method": "GET", "http.path": "/traffic/eui-1111111111111111", "mhdr": "m_type:PROPRIETARY major:3 ", "namespace": "web", "peer.address": "127.0.0.1:52472", "peer.real_ip": "127.0.0.1", "remote_addr": "127.0.0.1:52472", "request_id": "01GBW9MK78B4Y3P59M37AHXRQV", "upstream_type": "updf"}
DEBUG	Delete connection stats	{"endpoint": "/traffic/{id}", "gateway_ip_address": "127.0.0.1", "gateway_uid": "test-gtw", "http.method": "GET", "http.path": "/traffic/eui-1111111111111111", "namespace": "web", "peer.address": "127.0.0.1:52472", "peer.real_ip": "127.0.0.1", "protocol": "ws", "remote_addr": "127.0.0.1:52472", "request_id": "01GBW9MK78B4Y3P59M37AHXRQV"}
WARN	Task failed	{"endpoint": "/traffic/{id}", "error": "error:pkg/gatewayserver/io/ws/lbslns:mhdr (invalid MHDR `m_type:PROPRIETARY major:3 ` received)", "gateway_ip_address": "127.0.0.1", "gateway_uid": "test-gtw", "http.method": "GET", "http.path": "/traffic/eui-1111111111111111", "invocation": 1, "mhdr": "m_type:PROPRIETARY major:3 ", "namespace": "web", "peer.address": "127.0.0.1:52472", "peer.real_ip": "127.0.0.1", "protocol": "ws", "remote_addr": "127.0.0.1:52472", "request_id": "01GBW9MK78B4Y3P59M37AHXRQV", "task_id": "disconnect_on_change_test-gtw"}
```

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Please see the comments [here](https://github.com/TheThingsNetwork/lorawan-stack/blob/4918108c9bd02279b4ecbe4e33d167d6ffdeca24/pkg/gatewayserver/io/ws/lbslns/upstream.go#L586-L592) and [here](https://github.com/TheThingsNetwork/lorawan-stack/blob/4918108c9bd02279b4ecbe4e33d167d6ffdeca24/pkg/gatewayserver/io/ws/lbslns/upstream.go#L618-L624) first.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
