### PR TITLE
Remove GPS timestamp workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Removed
 
+- Experimental support for `LoRa Basics Station` gateway GPS timestamps which use the wrong precision (milliseconds instead of microseconds). Please ensure that your gateway has been updated to the latest firmware.
+
 ### Fixed
 
 - The Gateway Server scheduler no longer considers the absolute time of a downlink to be the time of arrival.

--- a/pkg/gatewayserver/io/ws/lbslns/time_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/time_test.go
@@ -25,6 +25,8 @@ import (
 func timePtr(t time.Time) *time.Time { return &t }
 
 func TestTimePtrFromUpInfo(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		Name          string
 		GPSTime       int64
@@ -37,39 +39,31 @@ func TestTimePtrFromUpInfo(t *testing.T) {
 			ReferenceTime: time.Unix(0, 456),
 		},
 		{
-			Name:          "OnlyRxTime",
-			RxTime:        123.456,
-			ReferenceTime: time.Unix(0, 456),
+			Name:   "OnlyRxTime",
+			RxTime: 123.456,
 
 			ExpectedTime: timePtr(time.Unix(123, 456000000).UTC()),
 		},
 		{
-			Name:          "EqualGPSTimeAndRxTime",
-			GPSTime:       -315964676544, // The timestamp is negative as the UTC epoch precedes the GPS epoch.
-			RxTime:        123.456,
-			ReferenceTime: time.Unix(123, 456),
+			Name:    "EqualGPSTimeAndRxTime",
+			GPSTime: -315964676544000, // microseconds. The timestamp is negative as the UTC epoch precedes the GPS epoch.
+			RxTime:  123.456,
 
 			ExpectedTime: timePtr(time.Unix(123, 456000000).UTC()),
 		},
 		{
-			Name:          "OnlyGPSTime",
-			GPSTime:       -315964676544, // The timestamp is negative as the UTC epoch precedes the GPS epoch.
-			ReferenceTime: time.Unix(0, 456),
+			Name:    "OnlyGPSTime",
+			GPSTime: 123456000, // microseconds.
 
-			ExpectedTime: timePtr(time.Unix(123, 456000000).UTC()),
-		},
-		{
-			Name:          "MillisecondGPSTime",
-			GPSTime:       1321619791991, // This timestamp is in milliseconds, instead of microseconds.
-			RxTime:        1637584573,
-			ReferenceTime: time.Unix(1637584483, 999974502), // 2021-11-22T12:34:43.999974502Z
-
-			ExpectedTime: timePtr(time.Unix(1637584573, 991000000).UTC()),
+			ExpectedTime: timePtr(time.Unix(315964923, 456000000).UTC()),
 		},
 	} {
+		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			a, _ := test.New(t)
-			a.So(TimePtrFromUpInfo(tc.GPSTime, tc.RxTime, tc.ReferenceTime), should.Resemble, tc.ExpectedTime)
+			a.So(TimePtrFromUpInfo(tc.GPSTime, tc.RxTime), should.Resemble, tc.ExpectedTime)
 		})
 	}
 }

--- a/pkg/gatewayserver/io/ws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream.go
@@ -213,7 +213,7 @@ func (req *JoinRequest) toUplinkMessage(ids *ttnpb.GatewayIdentifiers, bandID st
 	}
 
 	timestamp := TimestampFromXTime(req.RadioMetaData.UpInfo.XTime)
-	tm := TimePtrFromUpInfo(req.UpInfo.GPSTime, req.UpInfo.RxTime, receivedAt)
+	tm := TimePtrFromUpInfo(req.UpInfo.GPSTime, req.UpInfo.RxTime)
 	gpsTime := TimePtrFromGPSTime(req.UpInfo.GPSTime)
 	up.RxMetadata = []*ttnpb.RxMetadata{
 		{
@@ -374,7 +374,7 @@ func (updf *UplinkDataFrame) toUplinkMessage(ids *ttnpb.GatewayIdentifiers, band
 
 	timestamp := TimestampFromXTime(updf.RadioMetaData.UpInfo.XTime)
 	gpsTime := TimePtrFromGPSTime(updf.UpInfo.GPSTime)
-	tm := TimePtrFromUpInfo(updf.UpInfo.GPSTime, updf.UpInfo.RxTime, receivedAt)
+	tm := TimePtrFromUpInfo(updf.UpInfo.GPSTime, updf.UpInfo.RxTime)
 	up.RxMetadata = []*ttnpb.RxMetadata{
 		{
 			GatewayIds:   ids,
@@ -533,7 +533,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids *ttnpb.GatewayIde
 			ServerTime: receivedAt,
 			// RxTime is an undocumented field with unspecified precision.
 			// Using 0.0 for RxTime here means that the GatewayTime is nil and is not used for syncing the gateway clock.
-			GatewayTime:      TimePtrFromUpInfo(gpsTime, 0.0, receivedAt),
+			GatewayTime:      TimePtrFromUpInfo(gpsTime, 0.0),
 			ConcentratorTime: ConcentratorTimeFromXTime(xTime),
 		}
 	}


### PR DESCRIPTION
This reverts commit aabbf2ae23b08907487a64bb7bc58da1fcda8b57.

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4907 

#### Changes
<!-- What are the changes made in this pull request? -->

- Reverted GPS timestamp workaround (#4899, commit aabbf2ae23b08907487a64bb7bc58da1fcda8b57)


#### Testing

<!-- How did you verify that this change works? -->

U.T.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
