### PR TITLE
Add claiming tests for end device onboarding

### DIFF
--- a/cypress/integration/console/devices/onboarding/claiming.spec.js
+++ b/cypress/integration/console/devices/onboarding/claiming.spec.js
@@ -1,0 +1,258 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { generateHexValue } from '../../../../support/utils'
+
+import { interceptDeviceRepo, selectDevice } from './utils'
+
+const composeExpectedRequest = ({ joinEui, devEui, cac, id, appId }) => ({
+  authenticated_identifiers: {
+    join_eui: joinEui.toUpperCase(),
+    dev_eui: devEui.toUpperCase(),
+    authentication_code: cac,
+  },
+  target_device_id: id,
+  target_application_ids: { application_id: appId },
+})
+
+const composeClaimResponse = ({ joinEui, devEui, id, appId }) => ({
+  application_ids: { application_id: appId },
+  device_id: id,
+  dev_eui: devEui,
+  join_eui: joinEui,
+  dev_addr: '2600ABCD',
+})
+
+describe('End device repository claiming', () => {
+  const user = {
+    ids: { user_id: 'claim-test-user' },
+    primary_email_address: 'claim-test-user@example.com',
+    password: 'ABCDefg123!',
+    password_confirm: 'ABCDefg123!',
+  }
+  const appId = 'claim-test-application'
+  const application = {
+    ids: { application_id: appId },
+  }
+
+  before(() => {
+    cy.dropAndSeedDatabase()
+    cy.createUser(user)
+    cy.createApplication(application, user.ids.user_id)
+  })
+
+  beforeEach(() => {
+    cy.intercept('POST', '/api/v3/edcs/claim/info', { body: { supports_claiming: true } })
+    interceptDeviceRepo(appId)
+    cy.loginConsole({ user_id: user.ids.user_id, password: user.password })
+    cy.visit(`${Cypress.config('consoleRootPath')}/applications/${appId}/devices/add`)
+  })
+
+  it('succeeds claiming a device when using the device repository', () => {
+    const device1 = {
+      id: 'repo-device01',
+      appId,
+      joinEui: generateHexValue(16),
+      devEui: generateHexValue(16),
+      cac: '000000001',
+    }
+
+    const device2 = {
+      id: 'repo-device02',
+      appId,
+      joinEui: device1.joinEui,
+      devEui: generateHexValue(16),
+      cac: '000000002',
+    }
+
+    // Select device type via device repository.
+    selectDevice({
+      brand_id: 'test-brand-otaa',
+      model_id: 'test-model3',
+      hw_version: '2.0',
+      fw_version: '1.0.1',
+      band_id: 'EU_863_870',
+    })
+
+    cy.intercept('POST', '/api/v3/edcs/claim', composeClaimResponse(device1)).as('claim-request')
+
+    cy.findByLabelText('Frequency plan').selectOption('EU_863_870_TTN')
+    cy.findByLabelText('JoinEUI').type(device1.joinEui)
+    cy.findByRole('button', { name: 'Confirm' }).click()
+
+    // Provision first device using claiming flow.
+    cy.findByLabelText('DevEUI').type(device1.devEui)
+    cy.findByLabelText('Claim authentication code').type(device1.cac)
+    cy.findByLabelText('End device ID')
+      .should('have.value', `eui-${device1.devEui.toLowerCase()}`)
+      .clear()
+      .type(device1.id)
+    cy.findByLabelText('Register another end device of this type').check()
+    cy.findByRole('button', { name: 'Add end device' }).click()
+    cy.wait('@claim-request')
+      .its('request.body')
+      .should('deep.equal', composeExpectedRequest(device1))
+    cy.findByTestId('toast-notification').findByText('End device registered').should('be.visible')
+    cy.findByRole('button', { name: 'Add end device' }).should('not.be.disabled')
+
+    cy.intercept('POST', '/api/v3/edcs/claim', composeClaimResponse(device2)).as('claim-request')
+
+    // Provision second device using claiming flow.
+    cy.findByLabelText('DevEUI').type(device2.devEui)
+    cy.findByLabelText('Claim authentication code').type(device2.cac)
+    cy.findByLabelText('End device ID')
+      .should('have.value', `eui-${device2.devEui.toLowerCase()}`)
+      .clear()
+      .type(device2.id)
+    cy.findByLabelText('View registered end device').check()
+    cy.findByRole('button', { name: 'Add end device' }).click()
+
+    cy.wait('@claim-request')
+      .its('request.body')
+      .should('deep.equal', composeExpectedRequest(device2))
+
+    // Check result.
+    cy.location('pathname').should(
+      'eq',
+      `${Cypress.config('consoleRootPath')}/applications/${appId}/devices/${device2.id}`,
+    )
+    cy.findByRole('heading', { name: device2.id }).should('be.visible')
+    cy.get('#stage').within(() => {
+      cy.findByRole('button', { name: 'General settings' }).click()
+    })
+    cy.findByText('Join settings')
+      .parents('[data-test-id="collapsible-section"]')
+      .within(() => {
+        cy.findByText('Not registered in this cluster').should('be.visible')
+      })
+    cy.get('#sidebar').within(() => {
+      cy.findByRole('link', { name: /End devices/ }).click()
+    })
+    cy.findByText(device1.id).should('be.visible')
+    cy.findByText(device2.id).should('be.visible')
+  })
+
+  it('succeeds claiming a multiple devices using manual type specification', () => {
+    const device1 = {
+      id: 'manual-device01',
+      appId,
+      joinEui: generateHexValue(16),
+      devEui: generateHexValue(16),
+      lorawanVersion: 'MAC_V1_0',
+      frequencyPlanId: '863-870 MHz',
+      cac: '000000001',
+    }
+
+    const device2 = {
+      id: 'manual-device02',
+      appId,
+      joinEui: device1.joinEui,
+      devEui: generateHexValue(16),
+      lorawanVersion: 'MAC_V1_0_3',
+      frequencyPlanId: '863-870 MHz',
+      cac: '000000002',
+    }
+
+    const device3 = {
+      id: 'manual-device03',
+      appId,
+      joinEui: generateHexValue(16),
+      devEui: generateHexValue(16),
+      lorawanVersion: 'MAC_V1_1',
+      phyVersion: 'PHY_V1_1_REV_A',
+      frequencyPlanId: '863-870 MHz',
+      cac: '000000003',
+    }
+
+    cy.intercept('POST', '/api/v3/edcs/claim', composeClaimResponse(device1)).as('claim-request')
+
+    // Select type info manually.
+    cy.findByLabelText('Enter end device specifics manually').check()
+    cy.findByLabelText('Frequency plan').selectOption(device1.frequencyPlanId)
+    cy.findByLabelText('LoRaWAN version').selectOption(device1.lorawanVersion)
+    cy.findByLabelText('JoinEUI').type(device1.joinEui)
+    cy.findByRole('button', { name: 'Confirm' }).click()
+
+    // Provision first device using claiming flow.
+    cy.findByText('Show advanced activation, LoRaWAN class and cluster settings').click()
+    cy.findByLabelText('Cluster settings').should('be.disabled').and('be.checked')
+    cy.findByLabelText('DevEUI').type(device1.devEui)
+    cy.findByLabelText('Claim authentication code').type(device1.cac)
+    cy.findByLabelText('End device ID').clear().type(device1.id)
+    cy.findByLabelText('Register another end device of this type').check()
+    cy.findByRole('button', { name: 'Add end device' }).click()
+    cy.wait('@claim-request')
+      .its('request.body')
+      .should('deep.equal', composeExpectedRequest(device1))
+    // Properly wait for the form to finish submitting.
+    cy.findByTestId('toast-notification').findByText('End device registered').should('be.visible')
+    cy.findByRole('button', { name: 'Add end device' }).should('not.be.disabled')
+
+    cy.intercept('POST', '/api/v3/edcs/claim', composeClaimResponse(device2)).as('claim-request')
+
+    // Provision second device using claiming flow.
+    cy.findByLabelText('LoRaWAN version').selectOption(device2.lorawanVersion)
+    cy.findByLabelText('DevEUI').type(device2.devEui)
+    cy.findByLabelText('Claim authentication code').type(device2.cac)
+    cy.findByLabelText('End device ID').clear().type(device2.id)
+    cy.findByRole('button', { name: 'Add end device' }).click()
+    cy.wait('@claim-request')
+      .its('request.body')
+      .should('deep.equal', composeExpectedRequest(device2))
+    // Properly wait for the form to finish submitting.
+    cy.findByTestId('toast-notification').findByText('End device registered').should('be.visible')
+    cy.findByRole('button', { name: 'Add end device' }).should('not.be.disabled')
+
+    cy.intercept('POST', '/api/v3/edcs/claim', composeClaimResponse(device3)).as('claim-request')
+
+    // Provision third device using claiming flow.
+    cy.findByLabelText('LoRaWAN version').selectOption(device3.lorawanVersion)
+    cy.findByLabelText('Regional Parameters version').selectOption(device3.phyVersion)
+    cy.findByRole('button', { name: 'Reset' }).click()
+    cy.findByLabelText('JoinEUI').should('not.be.disabled')
+    cy.findByLabelText('JoinEUI').type(`${device3.joinEui}{enter}`)
+    cy.findByLabelText('DevEUI').type(device3.devEui)
+    cy.findByLabelText('Claim authentication code').type(device3.cac)
+    cy.findByLabelText('End device ID').clear().type(device3.id)
+    cy.findByLabelText('View registered end device').check()
+    cy.findByRole('button', { name: 'Add end device' }).click()
+    cy.wait('@claim-request')
+      .its('request.body')
+      .should('deep.equal', composeExpectedRequest(device3))
+
+    // Check result.
+    cy.location('pathname').should(
+      'eq',
+      `${Cypress.config(
+        'consoleRootPath',
+      )}/applications/${appId}/devices/${device3.id.toLowerCase()}`,
+    )
+    cy.findByRole('heading', { name: `${device3.id.toLowerCase()}` }).should('be.visible')
+    cy.findByText('Provisioned on external Join Server').should('be.visible')
+    cy.get('#stage').within(() => {
+      cy.findByRole('button', { name: 'General settings' }).click()
+    })
+    cy.findByText('Join settings')
+      .parents('[data-test-id="collapsible-section"]')
+      .within(() => {
+        cy.findByText('Not registered in this cluster').should('be.visible')
+      })
+    cy.get('#sidebar').within(() => {
+      cy.findByRole('link', { name: /End devices/ }).click()
+    })
+    cy.findByText(device1.id).should('be.visible')
+    cy.findByText(device2.id).should('be.visible')
+    cy.findByText(device3.id).should('be.visible')
+  })
+})

--- a/cypress/integration/console/devices/onboarding/manual-registration.spec.js
+++ b/cypress/integration/console/devices/onboarding/manual-registration.spec.js
@@ -753,7 +753,7 @@ describe('End device manual create', () => {
         cy.findByTestId('full-error-view').should('not.exist')
       })
 
-      it('succeeds regitering multiple devices', () => {
+      it('succeeds registering multiple devices', () => {
         const device1 = {
           id: 'multicast-test-1',
           join_eui: generateHexValue(16),
@@ -766,22 +766,12 @@ describe('End device manual create', () => {
 
         const device2 = {
           id: 'multicast-test-2',
-          join_eui: generateHexValue(16),
           dev_addr: generateHexValue(8),
-          lorawan_version: 'MAC_V1_0',
-          frequency_plan_id: '863-870 MHz',
-          app_s_key: generateHexValue(32),
-          nwk_s_key: generateHexValue(32),
         }
 
         const device3 = {
           id: 'multicast-test-3',
-          join_eui: generateHexValue(16),
           dev_addr: generateHexValue(8),
-          lorawan_version: 'MAC_V1_0',
-          frequency_plan_id: '863-870 MHz',
-          app_s_key: generateHexValue(32),
-          nwk_s_key: generateHexValue(32),
         }
 
         // Device 1
@@ -802,28 +792,24 @@ describe('End device manual create', () => {
         cy.findByRole('button', { name: 'Add end device' }).click()
 
         cy.findByTestId('toast-notification')
-          .should('be.visible')
           .findByText('End device registered')
           .should('be.visible')
+        cy.findByRole('button', { name: 'Add end device' }).should('not.be.disabled')
 
         // Device 2
         cy.findByLabelText('Device address').type(device2.dev_addr)
-        cy.findByLabelText('AppSKey').clear().type(device2.app_s_key)
-        cy.findByLabelText('NwkSKey').clear().type(device2.nwk_s_key)
         cy.findByLabelText('End device ID').type(device2.id)
         cy.findByLabelText('Register another end device of this type').check()
 
         cy.findByRole('button', { name: 'Add end device' }).click()
 
         cy.findByTestId('toast-notification')
-          .should('be.visible')
           .findByText('End device registered')
           .should('be.visible')
+        cy.findByRole('button', { name: 'Add end device' }).should('not.be.disabled')
 
         // Device 3
         cy.findByLabelText('Device address').clear().type(device3.dev_addr)
-        cy.findByLabelText('AppSKey').clear().type(device3.app_s_key)
-        cy.findByLabelText('NwkSKey').clear().type(device3.nwk_s_key)
         cy.findByLabelText('End device ID').type(device3.id)
         cy.findByLabelText('View registered end device').check()
 

--- a/cypress/integration/console/devices/onboarding/repository-registration.spec.js
+++ b/cypress/integration/console/devices/onboarding/repository-registration.spec.js
@@ -14,6 +14,8 @@
 
 import { generateHexValue } from '../../../../support/utils'
 
+import { interceptDeviceRepo, selectDevice } from './utils'
+
 describe('End device repository manual registration', () => {
   const user = {
     ids: { user_id: 'create-dr-test-user' },
@@ -31,14 +33,6 @@ describe('End device repository manual registration', () => {
     const appId = 'otaa-test-application'
     const application = {
       ids: { application_id: appId },
-    }
-
-    const selectDevice = ({ brand_id, model_id, hw_version, fw_version, band_id }) => {
-      cy.findByLabelText('End device brand').selectOption(brand_id)
-      cy.findByLabelText('Model').selectOption(model_id)
-      cy.findByLabelText('Hardware Ver.').selectOption(hw_version)
-      cy.findByLabelText('Firmware Ver.').selectOption(fw_version)
-      cy.findByLabelText('Profile (Region)').selectOption(band_id)
     }
 
     before(() => {
@@ -80,43 +74,7 @@ describe('End device repository manual registration', () => {
 
     describe('Test Brand', () => {
       beforeEach(() => {
-        cy.fixture('console/devices/repository/test-brand-otaa-model4.template.json').then(
-          templateJson => {
-            cy.intercept(
-              'GET',
-              `/api/v3/dr/applications/${appId}/brands/test-brand-otaa/models/test-model4/1.0/EU_863_870/template`,
-              templateJson,
-            )
-          },
-        )
-        cy.fixture('console/devices/repository/test-brand-otaa-model3.template.json').then(
-          templateJson => {
-            cy.intercept(
-              'GET',
-              `/api/v3/dr/applications/${appId}/brands/test-brand-otaa/models/test-model3/1.0.1/EU_863_870/template`,
-              templateJson,
-            )
-          },
-        )
-        cy.fixture('console/devices/repository/test-brand-otaa-model2.template.json').then(
-          templateJson => {
-            cy.intercept(
-              'GET',
-              `/api/v3/dr/applications/${appId}/brands/test-brand-otaa/models/test-model2/1.0/EU_863_870/template`,
-              templateJson,
-            )
-          },
-        )
-        cy.fixture('console/devices/repository/test-brand-otaa.models.json').then(modelsJson => {
-          cy.intercept(
-            'GET',
-            `/api/v3/dr/applications/${appId}/brands/test-brand-otaa/models*`,
-            modelsJson,
-          )
-        })
-        cy.fixture('console/devices/repository/brands.json').then(brandsJson => {
-          cy.intercept('GET', `/api/v3/dr/applications/${appId}/brands*`, brandsJson)
-        })
+        interceptDeviceRepo(appId)
 
         cy.loginConsole({ user_id: user.ids.user_id, password: user.password })
         cy.visit(`${Cypress.config('consoleRootPath')}/applications/${appId}/devices/add`)
@@ -420,9 +378,8 @@ describe('End device repository manual registration', () => {
         cy.findByLabelText('Register another end device of this type').check()
 
         cy.findByRole('button', { name: 'Add end device' }).click()
-
+        cy.findByRole('button', { name: 'Add end device' }).should('not.be.disabled')
         cy.findByTestId('toast-notification')
-          .should('be.visible')
           .findByText('End device registered')
           .should('be.visible')
 
@@ -566,11 +523,10 @@ describe('End device repository manual registration', () => {
         cy.findByLabelText('Register another end device of this type').check()
 
         cy.findByRole('button', { name: 'Add end device' }).click()
-
         cy.findByTestId('toast-notification')
-          .should('be.visible')
           .findByText('End device registered')
           .should('be.visible')
+        cy.findByRole('button', { name: 'Add end device' }).should('not.be.disabled')
 
         const devId2 = 'test-abp-dev-2'
 
@@ -582,11 +538,10 @@ describe('End device repository manual registration', () => {
         cy.findByLabelText('Register another end device of this type').check()
 
         cy.findByRole('button', { name: 'Add end device' }).click()
-
         cy.findByTestId('toast-notification')
-          .should('be.visible')
           .findByText('End device registered')
           .should('be.visible')
+        cy.findByRole('button', { name: 'Add end device' }).should('not.be.disabled')
 
         const devId3 = 'test-abp-dev-3'
 

--- a/cypress/integration/console/devices/onboarding/utils.js
+++ b/cypress/integration/console/devices/onboarding/utils.js
@@ -1,0 +1,45 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const selectDevice = ({ brand_id, model_id, hw_version, fw_version, band_id }) => {
+  cy.findByLabelText('End device brand').selectOption(brand_id)
+  cy.findByLabelText('Model').selectOption(model_id)
+  cy.findByLabelText('Hardware Ver.').selectOption(hw_version)
+  cy.findByLabelText('Firmware Ver.').selectOption(fw_version)
+  cy.findByLabelText('Profile (Region)').selectOption(band_id)
+}
+
+export const interceptDeviceRepo = appId => {
+  cy.intercept(
+    'GET',
+    `/api/v3/dr/applications/${appId}/brands/test-brand-otaa/models/test-model4/1.0/EU_863_870/template`,
+    { fixture: 'console/devices/repository/test-brand-otaa-model4.template.json' },
+  )
+  cy.intercept(
+    'GET',
+    `/api/v3/dr/applications/${appId}/brands/test-brand-otaa/models/test-model3/1.0.1/EU_863_870/template`,
+    { fixture: 'console/devices/repository/test-brand-otaa-model3.template.json' },
+  )
+  cy.intercept(
+    'GET',
+    `/api/v3/dr/applications/${appId}/brands/test-brand-otaa/models/test-model2/1.0/EU_863_870/template`,
+    { fixture: 'console/devices/repository/test-brand-otaa-model2.template.json' },
+  )
+  cy.intercept('GET', `/api/v3/dr/applications/${appId}/brands/test-brand-otaa/models*`, {
+    fixture: 'console/devices/repository/test-brand-otaa.models.json',
+  })
+  cy.intercept('GET', `/api/v3/dr/applications/${appId}/brands*`, {
+    fixture: 'console/devices/repository/brands.json',
+  })
+}

--- a/pkg/webui/console/containers/dev-eui-component/index.js
+++ b/pkg/webui/console/containers/dev-eui-component/index.js
@@ -38,7 +38,7 @@ import {
 import style from './dev-eui.styl'
 
 const DevEUIComponent = props => {
-  const { name, required, disabled } = props
+  const { name, required, disabled, autoFocus } = props
   const { values, setFieldValue, touched } = useFormContext()
 
   const dispatch = useDispatch()
@@ -119,6 +119,7 @@ const DevEUIComponent = props => {
       inputRef={euiInputRef}
       required={required}
       disabled={disabled}
+      autoFocus={autoFocus}
     >
       <Message className={indicatorCls} component="label" content={indicatorContent} />
     </Form.Field>
@@ -134,17 +135,20 @@ const DevEUIComponent = props => {
       tooltipId={tooltipIds.DEV_EUI}
       onBlur={handleIdPrefill}
       disabled={disabled}
+      autoFocus={autoFocus}
     />
   )
 }
 
 DevEUIComponent.propTypes = {
+  autoFocus: PropTypes.bool,
   disabled: PropTypes.bool,
   name: PropTypes.string.isRequired,
   required: PropTypes.bool,
 }
 
 DevEUIComponent.defaultProps = {
+  autoFocus: false,
   disabled: false,
   required: false,
 }

--- a/pkg/webui/console/containers/device-onboarding-form/device-type-form-section/device-type-manual-form-section/advanced-settings-section.js
+++ b/pkg/webui/console/containers/device-onboarding-form/device-type-form-section/device-type-manual-form-section/advanced-settings-section.js
@@ -180,6 +180,7 @@ const AdvancedSettingsSection = () => {
     values: {
       mac_settings,
       _default_ns_settings,
+      _claim,
       frequency_plan_id,
       lorawan_phy_version,
       lorawan_version,
@@ -286,11 +287,7 @@ const AdvancedSettingsSection = () => {
 
   // Register hidden fields so they don't get cleaned.
   useEffect(() => {
-    const hiddenFields = [
-      'network_server_address',
-      'application_server_address',
-      'join_server_address',
-    ]
+    const hiddenFields = ['network_server_address', 'application_server_address']
     addToFieldRegistry(...hiddenFields)
     return () => removeFromFieldRegistry(...hiddenFields)
   }, [addToFieldRegistry, removeFromFieldRegistry])
@@ -557,6 +554,7 @@ const AdvancedSettingsSection = () => {
           decode={skipJsRegistrationDecoder}
           component={Checkbox}
           tooltipId={tooltipIds.SKIP_JOIN_SERVER_REGISTRATION}
+          disabled={_claim}
         />
       </Form.CollapseSection>
       <hr />

--- a/sdk/js/src/service/claim.js
+++ b/sdk/js/src/service/claim.js
@@ -24,21 +24,13 @@ class DeviceClaim {
   }
 
   // Claim
-  async claim(
-    applicationId,
-    qrCode,
-    values,
-    targetNetworkServerAddress = this._stackConfig.nsHost,
-    targetApplicationServerAddress = this._stackConfig.asHost,
-  ) {
+  async claim(applicationId, qrCode, values) {
     const deviceToClaim = qrCode ? { qr_code: qrCode } : values
     const payload = {
       ...deviceToClaim,
       target_application_ids: {
         application_id: applicationId,
       },
-      target_network_server_address: targetNetworkServerAddress,
-      target_application_server_address: targetApplicationServerAddress,
     }
 
     const response = await this._api.EndDeviceClaimingServer.Claim(undefined, payload)


### PR DESCRIPTION
#### Summary
This PR adds claiming tests for the new device onboarding flow.

References #4847  

#### Changes
- Add claim end-to-end tests
- Update other DO tests with progressive insight
- Apply some small fixes to DO related to the new tests


#### Testing

Yes.

#### Notes for Reviewers
I decided against splitting up the claim tests into device repository and manual type (in two files). Instead I used one test spec for both. I focused the tests on the claiming aspects to avoid too much repetition with the existing tests.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
