### PR TITLE
Make ADR commands generation report errors via events

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -7046,9 +7046,18 @@
       "file": "errors.go"
     }
   },
-  "error:pkg/networkserver/internal:downlink_channel": {
+  "error:pkg/networkserver/internal:incompatible_channel_mask": {
     "translations": {
-      "en": "channel does not allow uplinks"
+      "en": "the channel mask is not compatible with the current parameters"
+    },
+    "description": {
+      "package": "pkg/networkserver/internal",
+      "file": "errors.go"
+    }
+  },
+  "error:pkg/networkserver/internal:invalid_data_rate_index": {
+    "translations": {
+      "en": "invalid data rate index"
     },
     "description": {
       "package": "pkg/networkserver/internal",
@@ -7082,6 +7091,15 @@
       "file": "utils.go"
     }
   },
+  "error:pkg/networkserver/internal:no_uplink_frequency": {
+    "translations": {
+      "en": "uplink channel with no uplink frequency"
+    },
+    "description": {
+      "package": "pkg/networkserver/internal",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/networkserver/internal:payload": {
     "translations": {
       "en": "invalid payload"
@@ -7091,9 +7109,36 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/networkserver/internal:rejected_parameters": {
+    "translations": {
+      "en": "the parameters have been rejected in this session"
+    },
+    "description": {
+      "package": "pkg/networkserver/internal",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/networkserver/internal:session": {
     "translations": {
       "en": "no device session"
+    },
+    "description": {
+      "package": "pkg/networkserver/internal",
+      "file": "errors.go"
+    }
+  },
+  "error:pkg/networkserver/internal:too_many_channels": {
+    "translations": {
+      "en": "too many channels"
+    },
+    "description": {
+      "package": "pkg/networkserver/internal",
+      "file": "errors.go"
+    }
+  },
+  "error:pkg/networkserver/internal:tx_power_index_too_high": {
+    "translations": {
+      "en": "tx power index too high"
     },
     "description": {
       "package": "pkg/networkserver/internal",
@@ -10154,6 +10199,15 @@
   "event:ns.mac.link_adr.request": {
     "translations": {
       "en": "link ADR request enqueued"
+    },
+    "description": {
+      "package": "pkg/networkserver/mac",
+      "file": "link_adr.go"
+    }
+  },
+  "event:ns.mac.link_adr.request.fail": {
+    "translations": {
+      "en": "link ADR request generation failure"
     },
     "description": {
       "package": "pkg/networkserver/mac",

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -243,15 +243,7 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 			mac.EnqueueNewChannelReq,
 			func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) mac.EnqueueState {
 				// NOTE: LinkADRReq must be enqueued after NewChannelReq.
-				st, err := mac.EnqueueLinkADRReq(ctx, dev, maxDownLen, maxUpLen, phy)
-				if err != nil {
-					logger.WithError(err).Error("Failed to enqueue LinkADRReq")
-					return mac.EnqueueState{
-						MaxDownLen: maxDownLen,
-						MaxUpLen:   maxUpLen,
-					}
-				}
-				return st
+				return mac.EnqueueLinkADRReq(ctx, dev, maxDownLen, maxUpLen, phy)
 			},
 			mac.EnqueueRxTimingSetupReq,
 		)

--- a/pkg/networkserver/internal/errors.go
+++ b/pkg/networkserver/internal/errors.go
@@ -26,9 +26,45 @@ var (
 
 	ErrNetworkDownlinkSlot  = errors.DefineCorruption("network_downlink_slot", "could not generate network initiated downlink slot")
 	ErrUplinkChannel        = errors.DefineCorruption("uplink_channel", "channel does not allow downlinks")
-	ErrDownlinkChannel      = errors.DefineCorruption("downlink_channel", "channel does not allow uplinks")
 	ErrSession              = errors.DefineCorruption("session", "no device session")
 	ErrMACHandler           = errors.DefineCorruption("mac_handler", "missing MAC handler")
 	ErrChannelDataRateRange = errors.DefineCorruption("channel_data_rate_range", "could not generate channel datarate range")
 	ErrChannelMask          = errors.DefineCorruption("channel_mask", "could not generate channel mask")
+
+	ErrTooManyChannels = errors.DefineResourceExhausted(
+		"too_many_channels",
+		"too many channels",
+		"parameters",
+		"channels_len",
+		"phy_max_uplink_channels",
+	)
+	ErrNoUplinkFrequency = errors.DefineInvalidArgument(
+		"no_uplink_frequency",
+		"uplink channel with no uplink frequency",
+		"parameters",
+		"i",
+	)
+	ErrTxPowerIndexTooHigh = errors.DefineInvalidArgument(
+		"tx_power_index_too_high",
+		"tx power index too high",
+		"desired_adr_tx_power_index",
+		"phy_max_tx_power_index",
+	)
+	ErrInvalidDataRateIndex = errors.DefineInvalidArgument(
+		"invalid_data_rate_index",
+		"invalid data rate index",
+		"desired_adr_data_rate_index",
+	)
+	ErrRejectedParameters = errors.DefineUnavailable(
+		"rejected_parameters",
+		"the parameters have been rejected in this session",
+		"parameters",
+		"data_rate_index",
+		"tx_power_index",
+	)
+	ErrIncompatibleChannelMask = errors.DefineUnavailable(
+		"incompatible_channel_mask",
+		"the channel mask is not compatible with the current parameters",
+		"data_rate_index",
+	)
 )

--- a/pkg/networkserver/mac/adr.go
+++ b/pkg/networkserver/mac/adr.go
@@ -327,7 +327,7 @@ func AdaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, de
 		return nil
 	}
 
-	minDataRateIndex, maxDataRateIndex, ok := channelDataRateRange(currentParameters.Channels...)
+	minDataRateIndex, maxDataRateIndex, _, ok := channelDataRateRange(currentParameters.Channels...)
 	if !ok {
 		return internal.ErrCorruptedMACState.
 			WithCause(internal.ErrChannelDataRateRange)

--- a/pkg/networkserver/mac/link_adr.go
+++ b/pkg/networkserver/mac/link_adr.go
@@ -16,7 +16,6 @@ package mac
 
 import (
 	"context"
-	"math"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
@@ -40,6 +39,13 @@ var (
 		"link_adr", "link ADR",
 		events.WithDataType(&ttnpb.MACCommand_LinkADRAns{}),
 	)()
+
+	EvtGenerateLinkADRFail = events.Define(
+		"ns.mac.link_adr.request.fail",
+		"link ADR request generation failure",
+		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
+		events.WithErrorDataType(),
+	)
 )
 
 const (
@@ -54,47 +60,80 @@ type linkADRReqParameters struct {
 	NbTrans       uint32
 }
 
-func generateLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band) (linkADRReqParameters, bool, error) {
+// generateUplinkChannelMask generates the enabled uplink channel mask from the provided parameters.
+func generateUplinkChannelMask(name string, channels []*ttnpb.MACParameters_Channel, phy *band.Band) ([]bool, error) {
+	mask := make([]bool, phy.MaxUplinkChannels)
+	for i, ch := range channels {
+		enabled := ch.GetEnableUplink()
+		if enabled && ch.UplinkFrequency == 0 {
+			return nil, internal.ErrNoUplinkFrequency.WithAttributes(
+				"parameters", name,
+				"i", i,
+			)
+		}
+		mask[i] = enabled
+	}
+	return mask, nil
+}
+
+// generateLinkADRReq attempts to generate a `LinkADRReq` command payload in order to reconcile the drift
+// between the current and desired MAC state parameters. The parameters affected are the data rate index,
+// transmission power index, number of transmissions and the channels enabled for uplink usage.
+//
+// The desired parameters are validated against the provided band.
+//
+// The generated command will attempt to patch the channel mask even if the desired data rate index or
+// transmission power index have been rejected, using the no-change data rate indices if the session
+// LoRaWAN version supports them.
+// If the generated command is expected to be invalid (because the data rate index or transmission power
+// index has been rejected before), the generation will be skipped.
+func generateLinkADRReq( //nolint:gocyclo
+	_ context.Context, dev *ttnpb.EndDevice, phy *band.Band,
+) (linkADRReqParameters, bool, error) {
 	if dev.GetMulticast() || dev.GetMacState() == nil {
 		return linkADRReqParameters{}, false, nil
 	}
-	if len(dev.MacState.DesiredParameters.Channels) > int(phy.MaxUplinkChannels) {
-		return linkADRReqParameters{}, false, internal.ErrCorruptedMACState.
-			WithAttributes(
-				"desired_channels_len", len(dev.MacState.DesiredParameters.Channels),
-				"phy_max_uplink_channels", phy.MaxUplinkChannels,
-			).
-			WithCause(internal.ErrUnknownChannel)
+
+	macState := dev.MacState
+	desiredParameters, currentParameters := macState.DesiredParameters, macState.CurrentParameters
+	if n := len(currentParameters.Channels); n > int(phy.MaxUplinkChannels) {
+		return linkADRReqParameters{}, false, internal.ErrTooManyChannels.WithAttributes(
+			"parameters", "current",
+			"channels_len", n,
+			"phy_max_uplink_channels", phy.MaxUplinkChannels,
+		)
+	}
+	if n := len(desiredParameters.Channels); n > int(phy.MaxUplinkChannels) {
+		return linkADRReqParameters{}, false, internal.ErrTooManyChannels.WithAttributes(
+			"parameters", "desired",
+			"channels_len", n,
+			"phy_max_uplink_channels", phy.MaxUplinkChannels,
+		)
 	}
 
-	currentChs := make([]bool, phy.MaxUplinkChannels)
-	for i, ch := range dev.MacState.CurrentParameters.Channels {
-		currentChs[i] = ch.GetEnableUplink()
+	currentChs, err := generateUplinkChannelMask("current", currentParameters.Channels, phy)
+	if err != nil {
+		return linkADRReqParameters{}, false, err
 	}
-	desiredChs := make([]bool, phy.MaxUplinkChannels)
-	for i, ch := range dev.MacState.DesiredParameters.Channels {
-		isEnabled := ch.GetEnableUplink()
-		if isEnabled && ch.UplinkFrequency == 0 {
-			return linkADRReqParameters{}, false, internal.ErrCorruptedMACState.
-				WithAttributes(
-					"i", i,
-					"enabled", isEnabled,
-					"uplink_frequency", ch.UplinkFrequency,
-				).
-				WithCause(internal.ErrDownlinkChannel)
-		}
+	for i, ch := range desiredParameters.Channels {
+		// The channel may not be enabled yet, but an enqueued `NewChannelReq` within
+		// the same uplink may enable it.
 		if DeviceNeedsNewChannelReqAtIndex(dev, i) {
-			currentChs[i] = ch != nil && ch.UplinkFrequency != 0
+			currentChs[i] = ch.GetUplinkFrequency() != 0
 		}
-		desiredChs[i] = isEnabled
+	}
+	desiredChs, err := generateUplinkChannelMask("desired", desiredParameters.Channels, phy)
+	if err != nil {
+		return linkADRReqParameters{}, false, err
 	}
 
 	switch {
 	case !band.EqualChMasks(currentChs, desiredChs):
-		// NOTE: LinkADRReq is scheduled regardless of ADR settings if channel mask is required, which often is the case with ABP devices or when ChMask CFList is not supported/used.
-	case dev.MacState.DesiredParameters.AdrNbTrans != dev.MacState.CurrentParameters.AdrNbTrans,
-		dev.MacState.DesiredParameters.AdrDataRateIndex != dev.MacState.CurrentParameters.AdrDataRateIndex,
-		dev.MacState.DesiredParameters.AdrTxPowerIndex != dev.MacState.CurrentParameters.AdrTxPowerIndex:
+		// NOTE: LinkADRReq is scheduled regardless of ADR settings if channel mask is required, which often
+		// is the case with ABP devices or when ChMask CFList is not supported/used.
+	case desiredParameters.AdrNbTrans != currentParameters.AdrNbTrans,
+		desiredParameters.AdrDataRateIndex != currentParameters.AdrDataRateIndex,
+		desiredParameters.AdrTxPowerIndex != currentParameters.AdrTxPowerIndex:
 	default:
 		return linkADRReqParameters{}, false, nil
 	}
@@ -102,115 +141,97 @@ func generateLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Ban
 	if err != nil {
 		return linkADRReqParameters{}, false, err
 	}
-	if len(desiredMasks) > math.MaxUint16 {
-		// Something is really wrong.
-		return linkADRReqParameters{}, false, internal.ErrCorruptedMACState.
-			WithAttributes(
-				"len", len(desiredMasks),
-			).
-			WithCause(internal.ErrChannelMask)
-	}
 
 	var (
 		drIdx      ttnpb.DataRateIndex
 		txPowerIdx uint32
 		nbTrans    uint32
 	)
-	minDataRateIndex, maxDataRateIndex, ok := channelDataRateRange(dev.MacState.DesiredParameters.Channels...)
+	_, _, allowedDataRates, ok := channelDataRateRange(desiredParameters.Channels...)
 	if !ok {
-		return linkADRReqParameters{}, false, internal.ErrCorruptedMACState.
-			WithCause(internal.ErrChannelDataRateRange)
+		return linkADRReqParameters{}, false, internal.ErrChannelDataRateRange.New()
 	}
 
-	if dev.MacState.DesiredParameters.AdrTxPowerIndex != dev.MacState.CurrentParameters.AdrTxPowerIndex {
-		attributes := []interface{}{
-			"current_adr_tx_power_index", dev.MacState.CurrentParameters.AdrTxPowerIndex,
-			"desired_adr_tx_power_index", dev.MacState.DesiredParameters.AdrTxPowerIndex,
-		}
-		switch {
-		case dev.MacState.DesiredParameters.AdrTxPowerIndex > uint32(phy.MaxTxPowerIndex()):
-			return linkADRReqParameters{}, false, internal.ErrCorruptedMACState.
-				WithAttributes(append(attributes,
-					"phy_max_tx_power_index", phy.MaxTxPowerIndex(),
-				)...)
+	if desiredParameters.AdrTxPowerIndex != currentParameters.AdrTxPowerIndex {
+		if desiredParameters.AdrTxPowerIndex > uint32(phy.MaxTxPowerIndex()) {
+			return linkADRReqParameters{}, false, internal.ErrTxPowerIndexTooHigh.WithAttributes(
+				"desired_adr_tx_power_index", desiredParameters.AdrTxPowerIndex,
+				"phy_max_tx_power_index", phy.MaxTxPowerIndex(),
+			)
 		}
 	}
-	if dev.MacState.DesiredParameters.AdrDataRateIndex != dev.MacState.CurrentParameters.AdrDataRateIndex {
-		attributes := []interface{}{
-			"current_adr_data_rate_index", dev.MacState.CurrentParameters.AdrDataRateIndex,
-			"desired_adr_data_rate_index", dev.MacState.DesiredParameters.AdrDataRateIndex,
-		}
-		switch {
-		case dev.MacState.DesiredParameters.AdrDataRateIndex < minDataRateIndex:
-			return linkADRReqParameters{}, false, internal.ErrCorruptedMACState.
-				WithAttributes(append(attributes,
-					"min_adr_data_rate_index", minDataRateIndex,
-				)...)
-		case dev.MacState.DesiredParameters.AdrDataRateIndex > maxDataRateIndex:
-			return linkADRReqParameters{}, false, internal.ErrCorruptedMACState.
-				WithAttributes(append(attributes,
-					"max_adr_data_rate_index", maxDataRateIndex,
-				)...)
+	if desiredParameters.AdrDataRateIndex != currentParameters.AdrDataRateIndex {
+		if _, ok := allowedDataRates[desiredParameters.AdrDataRateIndex]; !ok {
+			return linkADRReqParameters{}, false, internal.ErrInvalidDataRateIndex.WithAttributes(
+				"desired_adr_data_rate_index", desiredParameters.AdrDataRateIndex,
+			)
 		}
 	}
 
-	drIdx = dev.MacState.DesiredParameters.AdrDataRateIndex
-	txPowerIdx = dev.MacState.DesiredParameters.AdrTxPowerIndex
-	nbTrans = dev.MacState.DesiredParameters.AdrNbTrans
-	resetDRTXToCurrent := func() {
-		drIdx = dev.MacState.CurrentParameters.AdrDataRateIndex
-		txPowerIdx = dev.MacState.CurrentParameters.AdrTxPowerIndex
-	}
+	drIdx = desiredParameters.AdrDataRateIndex
+	txPowerIdx = desiredParameters.AdrTxPowerIndex
+	nbTrans = desiredParameters.AdrNbTrans
 	switch {
 	case !deviceRejectedADRDataRateIndex(dev, drIdx) && !deviceRejectedADRTXPowerIndex(dev, txPowerIdx):
 		// Only send the desired DataRateIndex and TXPowerIndex if neither of them were rejected.
 
-	case len(desiredMasks) == 0 && dev.MacState.DesiredParameters.AdrNbTrans == dev.MacState.CurrentParameters.AdrNbTrans:
-		log.FromContext(ctx).Debug("Either desired data rate index or TX power output index have been rejected and there are no channel mask and NbTrans changes desired, avoid enqueueing LinkADRReq")
-		return linkADRReqParameters{}, false, nil
-
-	case macspec.HasNoChangeDataRateIndex(dev.MacState.LorawanVersion) && !deviceRejectedADRDataRateIndex(dev, noChangeDataRateIndex) &&
-		macspec.HasNoChangeTXPowerIndex(dev.MacState.LorawanVersion) && !deviceRejectedADRTXPowerIndex(dev, noChangeTXPowerIndex):
-		drIdx = noChangeDataRateIndex
-		txPowerIdx = noChangeTXPowerIndex
+	case len(desiredMasks) == 0 && desiredParameters.AdrNbTrans == currentParameters.AdrNbTrans:
+		// Either desired data rate index or TX power output index have been rejected and there are
+		// no channel mask and NbTrans changes desired.
+		return linkADRReqParameters{}, false, internal.ErrRejectedParameters.WithAttributes(
+			"parameters", "desired",
+			"data_rate_index", drIdx,
+			"tx_power_index", txPowerIdx,
+		)
 
 	default:
-		logger := log.FromContext(ctx).WithFields(log.Fields(
-			"current_adr_nb_trans", dev.MacState.CurrentParameters.AdrNbTrans,
-			"desired_adr_nb_trans", dev.MacState.DesiredParameters.AdrNbTrans,
-			"desired_mask_count", len(desiredMasks),
-		))
-		for deviceRejectedADRDataRateIndex(dev, drIdx) || deviceRejectedADRTXPowerIndex(dev, txPowerIdx) {
-			if drIdx < minDataRateIndex {
-				logger.Warn("Device desired data rate is under the minimum data rate for ADR. Avoiding data rate and TX power changes")
-				resetDRTXToCurrent()
-				break
-			}
-			// Since either data rate or TX power index (or both) were rejected by the device, undo the
-			// desired ADR adjustments step-by-step until possibly fitting index pair is found.
-			if drIdx == minDataRateIndex && (deviceRejectedADRDataRateIndex(dev, drIdx) || txPowerIdx == 0) {
-				logger.Warn("Device rejected either all available data rate indexes or all available TX power output indexes. Avoiding data rate and TX power changes")
-				resetDRTXToCurrent()
-				break
-			}
-			for drIdx > minDataRateIndex && (deviceRejectedADRDataRateIndex(dev, drIdx) || txPowerIdx == 0 && deviceRejectedADRTXPowerIndex(dev, txPowerIdx)) {
-				// Increase data rate until a non-rejected index is found.
-				// Set TX power to maximum possible value.
-				drIdx--
-				txPowerIdx = uint32(phy.MaxTxPowerIndex())
-			}
-			for txPowerIdx > 0 && deviceRejectedADRTXPowerIndex(dev, txPowerIdx) {
-				// Increase TX output power until a non-rejected index is found.
-				txPowerIdx--
-			}
+		// The desired data rate index and/or transmission power index have been rejected, and we have to
+		// either change the channel mask or the number of transmissions. We will attempt to maintain the
+		// current data rate index and transmission power index while changing the enabled channels mask
+		// and the number of transmissions.
+
+		drIdx = currentParameters.AdrDataRateIndex
+		txPowerIdx = currentParameters.AdrTxPowerIndex
+
+		// It can be the case that the new channel mask is no longer compatible with the old data rate index.
+		// We will not attempt to generate a `LinkADRReq` in such cases.
+		if _, ok := allowedDataRates[drIdx]; !ok {
+			return linkADRReqParameters{}, false, internal.ErrIncompatibleChannelMask.WithAttributes(
+				"data_rate_index", drIdx,
+			)
+		}
+
+		dataRateIndexRejected := deviceRejectedADRDataRateIndex(dev, drIdx)
+		txPowerIndexRejected := deviceRejectedADRTXPowerIndex(dev, txPowerIdx)
+		if macspec.HasNoChangeADRIndices(macState.LorawanVersion) {
+			dataRateIndexRejected = dataRateIndexRejected &&
+				deviceRejectedADRDataRateIndex(dev, noChangeDataRateIndex)
+			txPowerIndexRejected = txPowerIndexRejected &&
+				deviceRejectedADRTXPowerIndex(dev, noChangeTXPowerIndex)
+		}
+		if !dataRateIndexRejected && !txPowerIndexRejected {
+			break
+		}
+
+		// At this point we do cannot reuse the current data rate index and transmission power index in order
+		// to change the channel mask or number of transmissions.
+		return linkADRReqParameters{}, false, internal.ErrRejectedParameters.WithAttributes(
+			"parameters", "current",
+			"data_rate_index", drIdx,
+			"tx_power_index", txPowerIdx,
+		)
+	}
+	if macspec.HasNoChangeADRIndices(macState.LorawanVersion) {
+		if drIdx == currentParameters.AdrDataRateIndex &&
+			!deviceRejectedADRDataRateIndex(dev, noChangeDataRateIndex) {
+			drIdx = noChangeDataRateIndex
+		}
+		if txPowerIdx == currentParameters.AdrTxPowerIndex &&
+			!deviceRejectedADRTXPowerIndex(dev, noChangeTXPowerIndex) {
+			txPowerIdx = noChangeTXPowerIndex
 		}
 	}
-	if drIdx == dev.MacState.CurrentParameters.AdrDataRateIndex && macspec.HasNoChangeDataRateIndex(dev.MacState.LorawanVersion) && !deviceRejectedADRDataRateIndex(dev, noChangeDataRateIndex) {
-		drIdx = noChangeDataRateIndex
-	}
-	if txPowerIdx == dev.MacState.CurrentParameters.AdrTxPowerIndex && macspec.HasNoChangeTXPowerIndex(dev.MacState.LorawanVersion) && !deviceRejectedADRTXPowerIndex(dev, noChangeTXPowerIndex) {
-		txPowerIdx = noChangeTXPowerIndex
-	}
+
 	return linkADRReqParameters{
 		Masks:         desiredMasks,
 		DataRateIndex: drIdx,
@@ -219,35 +240,40 @@ func generateLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Ban
 	}, true, nil
 }
 
+// DeviceNeedsLinkADRReq returns if the end device needs a `LinkADRReq` command to be enqueued.
 func DeviceNeedsLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band) bool {
 	_, required, err := generateLinkADRReq(ctx, dev, phy)
 	return err == nil && required
 }
 
-func EnqueueLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16, phy *band.Band) (EnqueueState, error) {
+// EnqueueLinkADRReq enqueues a `LinkADRReq` request if needed.
+func EnqueueLinkADRReq(
+	ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16, phy *band.Band,
+) EnqueueState {
 	params, required, err := generateLinkADRReq(ctx, dev, phy)
 	if err != nil {
 		return EnqueueState{
-			MaxDownLen: maxDownLen,
-			MaxUpLen:   maxUpLen,
-		}, err
+			MaxDownLen:   maxDownLen,
+			MaxUpLen:     maxUpLen,
+			QueuedEvents: events.Builders{EvtGenerateLinkADRFail.BindData(err)},
+			Ok:           true,
+		}
 	}
 	if !required {
 		return EnqueueState{
 			MaxDownLen: maxDownLen,
 			MaxUpLen:   maxUpLen,
 			Ok:         true,
-		}, nil
+		}
 	}
-
-	var st EnqueueState
-	dev.MacState.PendingRequests, st = enqueueMACCommand(ttnpb.MACCommandIdentifier_CID_LINK_ADR, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, events.Builders, bool) {
+	macState := dev.MacState
+	f := func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, events.Builders, bool) {
 		if int(nDown) < len(params.Masks) {
 			return nil, 0, nil, false
 		}
 
 		uplinksNeeded := uint16(len(params.Masks))
-		if macspec.SingularLinkADRAns(dev.MacState.LorawanVersion) {
+		if macspec.SingularLinkADRAns(macState.LorawanVersion) {
 			uplinksNeeded = 1
 		}
 		if nUp < uplinksNeeded {
@@ -274,15 +300,28 @@ func EnqueueLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, ma
 			)).Debug("Enqueued LinkADRReq")
 		}
 		return cmds, uplinksNeeded, evs, true
-	}, dev.MacState.PendingRequests...)
-	return st, nil
+	}
+	var st EnqueueState
+	macState.PendingRequests, st = enqueueMACCommand(
+		ttnpb.MACCommandIdentifier_CID_LINK_ADR, maxDownLen, maxUpLen, f, macState.PendingRequests...,
+	)
+	return st
 }
 
-func HandleLinkADRAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_LinkADRAns, dupCount uint, fCntUp uint32, fps *frequencyplans.Store) (events.Builders, error) {
+// HandleLinkADRAns applies the update of the associated `LinkADRReq` request to the end device, if applicable.
+func HandleLinkADRAns( //nolint:gocyclo
+	_ context.Context,
+	dev *ttnpb.EndDevice,
+	pld *ttnpb.MACCommand_LinkADRAns,
+	dupCount uint,
+	fCntUp uint32,
+	fps *frequencyplans.Store,
+) (events.Builders, error) {
 	if pld == nil {
 		return nil, ErrNoPayload.New()
 	}
-	allowDuplicateLinkADRAns := macspec.AllowDuplicateLinkADRAns(dev.MacState.LorawanVersion)
+	macState := dev.MacState
+	allowDuplicateLinkADRAns := macspec.AllowDuplicateLinkADRAns(macState.LorawanVersion)
 	if !allowDuplicateLinkADRAns && dupCount != 0 {
 		return nil, internal.ErrInvalidPayload.New()
 	}
@@ -290,11 +329,6 @@ func HandleLinkADRAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACC
 	ev := EvtReceiveLinkADRAccept
 	if !pld.ChannelMaskAck || !pld.DataRateIndexAck || !pld.TxPowerIndexAck {
 		ev = EvtReceiveLinkADRReject
-
-		// See "Table 6: LinkADRAns status bits signification" of LoRaWAN 1.1 specification
-		if !pld.ChannelMaskAck {
-			log.FromContext(ctx).Warn("Either Network Server sent a channel mask, which enables a yet undefined channel or requires all channels to be disabled, or device is malfunctioning.")
-		}
 	}
 	evs := events.Builders{ev.With(events.WithData(pld))}
 
@@ -303,13 +337,14 @@ func HandleLinkADRAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACC
 		return evs, err
 	}
 
+	currentParameters := macState.CurrentParameters
 	handler := handleMACResponseBlock
-	if !allowDuplicateLinkADRAns && !macspec.SingularLinkADRAns(dev.MacState.LorawanVersion) {
+	if !allowDuplicateLinkADRAns && !macspec.SingularLinkADRAns(macState.LorawanVersion) {
 		handler = handleMACResponse
 	}
 	var n uint
 	var req *ttnpb.MACCommand_LinkADRReq
-	dev.MacState.PendingRequests, err = handler(
+	macState.PendingRequests, err = handler(
 		ttnpb.MACCommandIdentifier_CID_LINK_ADR,
 		false,
 		func(cmd *ttnpb.MACCommand) error {
@@ -331,62 +366,63 @@ func HandleLinkADRAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACC
 			if err != nil {
 				return err
 			}
+			channels := currentParameters.Channels
 			for i, masked := range m {
-				if int(i) >= len(dev.MacState.CurrentParameters.Channels) || dev.MacState.CurrentParameters.Channels[i] == nil {
+				if int(i) >= len(channels) || channels[i] == nil {
 					if !masked {
 						continue
 					}
 					return internal.ErrCorruptedMACState.
 						WithAttributes(
 							"i", i,
-							"channels_len", len(dev.MacState.CurrentParameters.Channels),
+							"channels_len", len(channels),
 						).
 						WithCause(internal.ErrUnknownChannel)
 				}
-				dev.MacState.CurrentParameters.Channels[i].EnableUplink = masked
+				channels[i].EnableUplink = masked
 			}
 			return nil
 		},
-		dev.MacState.PendingRequests...,
+		macState.PendingRequests...,
 	)
 	if err != nil || req == nil {
 		return evs, err
 	}
 
 	if !pld.DataRateIndexAck {
-		i := searchDataRateIndex(req.DataRateIndex, dev.MacState.RejectedAdrDataRateIndexes...)
-		if i == len(dev.MacState.RejectedAdrDataRateIndexes) ||
-			dev.MacState.RejectedAdrDataRateIndexes[i] != req.DataRateIndex {
-			dev.MacState.RejectedAdrDataRateIndexes = append(
-				dev.MacState.RejectedAdrDataRateIndexes, ttnpb.DataRateIndex_DATA_RATE_0,
+		i := searchDataRateIndex(req.DataRateIndex, macState.RejectedAdrDataRateIndexes...)
+		if i == len(macState.RejectedAdrDataRateIndexes) ||
+			macState.RejectedAdrDataRateIndexes[i] != req.DataRateIndex {
+			macState.RejectedAdrDataRateIndexes = append(
+				macState.RejectedAdrDataRateIndexes, ttnpb.DataRateIndex_DATA_RATE_0,
 			)
-			copy(dev.MacState.RejectedAdrDataRateIndexes[i+1:], dev.MacState.RejectedAdrDataRateIndexes[i:])
-			dev.MacState.RejectedAdrDataRateIndexes[i] = req.DataRateIndex
+			copy(macState.RejectedAdrDataRateIndexes[i+1:], macState.RejectedAdrDataRateIndexes[i:])
+			macState.RejectedAdrDataRateIndexes[i] = req.DataRateIndex
 		}
 	}
 	if !pld.TxPowerIndexAck {
-		i := searchUint32(req.TxPowerIndex, dev.MacState.RejectedAdrTxPowerIndexes...)
-		if i == len(dev.MacState.RejectedAdrTxPowerIndexes) ||
-			dev.MacState.RejectedAdrTxPowerIndexes[i] != req.TxPowerIndex {
-			dev.MacState.RejectedAdrTxPowerIndexes = append(dev.MacState.RejectedAdrTxPowerIndexes, 0)
-			copy(dev.MacState.RejectedAdrTxPowerIndexes[i+1:], dev.MacState.RejectedAdrTxPowerIndexes[i:])
-			dev.MacState.RejectedAdrTxPowerIndexes[i] = req.TxPowerIndex
+		i := searchUint32(req.TxPowerIndex, macState.RejectedAdrTxPowerIndexes...)
+		if i == len(macState.RejectedAdrTxPowerIndexes) ||
+			macState.RejectedAdrTxPowerIndexes[i] != req.TxPowerIndex {
+			macState.RejectedAdrTxPowerIndexes = append(macState.RejectedAdrTxPowerIndexes, 0)
+			copy(macState.RejectedAdrTxPowerIndexes[i+1:], macState.RejectedAdrTxPowerIndexes[i:])
+			macState.RejectedAdrTxPowerIndexes[i] = req.TxPowerIndex
 		}
 	}
 	if !pld.ChannelMaskAck || !pld.DataRateIndexAck || !pld.TxPowerIndexAck {
 		return evs, nil
 	}
-	if !macspec.HasNoChangeDataRateIndex(dev.MacState.LorawanVersion) || req.DataRateIndex != noChangeDataRateIndex {
-		dev.MacState.CurrentParameters.AdrDataRateIndex = req.DataRateIndex
-		dev.MacState.LastAdrChangeFCntUp = fCntUp
+	if !macspec.HasNoChangeADRIndices(macState.LorawanVersion) || req.DataRateIndex != noChangeDataRateIndex {
+		currentParameters.AdrDataRateIndex = req.DataRateIndex
+		macState.LastAdrChangeFCntUp = fCntUp
 	}
-	if !macspec.HasNoChangeTXPowerIndex(dev.MacState.LorawanVersion) || req.TxPowerIndex != noChangeTXPowerIndex {
-		dev.MacState.CurrentParameters.AdrTxPowerIndex = req.TxPowerIndex
-		dev.MacState.LastAdrChangeFCntUp = fCntUp
+	if !macspec.HasNoChangeADRIndices(macState.LorawanVersion) || req.TxPowerIndex != noChangeTXPowerIndex {
+		currentParameters.AdrTxPowerIndex = req.TxPowerIndex
+		macState.LastAdrChangeFCntUp = fCntUp
 	}
-	if req.NbTrans > 0 && dev.MacState.CurrentParameters.AdrNbTrans != req.NbTrans {
-		dev.MacState.CurrentParameters.AdrNbTrans = req.NbTrans
-		dev.MacState.LastAdrChangeFCntUp = fCntUp
+	if req.NbTrans > 0 && currentParameters.AdrNbTrans != req.NbTrans {
+		currentParameters.AdrNbTrans = req.NbTrans
+		macState.LastAdrChangeFCntUp = fCntUp
 	}
 	return evs, nil
 }

--- a/pkg/specification/macspec/specification.go
+++ b/pkg/specification/macspec/specification.go
@@ -69,13 +69,8 @@ func HasMaxFCntGap(v ttnpb.MACVersion) bool {
 	return compareMACVersion(v, ttnpb.MACVersion_MAC_V1_0_4) < 0
 }
 
-// HasNoChangeTXPowerIndex reports whether v defines a no-change TxPowerIndex value.
-func HasNoChangeTXPowerIndex(v ttnpb.MACVersion) bool {
-	return compareMACVersion(v, ttnpb.MACVersion_MAC_V1_0_4) >= 0
-}
-
-// HasNoChangeDataRateIndex reports whether v defines a no-change DataRateIndex value.
-func HasNoChangeDataRateIndex(v ttnpb.MACVersion) bool {
+// HasNoChangeADRIndices reports whether v defines a no-change TxPowerIndex and DataRateIndexValue.
+func HasNoChangeADRIndices(v ttnpb.MACVersion) bool {
 	return compareMACVersion(v, ttnpb.MACVersion_MAC_V1_0_4) >= 0
 }
 

--- a/pkg/util/test/assertions/events.go
+++ b/pkg/util/test/assertions/events.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 )
@@ -51,6 +52,13 @@ func ShouldResembleEvent(actual interface{}, expected ...interface{}) string {
 	ap, err := events.Proto(ae)
 	if s := assertions.ShouldBeNil(err); s != success {
 		return s
+	}
+	if _, ok := ee.Data().(errors.DefinitionInterface); ok {
+		if s := ShouldEqualErrorOrDefinition(ae.Data(), ee.Data()); s != success {
+			return s
+		}
+		ap.Data = nil
+		ep.Data = nil
 	}
 	ap.UniqueId = ""
 	ep.UniqueId = ""


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/3658

#### Changes
<!-- What are the changes made in this pull request? -->

- Refactor the `LinkADRReq` command generation to report errors via events, as opposed to log messages which are not accessible for hosted instances.
- Improve `LinkADRReq` validation:
  - Validate the current channels for to check that they are well formed (not only the desired channels).
  - Check individual data rate indices against the available data rate index intervals, instead of just checking `min <= index <= max`. This is relevant for cases in which there is a gap of data rate indices between `min` and `max`.
  - The NS will avoid now scheduling a channel mask which would render the end device impossible to send uplinks. This happens if for example the end device was using LR-FHSS channels and we disable uplinks over those. If we instruct the end device to keep its data rate, we are asking it to mute itself, since no channels are going to have uplinks available with the old LR-FHSS data rate.
- Refactor coding style for better visibility.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

`generateLinkADRReq` no longer attempts to lower the data rate used by the end device when the desired data rate index or transmission power has been rejected. This is fine, as the ADR algorithm was already doing it, and in cases in which ADR is disabled we do not need to do this for the end device - we will just maintain the current parameters.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
