### PR TITLE
Fix form bugs related to ADR

### DIFF
--- a/pkg/webui/console/components/mac-settings-section/index.js
+++ b/pkg/webui/console/components/mac-settings-section/index.js
@@ -120,8 +120,6 @@ const maxDutyCycleOptions = [
 const encodeAdrMode = value => ({ [value]: {} })
 const decodeAdrMode = value => (value !== undefined ? Object.keys(value)[0] : null)
 
-const decodeStaticFields = value => (value ? value : 0)
-
 const MacSettingsSection = props => {
   const {
     activationMode,
@@ -498,7 +496,6 @@ const MacSettingsSection = props => {
             component={Input}
             type="number"
             inputWidth="xs"
-            decode={decodeStaticFields}
           />
           <Form.Field
             title={m.adrTransPower}
@@ -506,7 +503,6 @@ const MacSettingsSection = props => {
             component={Input}
             type="number"
             inputWidth="xs"
-            decode={decodeStaticFields}
           />
           <Form.Field
             title={m.adrUplinks}
@@ -514,7 +510,6 @@ const MacSettingsSection = props => {
             component={Input}
             type="number"
             inputWidth="xs"
-            decode={decodeStaticFields}
           />
         </>
       )}

--- a/pkg/webui/console/components/mac-settings-section/index.js
+++ b/pkg/webui/console/components/mac-settings-section/index.js
@@ -120,6 +120,8 @@ const maxDutyCycleOptions = [
 const encodeAdrMode = value => ({ [value]: {} })
 const decodeAdrMode = value => (value !== undefined ? Object.keys(value)[0] : null)
 
+const decodeStaticFields = value => (value ? value : 0)
+
 const MacSettingsSection = props => {
   const {
     activationMode,
@@ -496,6 +498,7 @@ const MacSettingsSection = props => {
             component={Input}
             type="number"
             inputWidth="xs"
+            decode={decodeStaticFields}
           />
           <Form.Field
             title={m.adrTransPower}
@@ -503,6 +506,7 @@ const MacSettingsSection = props => {
             component={Input}
             type="number"
             inputWidth="xs"
+            decode={decodeStaticFields}
           />
           <Form.Field
             title={m.adrUplinks}
@@ -510,6 +514,7 @@ const MacSettingsSection = props => {
             component={Input}
             type="number"
             inputWidth="xs"
+            decode={decodeStaticFields}
           />
         </>
       )}

--- a/pkg/webui/console/views/device-general-settings/network-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/network-server-form/index.js
@@ -245,10 +245,8 @@ const NetworkServerForm = React.memo(props => {
   }, [onMacReset])
 
   const handleSubmit = React.useCallback(
-    async (values, { resetForm, setSubmitting }, cleanValues) => {
-      const { _activation_mode } = values
-
-      const castedValues = validationSchema.cast(cleanValues, {
+    async (values, { resetForm, setSubmitting }) => {
+      const castedValues = validationSchema.cast(values, {
         context: validationContext,
         stripUnknown: true,
       })
@@ -269,7 +267,7 @@ const NetworkServerForm = React.memo(props => {
       // Always submit current `mac_settings` values to avoid overwriting nested entries.
       patch.mac_settings = castedValues.mac_settings
 
-      const isOTAA = _activation_mode === ACTIVATION_MODES.OTAA
+      const isOTAA = values._activation_mode === ACTIVATION_MODES.OTAA
       // Do not update session for joined OTAA end devices.
       if (!isOTAA && castedValues.session && castedValues.session.keys) {
         const { app_s_key, ...keys } = castedValues.session.keys

--- a/pkg/webui/console/views/device-general-settings/network-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/network-server-form/index.js
@@ -150,6 +150,7 @@ const NetworkServerForm = React.memo(props => {
               {
                 ...values,
                 mac_settings: {
+                  ...settings,
                   ...values.mac_settings,
                   // To use `adr_margin` as initial value of `adr.dynamic.margin`.
                   // And to make sure that, if there is already a value set for `adr`, it is not overwritten
@@ -162,7 +163,6 @@ const NetworkServerForm = React.memo(props => {
                           },
                         }
                       : values.mac_settings.adr,
-                  ...settings,
                 },
               },
               { context: validationContext },

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -129,6 +129,20 @@ class Devices {
       ) {
         mac_settings.rx2_data_rate_index = 0
       }
+
+      if (mac_settings.adr && 'static' in mac_settings.adr) {
+        if (typeof mac_settings.adr.static.data_rate_index === 'undefined') {
+          mac_settings.adr.static.data_rate_index = 0
+        }
+
+        if (typeof mac_settings.adr.static.nb_trans === 'undefined') {
+          mac_settings.adr.static.nb_trans = 0
+        }
+
+        if (typeof mac_settings.adr.static.tx_power_index === 'undefined') {
+          mac_settings.adr.static.tx_power_index = 0
+        }
+      }
     }
 
     return device


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix some network server section bugs in the device general settings form.

#### Changes
<!-- What are the changes made in this pull request? -->

- The `settings` have to be spread inside `mac_settings` otherwise other values will not be shown correctly
- In adr static fields, if the user set them to 0, after refresh the values went back to being empty, because the backend did not include these fields in the response. This behavior happened due to adr static fields being either `enums` or `integers`, where '0' corresponds to 'default' or 'missing'. So in order to maintain some consistency and not have empty values when the user has set the value to '0'. I decided, after speaking to Adrian, to simply set the field value to '0' every time it is not present in the backend response.

https://user-images.githubusercontent.com/56658938/189659669-be653fbb-71d3-47c1-b96f-9f50ac5ac625.mov


#### Testing

<!-- How did you verify that this change works? -->

manually


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
