### PR TITLE
Support factory preset frequencies in fixed channel plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - `--mac-settings.adr.mode.disabled`, `--mac-settings.adr.mode.dynamic` and `--mac-settings.adr.mode.static` flags of the `end-device update` command.
 - Pagination in `sessions` and `access tokens` tables in the Console.
+- `LinkADRReq` MAC command generation for LoRaWAN 1.0 and 1.0.1 end devices.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For details about compatibility between different releases, see the **Commitment
   - Claiming end devices from external Join Servers is now possible seemlessly from the same onboarding flow.
 - LoRa coding rate now defined in `DataRate` instead of `Band`.
 - The Network Server will now schedule a potentially empty downlink in order to stop end devices from sending sticky MAC commands.
+- Factory preset frequencies may now be provided for bands with fixed channel plans, such as US915 or AU915. The factory preset frequencies are interpreted as the only channels which are enabled at boot time.
 
 ### Deprecated
 

--- a/pkg/band/au_915_928_rp1_v1_0_2.go
+++ b/pkg/band/au_915_928_rp1_v1_0_2.go
@@ -95,7 +95,7 @@ var AU_915_928_RP1_v1_0_2 = Band{
 		return au915928DownlinkDRTableLegacy[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(false),
+	GenerateChMasks: makeGenerateChMask72(false, true),
 	ParseChMask:     parseChMask72,
 
 	DefaultRx2Parameters: Rx2Parameters{ttnpb.DataRateIndex_DATA_RATE_8, 923300000},

--- a/pkg/band/au_915_928_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/au_915_928_rp1_v1_0_2_rev_b.go
@@ -97,7 +97,7 @@ var AU_915_928_RP1_v1_0_2_RevB = Band{
 		return au915928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(false),
+	GenerateChMasks: makeGenerateChMask72(false, true),
 	ParseChMask:     parseChMask72,
 
 	DefaultRx2Parameters: Rx2Parameters{ttnpb.DataRateIndex_DATA_RATE_8, 923300000},

--- a/pkg/band/au_915_928_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/au_915_928_rp1_v1_0_3_rev_a.go
@@ -102,7 +102,7 @@ var AU_915_928_RP1_v1_0_3_RevA = Band{
 		return au915928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	DefaultRx2Parameters: Rx2Parameters{ttnpb.DataRateIndex_DATA_RATE_8, 923300000},

--- a/pkg/band/au_915_928_rp1_v1_1_rev_a.go
+++ b/pkg/band/au_915_928_rp1_v1_1_rev_a.go
@@ -97,7 +97,7 @@ var AU_915_928_RP1_v1_1_RevA = Band{
 		return au915928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	DefaultRx2Parameters: Rx2Parameters{ttnpb.DataRateIndex_DATA_RATE_8, 923300000},

--- a/pkg/band/au_915_928_rp1_v1_1_rev_b.go
+++ b/pkg/band/au_915_928_rp1_v1_1_rev_b.go
@@ -101,7 +101,7 @@ var AU_915_928_RP1_v1_1_RevB = Band{
 		return au915928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	DefaultRx2Parameters: Rx2Parameters{ttnpb.DataRateIndex_DATA_RATE_8, 923300000},

--- a/pkg/band/au_915_928_rp2_v1_0_0.go
+++ b/pkg/band/au_915_928_rp2_v1_0_0.go
@@ -101,7 +101,7 @@ var AU_915_928_RP2_v1_0_0 = Band{
 		return au915928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	DefaultRx2Parameters: Rx2Parameters{ttnpb.DataRateIndex_DATA_RATE_8, 923300000},

--- a/pkg/band/au_915_928_rp2_v1_0_1.go
+++ b/pkg/band/au_915_928_rp2_v1_0_1.go
@@ -101,7 +101,7 @@ var AU_915_928_RP2_v1_0_1 = Band{
 		return au915928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	DefaultRx2Parameters: Rx2Parameters{ttnpb.DataRateIndex_DATA_RATE_8, 923300000},

--- a/pkg/band/au_915_928_rp2_v1_0_2.go
+++ b/pkg/band/au_915_928_rp2_v1_0_2.go
@@ -101,7 +101,7 @@ var AU_915_928_RP2_v1_0_2 = Band{
 		return au915928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	DefaultRx2Parameters: Rx2Parameters{ttnpb.DataRateIndex_DATA_RATE_8, 923300000},

--- a/pkg/band/au_915_928_rp2_v1_0_3.go
+++ b/pkg/band/au_915_928_rp2_v1_0_3.go
@@ -101,7 +101,7 @@ var AU_915_928_RP2_v1_0_3 = Band{
 		return au915928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	DefaultRx2Parameters: Rx2Parameters{ttnpb.DataRateIndex_DATA_RATE_8, 923300000},

--- a/pkg/band/au_915_928_ts1_v1_0_1.go
+++ b/pkg/band/au_915_928_ts1_v1_0_1.go
@@ -95,7 +95,7 @@ var AU_915_928_TS1_v1_0_1 = Band{
 		return au915928DownlinkDRTableLegacy[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(false),
+	GenerateChMasks: makeGenerateChMask72(false, false),
 	ParseChMask:     parseChMask72,
 
 	DefaultRx2Parameters: Rx2Parameters{ttnpb.DataRateIndex_DATA_RATE_8, 923300000},

--- a/pkg/band/band_internal_test.go
+++ b/pkg/band/band_internal_test.go
@@ -90,7 +90,7 @@ func TestGenerateChMask(t *testing.T) {
 
 		{
 			Name:     "72 channels/no cntl5/current(1-72)/desired(1-72)",
-			Generate: makeGenerateChMask72(false),
+			Generate: makeGenerateChMask72(false, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, true, true, true, true,
@@ -127,7 +127,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/cntl5/current(1-72)/desired(1-72)",
-			Generate: makeGenerateChMask72(true),
+			Generate: makeGenerateChMask72(true, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, true, true, true, true,
@@ -164,7 +164,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/no cntl5/current:(1-16,42,67,69);desired:(1-16,42,67,69)",
-			Generate: makeGenerateChMask72(false),
+			Generate: makeGenerateChMask72(false, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, true, true, true, true,
@@ -201,7 +201,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/cntl5/current:(1-16,42,67,69);desired:(1-16,42,67,69)",
-			Generate: makeGenerateChMask72(true),
+			Generate: makeGenerateChMask72(true, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, true, true, true, true,
@@ -238,7 +238,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/no cntl5/current:(1-4,6-16,42,67,69);desired:(1-16,42,67,69)",
-			Generate: makeGenerateChMask72(false),
+			Generate: makeGenerateChMask72(false, true),
 			CurrentChannels: []bool{
 				false, false, false, false, true, false, false, false,
 				false, false, false, false, false, false, false, false,
@@ -275,7 +275,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/cntl5/current:(1-4,6-16,42,67,69);desired:(1-16,42,67,69)",
-			Generate: makeGenerateChMask72(false),
+			Generate: makeGenerateChMask72(false, true),
 			CurrentChannels: []bool{
 				false, false, false, false, true, false, false, false,
 				false, false, false, false, false, false, false, false,
@@ -312,7 +312,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/no cntl5/current(1-12,14-33,36-42,44-72)/desired(1-69)",
-			Generate: makeGenerateChMask72(false),
+			Generate: makeGenerateChMask72(false, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, false, true, true, true,
@@ -350,7 +350,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/cntl5/current(1-12,14-33,36-42,44-72)/desired(1-69)",
-			Generate: makeGenerateChMask72(false),
+			Generate: makeGenerateChMask72(false, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, false, true, true, true,
@@ -388,7 +388,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/no cntl5/current(1-12,14-33,36-42,44-71)/desired(1-3,5-72)",
-			Generate: makeGenerateChMask72(false),
+			Generate: makeGenerateChMask72(false, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, false, true, true, true,
@@ -432,7 +432,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/cntl5/current(1-12,14-33,36-42,44-71)/desired(1-3,5-72)",
-			Generate: makeGenerateChMask72(false),
+			Generate: makeGenerateChMask72(false, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, false, true, true, true,
@@ -476,7 +476,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/no cntl5/current(1-12,14-33,36-42,44-63,65-72)/desired(1-3,5-72)",
-			Generate: makeGenerateChMask72(false),
+			Generate: makeGenerateChMask72(false, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, false, true, true, true,
@@ -520,7 +520,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/cntl5/current(1-12,14-33,36-42,44-63,65-72)/desired(1-3,5-72)",
-			Generate: makeGenerateChMask72(false),
+			Generate: makeGenerateChMask72(false, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, false, true, true, true,
@@ -564,7 +564,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/no cntl5/current(1-72)/desired(9-16,65-72)",
-			Generate: makeGenerateChMask72(false),
+			Generate: makeGenerateChMask72(false, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, true, true, true, true,
@@ -608,7 +608,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/cntl5/current(1-72)/desired(9-16,65-72)",
-			Generate: makeGenerateChMask72(true),
+			Generate: makeGenerateChMask72(true, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, true, true, true, true,
@@ -646,7 +646,7 @@ func TestGenerateChMask(t *testing.T) {
 		},
 		{
 			Name:     "72 channels/no cntl5/current(1-72)/desired(9-24)",
-			Generate: makeGenerateChMask72(false),
+			Generate: makeGenerateChMask72(false, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, true, true, true, true,
@@ -692,8 +692,73 @@ func TestGenerateChMask(t *testing.T) {
 			},
 		},
 		{
+			Name:     "72 channels/no cntl5/non-atomic/current(1-72)/desired(40-48)",
+			Generate: makeGenerateChMask72(false, false),
+			CurrentChannels: []bool{
+				true, true, true, true, true, true, true, true,
+				true, true, true, true, true, true, true, true,
+				true, true, true, true, true, true, true, true,
+				true, true, true, true, true, true, true, true,
+				true, true, true, true, true, true, true, true,
+				true, true, true, true, true, true, true, true,
+				true, true, true, true, true, true, true, true,
+				true, true, true, true, true, true, true, true,
+				true, true, true, true, true, true, true, true,
+			},
+			DesiredChannels: []bool{
+				false, false, false, false, false, false, false, false,
+				false, false, false, false, false, false, false, false,
+				false, false, false, false, false, false, false, false,
+				false, false, false, false, false, false, false, false,
+				false, false, false, false, false, false, false, false,
+				true, true, true, true, true, true, true, true,
+				false, false, false, false, false, false, false, false,
+				false, false, false, false, false, false, false, false,
+				false, false, false, false, false, false, false, false,
+			},
+			Expected: []ChMaskCntlPair{
+				{
+					Cntl: 2,
+					Mask: [16]bool{
+						false, false, false, false, false, false, false, false,
+						true, true, true, true, true, true, true, true,
+					},
+				},
+				{
+					Cntl: 4,
+					Mask: [16]bool{
+						false, false, false, false, false, false, false, false,
+						false, false, false, false, false, false, false, false,
+					},
+				},
+				{
+					Cntl: 3,
+					Mask: [16]bool{
+						false, false, false, false, false, false, false, false,
+						false, false, false, false, false, false, false, false,
+					},
+				},
+				{
+					Cntl: 1,
+					Mask: [16]bool{
+						false, false, false, false, false, false, false, false,
+						false, false, false, false, false, false, false, false,
+					},
+				},
+				{
+					Mask: [16]bool{
+						false, false, false, false, false, false, false, false,
+						false, false, false, false, false, false, false, false,
+					},
+				},
+			},
+			ErrorAssertion: func(t *testing.T, err error) bool {
+				return assertions.New(t).So(err, should.BeNil)
+			},
+		},
+		{
 			Name:     "72 channels/cntl5/current(1-72)/desired(9-24)",
-			Generate: makeGenerateChMask72(true),
+			Generate: makeGenerateChMask72(true, true),
 			CurrentChannels: []bool{
 				true, true, true, true, true, true, true, true,
 				true, true, true, true, true, true, true, true,

--- a/pkg/band/band_internal_test.go
+++ b/pkg/band/band_internal_test.go
@@ -32,6 +32,7 @@ var (
 )
 
 func TestGenerateChMask(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		Name            string
 		Generate        func([]bool, []bool) ([]ChMaskCntlPair, error)
@@ -61,6 +62,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -84,6 +86,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -122,6 +125,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -159,6 +163,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -196,6 +201,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -233,6 +239,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -270,6 +277,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -307,6 +315,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -345,6 +354,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -383,6 +393,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -427,6 +438,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -471,6 +483,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -515,6 +528,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -559,6 +573,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -603,6 +618,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -641,6 +657,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -688,6 +705,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -753,6 +771,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -798,6 +817,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -842,6 +862,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -882,6 +903,7 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
@@ -928,11 +950,14 @@ func TestGenerateChMask(t *testing.T) {
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
+				t.Helper()
 				return assertions.New(t).So(err, should.BeNil)
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
 			a := assertions.New(t)
 
 			current := append(tc.CurrentChannels[:0:0], tc.CurrentChannels...)

--- a/pkg/band/band_test.go
+++ b/pkg/band/band_test.go
@@ -734,3 +734,33 @@ func TestChannelsWellDefined(t *testing.T) {
 		}
 	}
 }
+
+func TestSubBandsWellDefined(t *testing.T) {
+	t.Parallel()
+
+	for name, versions := range All {
+		for version, b := range versions {
+			b := b
+			t.Run(fmt.Sprintf("%v/%v", name, version), func(t *testing.T) {
+				t.Parallel()
+
+				checkSubBand := func(ch Channel) bool {
+					for _, sb := range b.SubBands {
+						if sb.MinFrequency <= ch.Frequency && ch.Frequency <= sb.MaxFrequency {
+							return true
+						}
+					}
+					return false
+				}
+
+				a := assertions.New(t)
+				for _, ch := range b.UplinkChannels {
+					a.So(checkSubBand(ch), should.BeTrue)
+				}
+				for _, ch := range b.DownlinkChannels {
+					a.So(checkSubBand(ch), should.BeTrue)
+				}
+			})
+		}
+	}
+}

--- a/pkg/band/us_902_928_rp1_v1_0_2.go
+++ b/pkg/band/us_902_928_rp1_v1_0_2.go
@@ -97,7 +97,7 @@ var US_902_928_RP1_V1_0_2 = Band{
 		return us902928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(false),
+	GenerateChMasks: makeGenerateChMask72(false, true),
 	ParseChMask:     parseChMask72,
 
 	FreqMultiplier:   100,

--- a/pkg/band/us_902_928_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/us_902_928_rp1_v1_0_2_rev_b.go
@@ -97,7 +97,7 @@ var US_902_928_RP1_V1_0_2_Rev_B = Band{
 		return us902928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(false),
+	GenerateChMasks: makeGenerateChMask72(false, true),
 	ParseChMask:     parseChMask72,
 
 	FreqMultiplier:   100,

--- a/pkg/band/us_902_928_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/us_902_928_rp1_v1_0_3_rev_a.go
@@ -102,7 +102,7 @@ var US_902_928_RP1_V1_0_3_Rev_A = Band{
 		return us902928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	FreqMultiplier:   100,

--- a/pkg/band/us_902_928_rp1_v1_1_rev_a.go
+++ b/pkg/band/us_902_928_rp1_v1_1_rev_a.go
@@ -101,7 +101,7 @@ var US_902_928_RP1_V1_1_Rev_A = Band{
 		return us902928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	FreqMultiplier:   100,

--- a/pkg/band/us_902_928_rp1_v1_1_rev_b.go
+++ b/pkg/band/us_902_928_rp1_v1_1_rev_b.go
@@ -101,7 +101,7 @@ var US_902_928_RP1_V1_1_Rev_B = Band{
 		return us902928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	FreqMultiplier:   100,

--- a/pkg/band/us_902_928_rp2_v1_0_0.go
+++ b/pkg/band/us_902_928_rp2_v1_0_0.go
@@ -101,7 +101,7 @@ var US_902_928_RP2_V1_0_0 = Band{
 		return us902928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	FreqMultiplier:   100,

--- a/pkg/band/us_902_928_rp2_v1_0_1.go
+++ b/pkg/band/us_902_928_rp2_v1_0_1.go
@@ -101,7 +101,7 @@ var US_902_928_RP2_V1_0_1 = Band{
 		return us902928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	FreqMultiplier:   100,

--- a/pkg/band/us_902_928_rp2_v1_0_2.go
+++ b/pkg/band/us_902_928_rp2_v1_0_2.go
@@ -103,7 +103,7 @@ var US_902_928_RP2_V1_0_2 = Band{
 		return us902928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	FreqMultiplier:   100,

--- a/pkg/band/us_902_928_rp2_v1_0_3.go
+++ b/pkg/band/us_902_928_rp2_v1_0_3.go
@@ -103,7 +103,7 @@ var US_902_928_RP2_V1_0_3 = Band{
 		return us902928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(true),
+	GenerateChMasks: makeGenerateChMask72(true, true),
 	ParseChMask:     parseChMask72,
 
 	FreqMultiplier:   100,

--- a/pkg/band/us_902_928_ts1_v1_0.go
+++ b/pkg/band/us_902_928_ts1_v1_0.go
@@ -96,7 +96,7 @@ var US_902_928_TS1_V1_0 = Band{
 		return us902928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(false),
+	GenerateChMasks: makeGenerateChMask72(false, false),
 	ParseChMask:     parseChMask72,
 
 	FreqMultiplier:   100,

--- a/pkg/band/us_902_928_ts1_v1_0_1.go
+++ b/pkg/band/us_902_928_ts1_v1_0_1.go
@@ -96,7 +96,7 @@ var US_902_928_TS1_V1_0_1 = Band{
 		return us902928DownlinkDRTable[idx][offset], nil
 	},
 
-	GenerateChMasks: makeGenerateChMask72(false),
+	GenerateChMasks: makeGenerateChMask72(false, false),
 	ParseChMask:     parseChMask72,
 
 	FreqMultiplier:   100,

--- a/pkg/networkserver/mac/utils.go
+++ b/pkg/networkserver/mac/utils.go
@@ -541,6 +541,17 @@ outer:
 				continue outer
 			}
 		}
+		switch phy.CFListType {
+		case ttnpb.CFListType_FREQUENCIES:
+			// Factory preset frequencies in bands which provide frequencies as part of the CFList
+			// are interpreted as being used both for uplinks and downlinks.
+		case ttnpb.CFListType_CHANNEL_MASKS:
+			// Factory preset frequencies in bands which provide channel masks as part of the CFList
+			// are interpreted as enabling explicit uplink channels.
+			continue outer
+		default:
+			panic("unreachable")
+		}
 		if dev.Multicast {
 			chs = append(chs, &ttnpb.MACParameters_Channel{
 				DownlinkFrequency: freq,

--- a/pkg/webui/console/containers/device-onboarding-form/type-form-section/manual-form-section/advanced-settings-section.js
+++ b/pkg/webui/console/containers/device-onboarding-form/type-form-section/manual-form-section/advanced-settings-section.js
@@ -36,7 +36,7 @@ import { getBackendErrorName, isBackend } from '@ttn-lw/lib/errors/utils'
 import getHostFromUrl from '@ttn-lw/lib/host-from-url'
 import attachPromise from '@ttn-lw/lib/store/actions/attach-promise'
 
-import { ACTIVATION_MODES, hasCFListTypeChMask } from '@console/lib/device-utils'
+import { ACTIVATION_MODES } from '@console/lib/device-utils'
 import { checkFromState } from '@account/lib/feature-checks'
 import { mayEditApplicationDeviceKeys } from '@console/lib/feature-checks'
 
@@ -56,8 +56,6 @@ const m = defineMessages({
   classBandC: 'Class B and class C',
   skipJsRegistration: 'Skip registration on Join Server',
   multicastClassCapabilities: 'LoRaWAN class for multicast downlinks',
-  factoryFreqWarning:
-    'In LoRaWAN, factory preset frequencies are only supported for bands with a CFList type of frequencies',
   register: 'Register manually',
   macSettingsError:
     'There was an error and the default MAC settings for the <code>{freqPlan}</code> frequency plan could not be loaded',
@@ -198,14 +196,6 @@ const AdvancedSettingsSection = () => {
     Boolean(frequency_plan_id) && Boolean(lorawan_phy_version) && Boolean(lorawan_version)
   // Disallow using default settings when there is a required field within.
   const mayChangeToDefaultSettings = !((isABP || isMulticast) && isClassB)
-
-  // The technical difference between bands that do support factory preset frequencies
-  // and bands that do not support them, is that the former uses a CFList type of Frequencies,
-  // and the latter uses a CFList type of ChMask (channel mask).
-  // When there is a channel mask, the frequencies aren't configured by frequency in Hertz,
-  // but by index. The factory preset frequencies is really the frequencies in Hertz,
-  // so it requires bands with a CFList type of Frequencies.
-  const disableFactoryPresetFreq = hasCFListTypeChMask(frequency_plan_id)
 
   const dispatch = useDispatch()
 
@@ -532,9 +522,7 @@ const AdvancedSettingsSection = () => {
           {!isOTAA && (
             <Form.Field
               indexAsKey
-              disabled={disableFactoryPresetFreq}
               name="mac_settings.factory_preset_frequencies"
-              description={disableFactoryPresetFreq ? m.factoryFreqWarning : undefined}
               component={KeyValueMap}
               title={messages.factoryPresetFreqTitle}
               addMessage={messages.freqAdd}

--- a/pkg/webui/console/lib/device-utils.js
+++ b/pkg/webui/console/lib/device-utils.js
@@ -170,15 +170,6 @@ export const fCntWidthEncode = value => value === FRAME_WIDTH_COUNT.SUPPORTS_32_
 export const fCntWidthDecode = value =>
   value ? FRAME_WIDTH_COUNT.SUPPORTS_32_BIT : FRAME_WIDTH_COUNT.SUPPORTS_16_BIT
 
-/**
- * @param {string} freqPlan - End device frequency plan.
- * @returns {boolean} - Whether end device frequency plan has a CFList type of ChMask (channel mask).
- */
-export const hasCFListTypeChMask = (freqPlan = '') =>
-  freqPlan.startsWith('US_902_928') ||
-  freqPlan.startsWith('AU_915_928') ||
-  freqPlan.startsWith('CN_470_510')
-
 const ALL_ZERO_KEY = '0'.repeat(32)
 
 /**

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -559,7 +559,6 @@
   "console.containers.device-onboarding-form.type-form-section.manual-form-section.advanced-settings-section.classBandC": "Class B and class C",
   "console.containers.device-onboarding-form.type-form-section.manual-form-section.advanced-settings-section.skipJsRegistration": "Skip registration on Join Server",
   "console.containers.device-onboarding-form.type-form-section.manual-form-section.advanced-settings-section.multicastClassCapabilities": "LoRaWAN class for multicast downlinks",
-  "console.containers.device-onboarding-form.type-form-section.manual-form-section.advanced-settings-section.factoryFreqWarning": "In LoRaWAN, factory preset frequencies are only supported for bands with a CFList type of frequencies",
   "console.containers.device-onboarding-form.type-form-section.manual-form-section.advanced-settings-section.register": "Register manually",
   "console.containers.device-onboarding-form.type-form-section.manual-form-section.advanced-settings-section.macSettingsError": "There was an error and the default MAC settings for the <code>{freqPlan}</code> frequency plan could not be loaded",
   "console.containers.device-onboarding-form.type-form-section.manual-form-section.advanced-settings-section.fpNotFoundError": "The LoRaWAN version <code>{lorawanVersion}</code> does not support the <code>{freqPlan}</code> frequency plan. Please choose a different MAC version or frequency plan.",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/335


#### Changes
<!-- What are the changes made in this pull request? -->

- Factory preset frequencies may now be provided for fixed channel plans bands.
  - Semantically, the frequencies are interpreted as the uplink frequencies enabled at boot time in these bands.
- In bands with variable channel plans, factory preset frequencies are now validated to be within a sub band.
- The channel masks that we generate for LoRaWAN 1.0 and 1.0.1 end devices are now valid when evaluated individually.
  - Starting with LoRaWAN 1.0.2, `LinkADRReq` MAC commands are meant to be evaluated in atomic blocks - you have to accept all of the commands or reject all of the commands. This is not the case in LoRaWAN 1.0 and 1.0.1.
  - Our generator generates a `Cntl=7` command which disables all of the channels, then a `Cntl=n` command that enables an individual FSB. This is space efficient - it saves about 15 bytes per downlink which does matter at high SF.
  - Unfortunately the individual `Cntl=7` command that disables all of the channels is interpreted by the end device as being invalid (since when you interpret it as a singular command, it tries to mute the end device).
  - We're more friendly to such devices now - specifically we will now enable the individual FSBs that we do use, then disable the remaining FSBs. Since we start with the enabled channels, all of the intermediary states through which the end device goes while enabling the channels are valid (you always have _some_ channels enabled).

#### Testing

<!-- How did you verify that this change works? -->

Unit testing. 

I don't have a physical device with me at the moment, but one of our The Things Uno US915 variants can be used to test this change actually - the initial batches come with a 1.0.1 firmware, which shows the same behavior (reject the `Cntl=7`).

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. LoRaWAN 1.0 and 1.0.1 end device would previously reject these commands like there is no tomorrow anyway.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer please review all of the backend changes.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
