### PR TITLE
Fix MAC data download

### DIFF
--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -38,7 +38,7 @@ import Require from '@console/lib/components/require'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import { composeDataUri, downloadDataUriAsFile } from '@ttn-lw/lib/data-uri'
-import { selectJsConfig, selectStackConfig } from '@ttn-lw/lib/selectors/env'
+import { selectNsConfig, selectStackConfig } from '@ttn-lw/lib/selectors/env'
 import getHostFromUrl from '@ttn-lw/lib/host-from-url'
 
 import {
@@ -72,8 +72,8 @@ const m = defineMessages({
   noSession: 'This device has not joined the network yet',
 })
 
-const jsHost = getHostFromUrl(selectJsConfig().base_url)
-const jsEnabled = selectJsConfig().enabled
+const nsHost = getHostFromUrl(selectNsConfig().base_url)
+const nsEnabled = selectNsConfig().enabled
 
 @connect(state => {
   const appId = selectSelectedApplicationId(state)
@@ -104,16 +104,11 @@ class DeviceOverview extends React.Component {
   async onExport() {
     const {
       appId,
-      device: { ids, mac_settings, session, join_server_address },
+      device: { ids, mac_settings, session, network_server_address },
     } = this.props
 
     let result
-    if (
-      session &&
-      jsEnabled &&
-      join_server_address &&
-      getHostFromUrl(join_server_address) === jsHost
-    ) {
+    if (session && nsEnabled && getHostFromUrl(network_server_address) === nsHost) {
       try {
         result = await tts.Applications.Devices.getById(appId, ids.device_id, ['mac_state'])
 


### PR DESCRIPTION
#### Summary
This quickfix PR fixes downloading MAC data in the device overview for ABP devices.

#### Changes
<!-- What are the changes made in this pull request? -->
- Check against NS instead of JS

#### Testing

Manual.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
