### PR TITLE
Show commit hash in Console footer

### DIFF
--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -16,6 +16,7 @@
 
 import fs from 'fs'
 import path from 'path'
+import child_process from 'child_process'
 
 import webpack from 'webpack'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
@@ -30,6 +31,8 @@ import nib from 'nib'
 import pjson from '../package.json'
 
 const { version } = pjson
+const revision =
+  child_process.execSync('git rev-parse --short HEAD').toString().trim() || 'unknown revision'
 
 const {
   CONTEXT = '.',
@@ -263,6 +266,7 @@ export default {
       new webpack.EnvironmentPlugin({
         NODE_ENV,
         VERSION: version,
+        REVISION: revision,
       }),
       new webpack.DefinePlugin({
         'process.predefined.SUPPORTED_LOCALES': JSON.stringify(supportedLocales),

--- a/pkg/webui/components/footer/index.js
+++ b/pkg/webui/components/footer/index.js
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -196,22 +196,22 @@ const Footer = ({
           safe={safe}
           link={documentationLink ? `${documentationLink}/whats-new/` : undefined}
         >
-          v{process.env.VERSION}
+          v{process.env.VERSION} ({process.env.REVISION})
         </FooterSection>
         {documentationLink && (
           <FooterSection className={style.documentation} safe={safe} link={documentationLink}>
             <Message content={sharedMessages.documentation} />
           </FooterSection>
         )}
+        {statusPageLink && (
+          <FooterSection link={statusPageLink} safe={safe}>
+            <Message content={sharedMessages.statusPage} />
+          </FooterSection>
+        )}
         {supportLink && (
           <FooterSection link={supportLink} safe={safe} primary>
             <Icon icon="contact_support" textPaddedRight nudgeDown />
             <Message content={sharedMessages.getSupport} />
-          </FooterSection>
-        )}
-        {statusPageLink && (
-          <FooterSection link={statusPageLink} safe={safe} primary>
-            <Message content={sharedMessages.statusPage} />
           </FooterSection>
         )}
       </div>


### PR DESCRIPTION
#### Summary
This PR will add the commit hash to the footer in the Console.

<img width="215" alt="image" src="https://user-images.githubusercontent.com/5710611/189922912-a368f2c1-3340-40a4-98b3-467f76bfad22.png">

#### Changes
- Update webpack config to retrieve the current commit hash
- Add commit hash to footer
- Reorder the status page link and remove `primary` styling

#### Testing

Manual testing.

#### Notes for Reviewers
It's important to note that the hash only represents the git commit hash of the commit that the frontend was built on, which must not necessarily be the commit hash that the backend serving the frontend is running on. In most cases it is the same though.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
