### PR TITLE
Do not emit measurements for empty objects

### DIFF
--- a/pkg/messageprocessors/javascript/javascript.go
+++ b/pkg/messageprocessors/javascript/javascript.go
@@ -350,9 +350,12 @@ func (*host) decodeUplink(
 		if err != nil {
 			return errOutput.WithCause(err)
 		}
-		msg.NormalizedPayload = make([]*pbtypes.Struct, len(normalizedMeasurements))
-		for i, measurement := range normalizedMeasurements {
-			msg.NormalizedPayload[i] = measurement.Valid
+		msg.NormalizedPayload = make([]*pbtypes.Struct, 0, len(normalizedMeasurements))
+		for _, measurement := range normalizedMeasurements {
+			if len(measurement.Valid.GetFields()) == 0 {
+				continue
+			}
+			msg.NormalizedPayload = append(msg.NormalizedPayload, measurement.Valid)
 		}
 		msg.NormalizedPayloadWarnings = make([]string, 0, len(normalized.Warnings))
 		msg.NormalizedPayloadWarnings = append(msg.NormalizedPayloadWarnings, normalized.Warnings...)
@@ -366,9 +369,12 @@ func (*host) decodeUplink(
 		}
 		normalizedMeasurements, err := normalizedpayload.Parse(normalizedPayload)
 		if err == nil {
-			msg.NormalizedPayload = make([]*pbtypes.Struct, len(normalizedMeasurements))
-			for i, measurement := range normalizedMeasurements {
-				msg.NormalizedPayload[i] = measurement.Valid
+			msg.NormalizedPayload = make([]*pbtypes.Struct, 0, len(normalizedMeasurements))
+			for _, measurement := range normalizedMeasurements {
+				if len(measurement.Valid.GetFields()) == 0 {
+					continue
+				}
+				msg.NormalizedPayload = append(msg.NormalizedPayload, measurement.Valid)
 			}
 			msg.NormalizedPayloadWarnings = appendValidationErrors(msg.NormalizedPayloadWarnings, normalizedMeasurements)
 		}

--- a/pkg/messageprocessors/javascript/javascript_test.go
+++ b/pkg/messageprocessors/javascript/javascript_test.go
@@ -712,11 +712,7 @@ func TestDecodeUplink(t *testing.T) {
 		err := host.DecodeUplink(ctx, ids, nil, message, script)
 		a.So(err, should.BeNil)
 
-		a.So(message.NormalizedPayload, should.Resemble, []*pbtypes.Struct{
-			{
-				Fields: map[string]*pbtypes.Value{},
-			},
-		})
+		a.So(message.NormalizedPayload, should.Resemble, []*pbtypes.Struct{})
 		a.So(message.NormalizedPayloadWarnings, should.Resemble, []string{
 			"measurement 1: `air.temperature` should be equal or greater than `-273.15`",
 		})
@@ -727,9 +723,7 @@ func TestDecodeUplink(t *testing.T) {
 		for i, m := range parsedMeasurements {
 			measurements[i] = m.Measurement
 		}
-		a.So(measurements, should.Resemble, []normalizedpayload.Measurement{
-			{},
-		})
+		a.So(measurements, should.Resemble, []normalizedpayload.Measurement{})
 	}
 
 	// The Things Node example.

--- a/pkg/messageprocessors/normalizedpayload/uplink_test.go
+++ b/pkg/messageprocessors/normalizedpayload/uplink_test.go
@@ -114,6 +114,15 @@ func TestUplink(t *testing.T) {
 			},
 		},
 		{
+			name: "no fields",
+			normalizedPayload: []*pbtypes.Struct{
+				{},
+			},
+			expected: []normalizedpayload.Measurement{
+				{},
+			},
+		},
+		{
 			name: "below absolute zero",
 			normalizedPayload: []*pbtypes.Struct{
 				{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This short PR fixes the fact that empty objects (`{ }`) are detected as valid normalized payloads (since they contain no fields to contradict that claim).

#### Changes
<!-- What are the changes made in this pull request? -->

- If a measurement is empty, skip it from the rendering.


#### Testing

<!-- How did you verify that this change works? -->

UT.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This is fully experimental.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer please take a look.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
