### PR TITLE
Fix failing cypress tests and fix qr code parsing

### DIFF
--- a/cypress/integration/console/devices/onboarding/qr-scan.spec.js
+++ b/cypress/integration/console/devices/onboarding/qr-scan.spec.js
@@ -38,7 +38,7 @@ describe('Device onboarding with QR scan', () => {
     appId,
     joinEui: '0000000000000001',
     devEui: '0000000000000002',
-    cac: 'O22322',
+    cac: '22322',
   }
 
   const joinEui = device.joinEui.match(/.{1,2}/g).join(' ')

--- a/cypress/integration/console/devices/onboarding/utils.js
+++ b/cypress/integration/console/devices/onboarding/utils.js
@@ -49,7 +49,6 @@ export const composeClaimResponse = ({ joinEui, devEui, id, appId }) => ({
   device_id: id,
   dev_eui: devEui,
   join_eui: joinEui,
-  dev_addr: '2600ABCD',
 })
 
 export const composeExpectedRequest = ({ joinEui, devEui, cac, id, appId }) => ({

--- a/pkg/webui/console/lib/device-claiming-parse-qr.js
+++ b/pkg/webui/console/lib/device-claiming-parse-qr.js
@@ -19,6 +19,18 @@
 export const readDeviceQr = qrCode => {
   if (Boolean(qrCode.match(/^LW:D0:/))) {
     const parts = qrCode.split(':')
+    // The QR code, has mandatory fields (SchemaID, JoinEUI, DevEUI, ProfileID)
+    // and optional fields (OwnerToken, SerNum, Proprietary, CheckSum).
+    // The data for the optional fields is preceeded by a the first letter
+    // of the corresponding field. So when parsing we need to also split that
+    // and only include the actual field data.
+    // e.g `LW:D0:1122334455667788:AABBCCDDEEFF0011:AABB1122:OAABBCCDDEEFF:SYYWWNNNNNN:PFOOBAR:CAF2C`
+    const optionalTags = {
+      ownerToken: parts[5]?.split('O')[1],
+      serNum: parts[6]?.split('S')[1],
+      proprietary: parts[7]?.split('P')[1],
+      checkSum: parts[8]?.split('C')[1],
+    }
     return {
       formatId: 'tr005',
       schemaId: parts[1],
@@ -28,10 +40,10 @@ export const readDeviceQr = qrCode => {
         vendorID: parts[4].substring(0, 4),
         vendorProfileID: parts[4].substring(4, 8),
       },
-      ownerToken: parts[5],
-      qrCode,
+      ...optionalTags,
     }
   } else if (Boolean(qrCode.match(/^URN:DEV:LW:/))) {
+    // Good to know: draft versions are deprecated.
     const parts = qrCode.split(':')[3].split('_')
     return {
       formatId: 'tr005draft3',

--- a/pkg/webui/console/lib/device-claiming-parse-qr.js
+++ b/pkg/webui/console/lib/device-claiming-parse-qr.js
@@ -21,7 +21,7 @@ export const readDeviceQr = qrCode => {
     const parts = qrCode.split(':')
     // The QR code, has mandatory fields (SchemaID, JoinEUI, DevEUI, ProfileID)
     // and optional fields (OwnerToken, SerNum, Proprietary, CheckSum).
-    // The data for the optional fields is preceeded by a the first letter
+    // The data for the optional fields is preceded by a the first letter
     // of the corresponding field. So when parsing we need to also split that
     // and only include the actual field data.
     // e.g `LW:D0:1122334455667788:AABBCCDDEEFF0011:AABB1122:OAABBCCDDEEFF:SYYWWNNNNNN:PFOOBAR:CAF2C`


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes failing CI jobs and also fixes a bug in qr parsing found while testing.

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove unnecessary `dev_addr` from cypress tests.
- Parse the qr code according to the specs

#### Testing

<!-- How did you verify that this change works? -->

cypress

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I tested the claiming and when actually claiming the device the dev_addr was not sent, while in the cypress tests, in the mock request we were sending the dev_addr, which is why there was this error from backend:

```
{
  "code": 3,
  "message": "error:pkg/networkserver:field_value (invalid value of field `session.dev_addr`)",
  "details": [
    {
      "@type": "type.googleapis.com/ttn.lorawan.v3.ErrorDetails",
      "namespace": "pkg/networkserver",
      "name": "field_value",
      "message_format": "invalid value of field `{field}`",
      "attributes": {
        "field": "session.dev_addr"
      },
      "correlation_id": "9d64e40719354cf9b3111803d4a36d2b",
      "code": 3
    }
  ]
}
```

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
