### PR TITLE
Emit empty downlink for sticky MAC commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For details about compatibility between different releases, see the **Commitment
   - Device QR codes can now be scanned to speed up end device onboarding.
   - Claiming end devices from external Join Servers is now possible seemlessly from the same onboarding flow.
 - LoRa coding rate now defined in `DataRate` instead of `Band`.
+- The Network Server will now schedule a potentially empty downlink in order to stop end devices from sending sticky MAC commands.
 
 ### Deprecated
 

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -332,6 +332,11 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 			panic(fmt.Sprintf("invalid uplink MType: %s", up.Payload.MHdr.MType))
 		}
 	}
+	if class == ttnpb.Class_CLASS_A &&
+		mac.ContainsStickyMACCommand(dev.MacState.RecentMacCommandIdentifiers...) {
+		logger.Debug("Need downlink for sticky MAC command")
+		needsDownlink = true
+	}
 
 	pld := &ttnpb.MACPayload{
 		FHdr: &ttnpb.FHDR{

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -208,11 +208,8 @@ func appendRecentMACCommandIdentifier(
 	cids []ttnpb.MACCommandIdentifier,
 	cid ttnpb.MACCommandIdentifier,
 ) []ttnpb.MACCommandIdentifier {
-	switch cid {
-	case ttnpb.MACCommandIdentifier_CID_RX_PARAM_SETUP,
-		ttnpb.MACCommandIdentifier_CID_RX_TIMING_SETUP,
-		ttnpb.MACCommandIdentifier_CID_TX_PARAM_SETUP,
-		ttnpb.MACCommandIdentifier_CID_DL_CHANNEL:
+	switch {
+	case mac.ContainsStickyMACCommand(cid):
 		return append(cids, cid)
 	default:
 		return cids

--- a/pkg/networkserver/mac/STICKY.md
+++ b/pkg/networkserver/mac/STICKY.md
@@ -1,3 +1,4 @@
 The RxParamSetup, RxTimingSetup, TxParamSetup and DlChannel MAC commands use the sticky answer mechanism:
-After an end device receives a {Command}Req, it will piggy back the associated {Command}Ans on every subsequent uplink until a class A downlink reaches the end device. This means that we will observe {Command}Ans even in the absence of a request.
+After an end device receives a {Command}Req, it will piggy back the associated {Command}Ans on every subsequent uplink until a class A downlink reaches the end device. This means that we will observe {Command}Ans even in the absence of a request, and that we should generate a downlink in order to stop the end device from
+sending the {Command}Ans.
 We should allow this, provided the previous uplink messages did contain a {Command}Ans as well. A corollary of the sticky answer mechanism is that we should not schedule {Command}Req if an {Command}Ans was found in the last uplink received from the end device, as we cannot distinguish between a sticky answer and a real answer for the new {Command}Req.

--- a/pkg/networkserver/mac/utils.go
+++ b/pkg/networkserver/mac/utils.go
@@ -767,6 +767,29 @@ func containsMACCommandIdentifier(cid ttnpb.MACCommandIdentifier) func(...ttnpb.
 	}
 }
 
+func containsAnyMACCommandIdentifier(cids ...ttnpb.MACCommandIdentifier) func(...ttnpb.MACCommandIdentifier) bool {
+	m := make(map[ttnpb.MACCommandIdentifier]struct{}, len(cids))
+	for _, cid := range cids {
+		m[cid] = struct{}{}
+	}
+	f := func(cid ttnpb.MACCommandIdentifier) bool {
+		_, ok := m[cid]
+		return ok
+	}
+	return func(cmds ...ttnpb.MACCommandIdentifier) bool {
+		return slices.IndexFunc(cmds, f) >= 0
+	}
+}
+
+// ContainsStickyMACCommand checks if any of the provided MAC command identifiers exhibit sticky behavior.
+// See STICKY.md.
+var ContainsStickyMACCommand = containsAnyMACCommandIdentifier(
+	ttnpb.MACCommandIdentifier_CID_DL_CHANNEL,
+	ttnpb.MACCommandIdentifier_CID_RX_PARAM_SETUP,
+	ttnpb.MACCommandIdentifier_CID_RX_TIMING_SETUP,
+	ttnpb.MACCommandIdentifier_CID_TX_PARAM_SETUP,
+)
+
 func consumeMACCommandIdentifier(
 	cid ttnpb.MACCommandIdentifier,
 ) func(...ttnpb.MACCommandIdentifier) (rest []ttnpb.MACCommandIdentifier, found bool) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/Lora-net/LoRaMac-node/discussions/1350#discussioncomment-3653888

#### Changes
<!-- What are the changes made in this pull request? -->

- Generate a potentially empty downlink in order to stop end devices from repeating sticky MAC command responses.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

We're now generating an extra downlink in order to stop the end device from repeating the sticky answer. This is new behavior, but it should be in accordance with the specification.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer please review this one as well. Take a look at `pkg/networkserver/mac/STICKY.md` for some context on what I am trying to achieve here.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
