### PR TITLE
Fix Console downlink frame counter updates in LoRaWAN 1.1

### DIFF
--- a/pkg/webui/console/store/reducers/devices.js
+++ b/pkg/webui/console/store/reducers/devices.js
@@ -170,7 +170,7 @@ const devices = (state = defaultState, { type, payload, event }) => {
         // For 1.1+ end devices there are two frame counters. If `f_port` is equal to 0 - then it's the "network" frame counter,
         // otherwise it's the "application" frame counter. Currently, we display only the application counter.
         // Also, see https://github.com/TheThingsNetwork/lorawan-stack/issues/2740.
-        if (getByPath(event, 'data.payload.f_port') > 0) {
+        if (getByPath(event, 'data.payload.mac_payload.f_port') > 0) {
           const downlinkFrameCount = getByPath(event, 'data.payload.mac_payload.full_f_cnt')
           if (typeof downlinkFrameCount === 'number') {
             return mergeDerived(state, combinedDeviceId, {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the Console downlink frame counter updates coming from the events in LoRaWAN 1.1.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `data.payload.mac_payload.f_port` instead of `data.payload.f_port` in order to retrieve the frame port.

Payload example for `ns.down.data.schedule.attempt`:
<img width="428" alt="image" src="https://user-images.githubusercontent.com/36161392/190980666-42248fda-12a0-43fe-b54d-76f6e378ec05.png">


#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This is a fix for a regression - it can't be more broken than this.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
