### PR TITLE
Reorganise MAC command priorities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ For details about compatibility between different releases, see the **Commitment
 - LoRa coding rate now defined in `DataRate` instead of `Band`.
 - The Network Server will now schedule a potentially empty downlink in order to stop end devices from sending sticky MAC commands.
 - Factory preset frequencies may now be provided for bands with fixed channel plans, such as US915 or AU915. The factory preset frequencies are interpreted as the only channels which are enabled at boot time.
+- `TxParamSetupReq` MAC command priority has been increased.
+- `DevStatusReq` MAC command priority has been lowered.
 
 ### Deprecated
 
@@ -33,6 +35,7 @@ For details about compatibility between different releases, see the **Commitment
 - `--mac-settings.adr.mode.disabled`, `--mac-settings.adr.mode.dynamic` and `--mac-settings.adr.mode.static` flags of the `end-device update` command.
 - Pagination in `sessions` and `access tokens` tables in the Console.
 - `LinkADRReq` MAC command generation for LoRaWAN 1.0 and 1.0.1 end devices.
+- `LinkADRReq` no longer attempts to enable channels which have not yet been negotiated with the end device.
 
 ### Security
 

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -234,8 +234,7 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 		dev.MacState.QueuedResponses = nil
 		dev.MacState.PendingRequests = dev.MacState.PendingRequests[:0]
 
-		enqueuers := make([]func(context.Context, *ttnpb.EndDevice, uint16, uint16) mac.EnqueueState, 0, 13)
-		enqueuers = append(enqueuers,
+		enqueuers := []func(context.Context, *ttnpb.EndDevice, uint16, uint16) mac.EnqueueState{
 			mac.EnqueueDutyCycleReq,
 			func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) mac.EnqueueState {
 				return mac.EnqueueTxParamSetupReq(ctx, dev, maxDownLen, maxUpLen, phy)
@@ -258,25 +257,15 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 				return st
 			},
 			mac.EnqueueRxTimingSetupReq,
-		)
-		if dev.MacState.DeviceClass == ttnpb.Class_CLASS_B {
-			if class == ttnpb.Class_CLASS_A {
-				enqueuers = append(enqueuers,
-					mac.EnqueuePingSlotChannelReq,
-				)
-			}
-			enqueuers = append(enqueuers,
-				mac.EnqueueBeaconFreqReq,
-			)
-		}
-		enqueuers = append(enqueuers,
+			mac.EnqueueBeaconFreqReq,
+			mac.EnqueuePingSlotChannelReq,
 			mac.EnqueueDLChannelReq,
 			func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) mac.EnqueueState {
 				return mac.EnqueueADRParamSetupReq(ctx, dev, maxDownLen, maxUpLen, phy)
 			},
 			mac.EnqueueForceRejoinReq,
 			mac.EnqueueRejoinParamSetupReq,
-		)
+		}
 
 		for _, f := range enqueuers {
 			st := f(ctx, dev, maxDownLen, maxUpLen)

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -237,6 +237,9 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 		enqueuers := make([]func(context.Context, *ttnpb.EndDevice, uint16, uint16) mac.EnqueueState, 0, 13)
 		enqueuers = append(enqueuers,
 			mac.EnqueueDutyCycleReq,
+			func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) mac.EnqueueState {
+				return mac.EnqueueTxParamSetupReq(ctx, dev, maxDownLen, maxUpLen, phy)
+			},
 			mac.EnqueueRxParamSetupReq,
 			func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) mac.EnqueueState {
 				return mac.EnqueueDevStatusReq(ctx, dev, maxDownLen, maxUpLen, ns.defaultMACSettings, transmitAt)
@@ -264,13 +267,6 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 			}
 			enqueuers = append(enqueuers,
 				mac.EnqueueBeaconFreqReq,
-			)
-		}
-		if phy.TxParamSetupReqSupport {
-			enqueuers = append(enqueuers,
-				func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) mac.EnqueueState {
-					return mac.EnqueueTxParamSetupReq(ctx, dev, maxDownLen, maxUpLen, phy)
-				},
 			)
 		}
 		enqueuers = append(enqueuers,

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -240,9 +240,6 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 				return mac.EnqueueTxParamSetupReq(ctx, dev, maxDownLen, maxUpLen, phy)
 			},
 			mac.EnqueueRxParamSetupReq,
-			func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) mac.EnqueueState {
-				return mac.EnqueueDevStatusReq(ctx, dev, maxDownLen, maxUpLen, ns.defaultMACSettings, transmitAt)
-			},
 			mac.EnqueueNewChannelReq,
 			func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) mac.EnqueueState {
 				// NOTE: LinkADRReq must be enqueued after NewChannelReq.
@@ -265,6 +262,9 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 			},
 			mac.EnqueueForceRejoinReq,
 			mac.EnqueueRejoinParamSetupReq,
+			func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) mac.EnqueueState {
+				return mac.EnqueueDevStatusReq(ctx, dev, maxDownLen, maxUpLen, ns.defaultMACSettings, transmitAt)
+			},
 		}
 
 		for _, f := range enqueuers {

--- a/pkg/networkserver/mac/beacon_freq.go
+++ b/pkg/networkserver/mac/beacon_freq.go
@@ -38,9 +38,11 @@ var (
 )
 
 func DeviceNeedsBeaconFreqReq(dev *ttnpb.EndDevice) bool {
-	return !dev.GetMulticast() &&
-		dev.GetMacState().GetDeviceClass() == ttnpb.Class_CLASS_B &&
-		dev.MacState.DesiredParameters.BeaconFrequency != dev.MacState.CurrentParameters.BeaconFrequency
+	if dev.GetMulticast() || dev.GetMacState() == nil {
+		return false
+	}
+	desiredParameters, currentParameters := dev.MacState.DesiredParameters, dev.MacState.CurrentParameters
+	return desiredParameters.BeaconFrequency != currentParameters.BeaconFrequency
 }
 
 func EnqueueBeaconFreqReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) EnqueueState {

--- a/pkg/networkserver/mac/beacon_freq_test.go
+++ b/pkg/networkserver/mac/beacon_freq_test.go
@@ -77,7 +77,7 @@ func TestNeedsBeaconFreqReq(t *testing.T) {
 							DesiredParameters: conf.DesiredParameters,
 						},
 					},
-					Needs: conf.Needs && class == ttnpb.Class_CLASS_B,
+					Needs: conf.Needs,
 				},
 			)
 		}

--- a/pkg/networkserver/mac/new_channel.go
+++ b/pkg/networkserver/mac/new_channel.go
@@ -69,7 +69,7 @@ func DeviceNeedsNewChannelReq(dev *ttnpb.EndDevice) bool {
 	if dev.GetMulticast() || dev.GetMacState() == nil {
 		return false
 	}
-	if len(dev.MacState.DesiredParameters.Channels) != len(dev.MacState.CurrentParameters.Channels) {
+	if len(dev.MacState.DesiredParameters.Channels) > len(dev.MacState.CurrentParameters.Channels) {
 		return true
 	}
 	for i := range dev.MacState.DesiredParameters.Channels {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/4041
References https://github.com/TheThingsNetwork/lorawan-stack/issues/5393 (This PR fixes the channel mask loop, but the data rate index range 'bug' is still open)

#### Changes
<!-- What are the changes made in this pull request? -->

- Send `TxParamSetupReq` as early as possible.
  - The reason to do this is to ensure that the end device and the Network Server are synchronized with respect to dwell time limitations. This also enables the Network Server to use the RX1 slot in places where the usage is ambiguous.
- `BeaconFreqReq` is now sent even outside of class B operation mode, if a drift is found.
  - The condition for this command did not actually make sense - an end device needs to acquire a beacon before it switches to class B, but it cannot acquire the beacon if it listens for it on the wrong channel.
- `DevStatusReq` is now lower priority than other MAC commands.
  - The synchronization of MAC parameters (channels, data rates, frequencies) is more important than an up to date `DevStatusReq` at the beginning of a session.
- `LinkADRReq` channel mask generation now takes into account the fact that the end device may not actually have a channel available. Consider the following scenario:
  - The end device joins. It knows only the 2 default channels of AS923.
  - The NS enqueues a `NewChannelReq` and a `LinkADRReq`.
  - Before this fix, the `LinkADRReq` would attempt to enable all 8 channels of the AS923 frequency plan, even though the end device knows at most 3 channels after processing the singular `NewChannelReq`.
  - After this fix, the `LinkADRReq` attempts to enable only the 3 channels (2 known defaults + 1 from the enqueud `NewChannelReq`).
- `NewChannelReq` will no longer perpetually attempt to delete a channel.
  - This used to occur if the number of current channels was larger than the number of desired channels.
- NS flow tests have been adapted to the MAC command reordering changes.
- NS flow tests now correctly render the MAC commands attached to a downlink when the MAC version encrypts the MAC commands.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing + physical `AS923` end device tested on `staging1`.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Physical end device testing covered pretty much all of the changes:
- `TxParamSetup` is among the first downlink commands scheduled.
- The first `LinkADRReq` now correctly contains a mask that refers only to the channels which have been configured on the end device.
- `NewChannelReq` is working correctly in adding the remaining 6 channels.
- `DevStatusReq` is not enqueued among the first MAC commands anymore.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer please take a look at the changes. Let me know if you need more context somewhere, but the description above should cover everything hopefully. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
