### PR TITLE
Ensure imported downlink frame counters do not reset

### DIFF
--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -497,6 +497,9 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 					panic(fmt.Sprintf("invalid downlink MType: %s", down.Payload.MHdr.MType))
 				}
 			}
+			if dev.Session.LastNFCntDown > 0 {
+				return dev.Session.LastNFCntDown + 1
+			}
 			return 0
 		}()
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes a bug introduced two years ago in https://github.com/TheThingsNetwork/lorawan-stack/commit/10ed3aaeacc8bcf61bea11352204bbacbeb9259c . The bug causes the downlink frame counters to be reset to 0 if the first downlink transmitted by the end device is a network downlink (`FPort == 0`).

This bug has the following prerequisites:
1. Device has no recent downlinks in the current MAC state. This happens for imported devices (ABP or just OTAA with session) coming from non-v3 Network Servers.
2. The NS needs to send a network downlink to the end device.
3. No application downlink is available.

What happens is that because there are no recent downlink, the downlink frame counter generator just generates a downlink with frame counter 0, because the loop is skipped and the default return is used. This frame counter is then recorded as the last network frame counter, thus resetting the downlink frame counter completely.

#### Changes
<!-- What are the changes made in this pull request? -->

- If there are no recent downlinks, and the network frame counter is greater than 0, use the network frame counter.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This PR ensures that the downlink network frame counters generated by the Network Server always take into account the last known downlink frame counter.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer please take a look here and let me know if you need extra context. The (old) frame counter generator code is:
https://github.com/TheThingsNetwork/lorawan-stack/blob/0d917a15637ded5cd420d845042b0ccf582f3d22/pkg/networkserver/downlink.go#L476-L501
And the frame counter recording section is:
https://github.com/TheThingsNetwork/lorawan-stack/blob/0d917a15637ded5cd420d845042b0ccf582f3d22/pkg/networkserver/downlink.go#L1349-L1351

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
