### PR TITLE
Fill datarate coding rate only once

### DIFF
--- a/pkg/gatewayserver/io/udp/udp_util_test.go
+++ b/pkg/gatewayserver/io/udp/udp_util_test.go
@@ -69,6 +69,7 @@ func generatePushData(eui types.EUI64, status bool, timestamps ...time.Duration)
 						Lora: &ttnpb.LoRaDataRate{
 							SpreadingFactor: 7,
 							Bandwidth:       125000,
+							CodingRate:      band.Cr4_5,
 						},
 					},
 				},

--- a/pkg/ttnpb/udp/translation.go
+++ b/pkg/ttnpb/udp/translation.go
@@ -218,14 +218,6 @@ func convertUplink(rx RxPacket, md UpstreamMetadata) (*ttnpb.UplinkMessage, erro
 			md.GpsTime = protoTime
 		}
 	}
-
-	switch mod := up.Settings.DataRate.Modulation.(type) {
-	case *ttnpb.DataRate_Lora:
-		mod.Lora.CodingRate = rx.CodR
-	case *ttnpb.DataRate_Lrfhss:
-		mod.Lrfhss.CodingRate = rx.CodR
-	}
-
 	return up, nil
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/5715

This PR ensures that only `RxPacket.UnmarshalJSON` will fill the coding rate of the data rate. Previously both `RxPacket.UnmarshalJSON` and `convertUplink` would fulfill this function, but `convertUplink` did not take into consideration the LR-FHSS coding rate reduction.

#### Changes
<!-- What are the changes made in this pull request? -->

- Fill the data rate coding rate only on unmarshal.

#### Testing

<!-- How did you verify that this change works? -->

Updated unit tests.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This is a regression in itself.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@ysmilda please review.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
