### PR TITLE
Take into consideration sticky MAC responses on data downlink slot

### DIFF
--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -246,6 +246,9 @@ func nextDataDownlinkSlot(ctx context.Context, dev *ttnpb.EndDevice, phy *band.B
 		case len(dev.MacState.QueuedResponses) > 0:
 			logger.Debug("MAC responses enqueued, choose class A downlink slot")
 			return classA, true
+		case mac.ContainsStickyMACCommand(dev.MacState.RecentMacCommandIdentifiers...):
+			logger.Debug("Sticky MAC response received, choose class A downlink slot")
+			return classA, true
 		case mac.DeviceNeedsADRParamSetupReq(dev, phy):
 			logger.Debug("Device needs ADRParamSetupReq, choose class A downlink slot")
 			return classA, true


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/5808

#### Changes
<!-- What are the changes made in this pull request? -->

- Add switch case for sticky MAC commands downlinks. Otherwise, the NS does not take the slot into consideration (even though the downlink would be needed).


#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer please take a look.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
