### PR TITLE
Fix NewChannelReq application on existing channels

### DIFF
--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -240,7 +240,9 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 				return mac.EnqueueTxParamSetupReq(ctx, dev, maxDownLen, maxUpLen, phy)
 			},
 			mac.EnqueueRxParamSetupReq,
-			mac.EnqueueNewChannelReq,
+			func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) mac.EnqueueState {
+				return mac.EnqueueNewChannelReq(ctx, dev, maxDownLen, maxUpLen, phy)
+			},
 			func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) mac.EnqueueState {
 				// NOTE: LinkADRReq must be enqueued after NewChannelReq.
 				st, err := mac.EnqueueLinkADRReq(ctx, dev, maxDownLen, maxUpLen, phy)
@@ -256,7 +258,9 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 			mac.EnqueueRxTimingSetupReq,
 			mac.EnqueueBeaconFreqReq,
 			mac.EnqueuePingSlotChannelReq,
-			mac.EnqueueDLChannelReq,
+			func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) mac.EnqueueState {
+				return mac.EnqueueDLChannelReq(ctx, dev, maxDownLen, maxUpLen, phy)
+			},
 			func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) mac.EnqueueState {
 				return mac.EnqueueADRParamSetupReq(ctx, dev, maxDownLen, maxUpLen, phy)
 			},

--- a/pkg/networkserver/mac/dl_channel.go
+++ b/pkg/networkserver/mac/dl_channel.go
@@ -53,7 +53,12 @@ func DeviceNeedsDLChannelReqAtIndex(dev *ttnpb.EndDevice, i int) bool {
 		deviceRejectedFrequency(dev, desiredCh.DownlinkFrequency) {
 		return false
 	}
-	if DeviceNeedsNewChannelReqAtIndex(dev, i) {
+	var hasPendingChannel bool
+	iteratePendingNewChannelReq(dev, func(req *ttnpb.MACCommand_NewChannelReq) bool {
+		hasPendingChannel = req.ChannelIndex == uint32(i)
+		return !hasPendingChannel
+	})
+	if hasPendingChannel {
 		return desiredCh.DownlinkFrequency != desiredCh.UplinkFrequency
 	}
 	// NOTE: NewChannelReq may be needed, but parameters could have been rejected before.

--- a/pkg/networkserver/mac/dl_channel.go
+++ b/pkg/networkserver/mac/dl_channel.go
@@ -17,6 +17,7 @@ package mac
 import (
 	"context"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/networkserver/internal"
@@ -68,7 +69,10 @@ func DeviceNeedsDLChannelReqAtIndex(dev *ttnpb.EndDevice, i int) bool {
 	return desiredCh.DownlinkFrequency != currentParameters.Channels[i].DownlinkFrequency
 }
 
-func DeviceNeedsDLChannelReq(dev *ttnpb.EndDevice) bool {
+func DeviceNeedsDLChannelReq(dev *ttnpb.EndDevice, phy *band.Band) bool {
+	if phy.CFListType != ttnpb.CFListType_FREQUENCIES {
+		return false
+	}
 	if dev.GetMulticast() ||
 		dev.GetMacState() == nil {
 		return false
@@ -86,8 +90,10 @@ func DeviceNeedsDLChannelReq(dev *ttnpb.EndDevice) bool {
 	return false
 }
 
-func EnqueueDLChannelReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) EnqueueState {
-	if !DeviceNeedsDLChannelReq(dev) {
+func EnqueueDLChannelReq(
+	ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16, phy *band.Band,
+) EnqueueState {
+	if !DeviceNeedsDLChannelReq(dev, phy) {
 		return EnqueueState{
 			MaxDownLen: maxDownLen,
 			MaxUpLen:   maxUpLen,

--- a/pkg/networkserver/mac/dl_channel_test.go
+++ b/pkg/networkserver/mac/dl_channel_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	. "go.thethings.network/lorawan-stack/v3/pkg/networkserver/internal"
@@ -362,12 +363,13 @@ func TestDLChannelReq(t *testing.T) {
 					},
 				})
 
+				phy := &band.Band{CFListType: ttnpb.CFListType_FREQUENCIES}
 				test.RunSubtestFromContext(ctx, test.SubtestConfig{
 					Name:     "DeviceNeedsDLChannelReq",
 					Parallel: true,
 					Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
 						dev := makeDevice()
-						a.So(DeviceNeedsDLChannelReq(dev), func() func(interface{}, ...interface{}) string {
+						a.So(DeviceNeedsDLChannelReq(dev, phy), func() func(interface{}, ...interface{}) string {
 							if len(tc.Commands) > 0 {
 								return should.BeTrue
 							}
@@ -396,7 +398,7 @@ func TestDLChannelReq(t *testing.T) {
 						Parallel: true,
 						Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
 							dev := makeDevice()
-							st := EnqueueDLChannelReq(ctx, dev, cmdLen, answerLen)
+							st := EnqueueDLChannelReq(ctx, dev, cmdLen, answerLen, phy)
 							expectedDevice := makeDevice()
 							var expectedEventBuilders []events.Builder
 							for _, cmd := range cmds {

--- a/pkg/networkserver/mac/dl_channel_test.go
+++ b/pkg/networkserver/mac/dl_channel_test.go
@@ -32,6 +32,7 @@ import (
 func TestDLChannelReq(t *testing.T) {
 	for _, tc := range []struct {
 		CurrentChannels, DesiredChannels []*ttnpb.MACParameters_Channel
+		PendingRequests                  []*ttnpb.MACCommand
 		RejectedFrequencies              []uint64
 		Commands                         []*ttnpb.MACCommand_DLChannelReq
 	}{
@@ -57,6 +58,15 @@ func TestDLChannelReq(t *testing.T) {
 				{
 					UplinkFrequency:   128,
 					DownlinkFrequency: 128,
+				},
+			},
+			PendingRequests: []*ttnpb.MACCommand{
+				{
+					Payload: &ttnpb.MACCommand_NewChannelReq_{
+						NewChannelReq: &ttnpb.MACCommand_NewChannelReq{
+							ChannelIndex: 2,
+						},
+					},
 				},
 			},
 		},
@@ -87,6 +97,15 @@ func TestDLChannelReq(t *testing.T) {
 				{
 					UplinkFrequency:   128,
 					DownlinkFrequency: 128,
+				},
+			},
+			PendingRequests: []*ttnpb.MACCommand{
+				{
+					Payload: &ttnpb.MACCommand_NewChannelReq_{
+						NewChannelReq: &ttnpb.MACCommand_NewChannelReq{
+							ChannelIndex: 2,
+						},
+					},
 				},
 			},
 		},
@@ -123,6 +142,29 @@ func TestDLChannelReq(t *testing.T) {
 				{
 					UplinkFrequency:   129,
 					DownlinkFrequency: 130,
+				},
+			},
+			PendingRequests: []*ttnpb.MACCommand{
+				{
+					Payload: &ttnpb.MACCommand_NewChannelReq_{
+						NewChannelReq: &ttnpb.MACCommand_NewChannelReq{
+							ChannelIndex: 0,
+						},
+					},
+				},
+				{
+					Payload: &ttnpb.MACCommand_NewChannelReq_{
+						NewChannelReq: &ttnpb.MACCommand_NewChannelReq{
+							ChannelIndex: 1,
+						},
+					},
+				},
+				{
+					Payload: &ttnpb.MACCommand_NewChannelReq_{
+						NewChannelReq: &ttnpb.MACCommand_NewChannelReq{
+							ChannelIndex: 3,
+						},
+					},
 				},
 			},
 			Commands: []*ttnpb.MACCommand_DLChannelReq{
@@ -171,6 +213,29 @@ func TestDLChannelReq(t *testing.T) {
 					DownlinkFrequency: 130,
 				},
 			},
+			PendingRequests: []*ttnpb.MACCommand{
+				{
+					Payload: &ttnpb.MACCommand_NewChannelReq_{
+						NewChannelReq: &ttnpb.MACCommand_NewChannelReq{
+							ChannelIndex: 0,
+						},
+					},
+				},
+				{
+					Payload: &ttnpb.MACCommand_NewChannelReq_{
+						NewChannelReq: &ttnpb.MACCommand_NewChannelReq{
+							ChannelIndex: 1,
+						},
+					},
+				},
+				{
+					Payload: &ttnpb.MACCommand_NewChannelReq_{
+						NewChannelReq: &ttnpb.MACCommand_NewChannelReq{
+							ChannelIndex: 3,
+						},
+					},
+				},
+			},
 			Commands: []*ttnpb.MACCommand_DLChannelReq{
 				{
 					ChannelIndex: 1,
@@ -206,6 +271,22 @@ func TestDLChannelReq(t *testing.T) {
 				{
 					UplinkFrequency:   130,
 					DownlinkFrequency: 131,
+				},
+			},
+			PendingRequests: []*ttnpb.MACCommand{
+				{
+					Payload: &ttnpb.MACCommand_NewChannelReq_{
+						NewChannelReq: &ttnpb.MACCommand_NewChannelReq{
+							ChannelIndex: 0,
+						},
+					},
+				},
+				{
+					Payload: &ttnpb.MACCommand_NewChannelReq_{
+						NewChannelReq: &ttnpb.MACCommand_NewChannelReq{
+							ChannelIndex: 1,
+						},
+					},
 				},
 			},
 			Commands: []*ttnpb.MACCommand_DLChannelReq{
@@ -245,6 +326,7 @@ func TestDLChannelReq(t *testing.T) {
 							DesiredParameters: &ttnpb.MACParameters{
 								Channels: tc.DesiredChannels,
 							},
+							PendingRequests:     tc.PendingRequests,
 							RejectedFrequencies: tc.RejectedFrequencies,
 							LorawanVersion:      ttnpb.MACVersion_MAC_V1_0_3,
 						},

--- a/pkg/networkserver/mac/link_adr.go
+++ b/pkg/networkserver/mac/link_adr.go
@@ -72,16 +72,12 @@ func generateLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Ban
 		currentChs[i] = ch.GetEnableUplink()
 	}
 	pendingChs := make([]bool, phy.MaxUplinkChannels)
-	for _, req := range dev.MacState.PendingRequests {
-		newChannelReq := req.GetNewChannelReq()
-		if newChannelReq == nil {
-			continue
-		}
-		idx := int(newChannelReq.ChannelIndex)
-		pendingChs[idx] = true
+	iteratePendingNewChannelReq(dev, func(req *ttnpb.MACCommand_NewChannelReq) bool {
+		pendingChs[req.ChannelIndex] = true
 		// NewChannelReq will automatically enable the channel if the frequency is not 0.
-		currentChs[idx] = newChannelReq.Frequency != 0
-	}
+		currentChs[req.ChannelIndex] = req.Frequency != 0
+		return true
+	})
 	desiredChs := make([]bool, phy.MaxUplinkChannels)
 	for i, ch := range dev.MacState.DesiredParameters.Channels {
 		isEnabled := ch.GetEnableUplink()

--- a/pkg/networkserver/mac/new_channel.go
+++ b/pkg/networkserver/mac/new_channel.go
@@ -17,6 +17,7 @@ package mac
 import (
 	"context"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -67,7 +68,10 @@ func DeviceNeedsNewChannelReqAtIndex(dev *ttnpb.EndDevice, i int) bool {
 	return false
 }
 
-func DeviceNeedsNewChannelReq(dev *ttnpb.EndDevice) bool {
+func DeviceNeedsNewChannelReq(dev *ttnpb.EndDevice, phy *band.Band) bool {
+	if phy.CFListType != ttnpb.CFListType_FREQUENCIES {
+		return false
+	}
 	if dev.GetMulticast() || dev.GetMacState() == nil {
 		return false
 	}
@@ -82,8 +86,10 @@ func DeviceNeedsNewChannelReq(dev *ttnpb.EndDevice) bool {
 	return false
 }
 
-func EnqueueNewChannelReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) EnqueueState {
-	if !DeviceNeedsNewChannelReq(dev) {
+func EnqueueNewChannelReq(
+	ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16, phy *band.Band,
+) EnqueueState {
+	if !DeviceNeedsNewChannelReq(dev, phy) {
 		return EnqueueState{
 			MaxDownLen: maxDownLen,
 			MaxUpLen:   maxUpLen,

--- a/pkg/networkserver/mac/new_channel_test.go
+++ b/pkg/networkserver/mac/new_channel_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	. "go.thethings.network/lorawan-stack/v3/pkg/networkserver/mac"
@@ -344,12 +345,13 @@ func TestNewChannelReq(t *testing.T) {
 					},
 				})
 
+				phy := &band.Band{CFListType: ttnpb.CFListType_FREQUENCIES}
 				test.RunSubtestFromContext(ctx, test.SubtestConfig{
 					Name:     "DeviceNeedsNewChannelReq",
 					Parallel: true,
 					Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
 						dev := makeDevice()
-						a.So(DeviceNeedsNewChannelReq(dev), func() func(interface{}, ...interface{}) string {
+						a.So(DeviceNeedsNewChannelReq(dev, phy), func() func(interface{}, ...interface{}) string {
 							if len(tc.Commands) > 0 {
 								return should.BeTrue
 							}
@@ -378,7 +380,7 @@ func TestNewChannelReq(t *testing.T) {
 						Parallel: true,
 						Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
 							dev := makeDevice()
-							st := EnqueueNewChannelReq(ctx, dev, cmdLen, answerLen)
+							st := EnqueueNewChannelReq(ctx, dev, cmdLen, answerLen, phy)
 							expectedDevice := makeDevice()
 							var expectedEventBuilders []events.Builder
 							for _, cmd := range cmds {

--- a/pkg/networkserver/mac/utils.go
+++ b/pkg/networkserver/mac/utils.go
@@ -811,3 +811,21 @@ func consumeMACCommandIdentifier(
 		return cmds, false
 	}
 }
+
+// iteratePendingRequests returns a functions that iterates the pending requests of the end device
+// and checks if they match the provided selector. If they match the selector, the provided function
+// is called. The function may stop the iteration by returning false.
+func iteratePendingRequests[T any](selector func(*ttnpb.MACCommand) *T) func(*ttnpb.EndDevice, func(*T) bool) {
+	f := func(dev *ttnpb.EndDevice, f func(*T) bool) {
+		for _, req := range dev.MacState.PendingRequests {
+			cmd := selector(req)
+			if cmd == nil {
+				continue
+			}
+			if !f(cmd) {
+				return
+			}
+		}
+	}
+	return f
+}

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -261,7 +261,7 @@ func nextDataDownlinkSlot(ctx context.Context, dev *ttnpb.EndDevice, phy *band.B
 		case mac.DeviceNeedsDevStatusReq(dev, defaults, rx2):
 			logger.Debug("Device needs DevStatusReq, choose class A downlink slot")
 			return classA, true
-		case mac.DeviceNeedsDLChannelReq(dev):
+		case mac.DeviceNeedsDLChannelReq(dev, phy):
 			logger.Debug("Device needs DLChannelReq, choose class A downlink slot")
 			return classA, true
 		case mac.DeviceNeedsDutyCycleReq(dev):
@@ -270,7 +270,7 @@ func nextDataDownlinkSlot(ctx context.Context, dev *ttnpb.EndDevice, phy *band.B
 		case mac.DeviceNeedsLinkADRReq(ctx, dev, phy):
 			logger.Debug("Device needs LinkADRReq, choose class A downlink slot")
 			return classA, true
-		case mac.DeviceNeedsNewChannelReq(dev):
+		case mac.DeviceNeedsNewChannelReq(dev, phy):
 			logger.Debug("Device needs NewChannelReq, choose class A downlink slot")
 			return classA, true
 		case mac.DeviceNeedsPingSlotChannelReq(dev):


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes two issues relating to `NewChannelReq` and `DlChannelReq`:
1. `NewChannelReq` sets the downlink frequency of the channel to the provided frequency by default. This happens in all applicable LoRaWAN versions (1.0.2+). Previously, we would set the downlink frequency only on the first `NewChannelReq`.
2. `NewChannelReq` and `DLChannelReq` should be used only in dynamic channel plans (i.e not US915/AU915).

<img width="785" alt="image" src="https://user-images.githubusercontent.com/36161392/192342595-300984d0-4a73-4193-b3e9-915babc6471f.png">
<img width="801" alt="image" src="https://user-images.githubusercontent.com/36161392/192342891-cb3f9787-128d-4bdf-b666-76bd7f232140.png">


#### Changes
<!-- What are the changes made in this pull request? -->

- Ensure that channel updates via `NewChannelReq` also update the downlink frequency.
- Ensure that we send `NewChannelReq`/`DLChannelReq` only in applicable bands.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This functionality is mainly tech debt. In normal production usage (so when people don't manually edit the `mac_state`), these two situations are never hit, since the channels are generated only once (so only `NewChannelReq` is used).

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer please take a look.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
