### PR TITLE
Fix QR scan flaky cypress test

### DIFF
--- a/pkg/webui/console/containers/device-onboarding-form/type-form-section/repository-form-section/device-selection/brand-select/brand-select.js
+++ b/pkg/webui/console/containers/device-onboarding-form/type-form-section/repository-form-section/device-selection/brand-select/brand-select.js
@@ -39,12 +39,8 @@ const formatOptions = (brands = []) =>
     .concat([{ value: SELECT_OTHER_OPTION, label: messages.otherOption }])
 
 const BrandSelect = props => {
-  const { appId, name, error, fetching, brands, listBrands, onChange, ...rest } = props
+  const { appId, name, error, fetching, brands, onChange, ...rest } = props
   const { formatMessage } = useIntl()
-
-  React.useEffect(() => {
-    listBrands(appId, {}, ['name', 'lora_alliance_vendor_id'])
-  }, [appId, listBrands])
 
   const options = React.useMemo(() => formatOptions(brands), [brands])
   const handleNoOptions = React.useCallback(

--- a/pkg/webui/console/containers/device-onboarding-form/type-form-section/repository-form-section/device-selection/brand-select/connect.js
+++ b/pkg/webui/console/containers/device-onboarding-form/type-form-section/repository-form-section/device-selection/brand-select/connect.js
@@ -14,8 +14,6 @@
 
 import { connect } from 'react-redux'
 
-import { listBrands } from '@console/store/actions/device-repository'
-
 import {
   selectDeviceBrands,
   selectDeviceBrandsError,
@@ -30,6 +28,6 @@ const mapStateToProps = state => ({
   fetching: selectDeviceBrandsFetching(state),
 })
 
-const mapDispatchToProps = { listBrands }
+const mapDispatchToProps = {}
 
 export default BrandSelect => connect(mapStateToProps, mapDispatchToProps)(BrandSelect)

--- a/pkg/webui/console/views/device-add/connect.js
+++ b/pkg/webui/console/views/device-add/connect.js
@@ -20,6 +20,7 @@ import { selectJsConfig } from '@ttn-lw/lib/selectors/env'
 
 import { getJoinEUIPrefixes } from '@console/store/actions/join-server'
 
+import { selectSelectedApplicationId } from '@console/store/selectors/applications'
 import {
   selectJoinEUIPrefixesFetching,
   selectJoinEUIPrefixesError,
@@ -29,6 +30,7 @@ const mapStateToProps = state => {
   const { enabled: jsEnabled } = selectJsConfig()
 
   return {
+    appId: selectSelectedApplicationId(state),
     fetching: selectJoinEUIPrefixesFetching(state) && jsEnabled,
     error: selectJoinEUIPrefixesError(state),
     jsEnabled,

--- a/pkg/webui/console/views/device-add/device-add.js
+++ b/pkg/webui/console/views/device-add/device-add.js
@@ -18,21 +18,36 @@ import { defineMessages } from 'react-intl'
 
 import PageTitle from '@ttn-lw/components/page-title'
 
+import RequireRequest from '@ttn-lw/lib/components/require-request'
+
 import DeviceOnboardingForm from '@console/containers/device-onboarding-form'
+
+import PropTypes from '@ttn-lw/lib/prop-types'
+
+import { listBrands } from '@console/store/actions/device-repository'
 
 const m = defineMessages({
   title: 'Register end device',
 })
 
-const DeviceAdd = () => (
-  <Container>
-    <Row>
-      <Col>
-        <PageTitle tall title={m.title} className="mb-cs-m" />
-        <DeviceOnboardingForm />
-      </Col>
-    </Row>
-  </Container>
-)
+const DeviceAdd = props => {
+  const { appId } = props
+  return (
+    <RequireRequest requestAction={listBrands(appId, {}, ['name', 'lora_alliance_vendor_id'])}>
+      <Container>
+        <Row>
+          <Col>
+            <PageTitle tall title={m.title} className="mb-cs-m" />
+            <DeviceOnboardingForm />
+          </Col>
+        </Row>
+      </Container>
+    </RequireRequest>
+  )
+}
+
+DeviceAdd.propTypes = {
+  appId: PropTypes.string.isRequired,
+}
 
 export default DeviceAdd

--- a/pkg/webui/lib/components/require-request.js
+++ b/pkg/webui/lib/components/require-request.js
@@ -36,7 +36,7 @@ const RequireRequest = ({
   const [fetching, error] = useRequest(requestAction)
   if (fetching) {
     return (
-      <Spinner inline center>
+      <Spinner center>
         <Message content={sharedMessages.fetching} />
       </Spinner>
     )


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

The brand was not being set because the brands had not loaded yet, this blocks rendering of the qr scan modal button if the brands selector has not been populated.

#### Changes
<!-- What are the changes made in this pull request? -->

- Wrap component in condition.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
