### PR TITLE
Fix downlink path computation for non-LoRa modulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ For details about compatibility between different releases, see the **Commitment
 - Pagination in `sessions` and `access tokens` tables in the Console.
 - `LinkADRReq` MAC command generation for LoRaWAN 1.0 and 1.0.1 end devices.
 - `LinkADRReq` no longer attempts to enable channels which have not yet been negotiated with the end device.
+- Downlink path selection for uplinks which are not LoRa modulated.
 
 ### Security
 

--- a/pkg/auth/pbkdf2/pbkdf2.go
+++ b/pkg/auth/pbkdf2/pbkdf2.go
@@ -93,8 +93,7 @@ var errKeyLength = errors.DefineInternal(
 // Validate validates a plaintext password against a hashed one.
 // The format of the hashed password should be:
 //
-//     PBKDF2$<algorithm>$<iterations>$<salt>$<key in base64>
-//
+//	PBKDF2$<algorithm>$<iterations>$<salt>$<key in base64>
 func (PBKDF2) Validate(hashed, plain string) (bool, error) {
 	parts := strings.Split(hashed, "$")
 	if len(parts) != 5 {

--- a/pkg/auth/rights/fetcher.go
+++ b/pkg/auth/rights/fetcher.go
@@ -48,11 +48,10 @@ type Fetcher interface {
 // A EntityFetcherFunc that returns all Application rights for any Application,
 // would look like this:
 //
-//    fetcher := rights.EntityFetcherFunc(func(ctx context.Context, ids *ttnpb.EntityIdentifiers) (*ttnpb.Rights, error) {
-//    	rights := ttnpb.AllApplicationRights // Instead this usually comes from an identity server or a database.
-//    	return &rights, nil
-//    })
-//
+//	fetcher := rights.EntityFetcherFunc(func(ctx context.Context, ids *ttnpb.EntityIdentifiers) (*ttnpb.Rights, error) {
+//		rights := ttnpb.AllApplicationRights // Instead this usually comes from an identity server or a database.
+//		return &rights, nil
+//	})
 type EntityFetcherFunc func(ctx context.Context, ids *ttnpb.EntityIdentifiers) (*ttnpb.Rights, error)
 
 // ApplicationRights implements the Fetcher interface.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -114,37 +114,37 @@ var DefaultOptions = []Option{
 //
 // Possible struct tags are:
 //
-// - `name:"<name>"`: Defines the name of the config flag, in the environment,
-//    on the command line and in the config files.
-// - `shorthand:"<n>"`: Defines a shorthand name for use on the command line.
-// - `description:"<description>"`: Add a description that will be printed in the
-//    command's help message.
-// - `file-only:"<true|false>"` Denotes wether or not to attempt to parse this
-//    variable from the command line and environment or only from the config file.
-//    This can be used to allow complicated types to exist in the config file
-//    but not on the command line.
+//   - `name:"<name>"`: Defines the name of the config flag, in the environment,
+//     on the command line and in the config files.
+//   - `shorthand:"<n>"`: Defines a shorthand name for use on the command line.
+//   - `description:"<description>"`: Add a description that will be printed in the
+//     command's help message.
+//   - `file-only:"<true|false>"` Denotes wether or not to attempt to parse this
+//     variable from the command line and environment or only from the config file.
+//     This can be used to allow complicated types to exist in the config file
+//     but not on the command line.
 //
 // The type of the struct fields also defines their type when parsing the config
 // file, command line arguments or environment variables.
 // Currently, the following types are supported:
 //
-// - `bool`
-// - `int`, `int8`, `int16`, `int32`, `int64`
-// - `uint`, `uint8`, `uint16`, `uint32`, `uint64`
-// - `float32`, `float64`
-// - `string`
-// - `time.Time`: Parsed according to the TimeFormat variable set in this package
-// - `time.Duration`: Parsed by `time.ParseDuration`
-// - `[]string``: Parsed by splitting on whitespace or by passing multiple flags
+//   - `bool`
+//   - `int`, `int8`, `int16`, `int32`, `int64`
+//   - `uint`, `uint8`, `uint16`, `uint32`, `uint64`
+//   - `float32`, `float64`
+//   - `string`
+//   - `time.Time`: Parsed according to the TimeFormat variable set in this package
+//   - `time.Duration`: Parsed by `time.ParseDuration`
+//   - `[]string`: Parsed by splitting on whitespace or by passing multiple flags
 //     VAR="a b c" or --var a --var b --var c
-// - `map[string]string``: Parsed by key=val pairs
+//   - `map[string]string`: Parsed by key=val pairs
 //     VAR="k=v q=r" or --var k=v --var q=r
-// - `map[string][]byte``: Parsed by key=val pairs, val must be hex
+//   - `map[string][]byte`: Parsed by key=val pairs, val must be hex
 //     VAR="k=0x01 q=0x02" or --var k=0x01 --var q=0x02
-// - `map[string][]string``: Parsed by key=val pairs where keys are repeated
+//   - `map[string][]string`: Parsed by key=val pairs where keys are repeated
 //     VAR="k=v1 k=v2 q=r" or --var k=v1 --var k=v2 --var q=r
-// - `Configurable``: Parsed by the UnmarshalConfigString method
-// - structs with fields of these types: The nested config names will be prefixed
+//   - `Configurable`: Parsed by the UnmarshalConfigString method
+//   - structs with fields of these types: The nested config names will be prefixed
 //     by the name of this struct, unless it is `name:",squash"` in which case
 //     the names are merged into the parent struct.
 func Initialize(name, envPrefix string, defaults interface{}, opts ...Option) *Manager {

--- a/pkg/identityserver/user_registry_test.go
+++ b/pkg/identityserver/user_registry_test.go
@@ -54,8 +54,8 @@ func TestValidatePasswordStrength(t *testing.T) {
 			"password1":    false, // Too common.
 			"āaaAAA123!@#": true,
 			"       1A":    true,
-			"āaa	AAA123 ": true,
-			"āaaAAA123 ": true,
+			"āaa	AAA123 ":  true,
+			"āaaAAA123 ":   true,
 		} {
 			t.Run(p, func(t *testing.T) {
 				a, ctx := test.New(t)

--- a/pkg/networkserver/downlink_test.go
+++ b/pkg/networkserver/downlink_test.go
@@ -95,7 +95,10 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 		var downlinkPaths []DownlinkPath
 		if !fixedPaths {
-			downlinkPaths = DownlinkPathsFromMetadata(ToMACStateRxMetadata(DefaultRxMetadata[:]...)...)
+			downlinkPaths = DownlinkPathsFromMetadata(
+				ToMACStateTxSettings(DefaultTxSettings),
+				ToMACStateRxMetadata(DefaultRxMetadata[:]),
+			)
 		} else {
 			for i, ids := range DefaultClassBCGatewayIdentifiers {
 				ids := ids

--- a/pkg/networkserver/grpc_asns_test.go
+++ b/pkg/networkserver/grpc_asns_test.go
@@ -45,6 +45,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				},
 			},
 		},
+		Settings:   DefaultTxSettings,
 		RxMetadata: DefaultRxMetadata[:],
 		ReceivedAt: ttnpb.ProtoTimePtr(time.Time{}),
 	}

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -735,7 +735,7 @@ macLoop:
 	}, true, nil
 }
 
-func toMACStateRxMetadata(mds ...*ttnpb.RxMetadata) []*ttnpb.MACState_UplinkMessage_RxMetadata {
+func toMACStateRxMetadata(mds []*ttnpb.RxMetadata) []*ttnpb.MACState_UplinkMessage_RxMetadata {
 	if len(mds) == 0 {
 		return nil
 	}
@@ -757,22 +757,25 @@ func toMACStateRxMetadata(mds ...*ttnpb.RxMetadata) []*ttnpb.MACState_UplinkMess
 	return recentMDs
 }
 
+func toMACStateTxSettings(settings *ttnpb.TxSettings) *ttnpb.MACState_UplinkMessage_TxSettings {
+	if settings == nil {
+		return nil
+	}
+	return &ttnpb.MACState_UplinkMessage_TxSettings{
+		DataRate: settings.DataRate,
+	}
+}
+
 func toMACStateUplinkMessages(ups ...*ttnpb.UplinkMessage) []*ttnpb.MACState_UplinkMessage {
 	if len(ups) == 0 {
 		return nil
 	}
 	recentUps := make([]*ttnpb.MACState_UplinkMessage, 0, len(ups))
 	for _, up := range ups {
-		var settings *ttnpb.MACState_UplinkMessage_TxSettings
-		if up.Settings != nil {
-			settings = &ttnpb.MACState_UplinkMessage_TxSettings{
-				DataRate: up.Settings.DataRate,
-			}
-		}
 		recentUps = append(recentUps, &ttnpb.MACState_UplinkMessage{
 			Payload:            up.Payload,
-			Settings:           settings,
-			RxMetadata:         toMACStateRxMetadata(up.RxMetadata...),
+			Settings:           toMACStateTxSettings(up.Settings),
+			RxMetadata:         toMACStateRxMetadata(up.RxMetadata),
 			ReceivedAt:         up.ReceivedAt,
 			CorrelationIds:     up.CorrelationIds,
 			DeviceChannelIndex: up.DeviceChannelIndex,

--- a/pkg/networkserver/internal/test/test.go
+++ b/pkg/networkserver/internal/test/test.go
@@ -101,6 +101,18 @@ var (
 		},
 	}
 
+	DefaultTxSettings = &ttnpb.TxSettings{
+		DataRate: &ttnpb.DataRate{
+			Modulation: &ttnpb.DataRate_Lora{
+				Lora: &ttnpb.LoRaDataRate{
+					Bandwidth:       125000,
+					SpreadingFactor: 7,
+					CodingRate:      band.Cr4_5,
+				},
+			},
+		},
+	}
+
 	DefaultRxMetadata = [...]*ttnpb.RxMetadata{
 		{
 			GatewayIds:             &ttnpb.GatewayIdentifiers{GatewayId: "gateway-test-1"},

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -63,6 +63,7 @@ const (
 var (
 	ToMACStateDownlinkMessages          = toMACStateDownlinkMessages
 	AppendRecentDownlink                = appendRecentDownlink
+	ToMACStateTxSettings                = toMACStateTxSettings
 	ToMACStateRxMetadata                = toMACStateRxMetadata
 	ToMACStateUplinkMessages            = toMACStateUplinkMessages
 	AppendRecentUplink                  = appendRecentUplink
@@ -975,7 +976,7 @@ func (env TestEnvironment) AssertScheduleDownlink(ctx context.Context, conf Down
 
 			var downlinkPaths []DownlinkPath
 			if conf.Uplink != nil {
-				downlinkPaths = DownlinkPathsFromMetadata(conf.Uplink.RxMetadata...)
+				downlinkPaths = DownlinkPathsFromMetadata(conf.Uplink.Settings, conf.Uplink.RxMetadata)
 			} else {
 				for i := range conf.FixedPaths {
 					downlinkPaths = append(downlinkPaths, DownlinkPath{

--- a/pkg/networkserver/utils_internal_test.go
+++ b/pkg/networkserver/utils_internal_test.go
@@ -57,7 +57,8 @@ func TestNextDataDownlinkSlot(t *testing.T) {
 				},
 			},
 		},
-		RxMetadata: ToMACStateRxMetadata(DefaultRxMetadata[:]...),
+		Settings:   ToMACStateTxSettings(DefaultTxSettings),
+		RxMetadata: ToMACStateRxMetadata(DefaultRxMetadata[:]),
 		ReceivedAt: ttnpb.ProtoTimePtr(beaconTime),
 	}
 	ups := []*ttnpb.MACState_UplinkMessage{up}

--- a/pkg/rpcmiddleware/validator/validator.go
+++ b/pkg/rpcmiddleware/validator/validator.go
@@ -157,9 +157,7 @@ func validateMessage(ctx context.Context, fullMethod string, msg interface{}) er
 		}
 		return nil
 
-	case interface {
-		Validate() error
-	}:
+	case interface{ Validate() error }:
 		defer trace.StartRegion(ctx, "validate without context").End()
 		if err := v.Validate(); err != nil {
 			return convertError(err)
@@ -185,9 +183,11 @@ func validateMessage(ctx context.Context, fullMethod string, msg interface{}) er
 
 // UnaryServerInterceptor returns a new unary server interceptor that validates
 // incoming messages if those incoming messages implement:
-//   (A) ValidateContext(ctx context.Context) error
-//   (B) Validate() error
-//   (C) ValidateFields(...string) error
+//
+//	(A) ValidateContext(ctx context.Context) error
+//	(B) Validate() error
+//	(C) ValidateFields(...string) error
+//
 // If a message implements both, then (A) should call (B).
 //
 // Invalid messages will be rejected with the error returned from the validator,
@@ -222,9 +222,11 @@ func (s *recvWrapper) RecvMsg(msg interface{}) error {
 
 // StreamServerInterceptor returns a new streaming server interceptor that validates
 // incoming messages if those incoming messages implement:
-//   (A) ValidateContext(ctx context.Context) error
-//   (B) Validate() error
-//   (C) ValidateFields(...string) error
+//
+//	(A) ValidateContext(ctx context.Context) error
+//	(B) Validate() error
+//	(C) ValidateFields(...string) error
+//
 // If a message implements both, then (A) should call (B).
 //
 // Invalid messages will be rejected with the error returned from the validator,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR downlink path computation for non-LoRa modulated uplinks (FSK/LR-FHSS). 

The context is as follows: when an uplink is received by multiple gateways, we need to choose through which gateway we may send a potential RX1/RX2 downlink. This selection is traditionally done by sorting the gateways by their LoRa-adjusted RSSI. LoRa-adjusted RSSI is a combination of channel RSSI and SNR. The problem is that modulations which are not LoRa (FSK and LR-FHSS for now) do not have an SNR (it is effectively either 0, or -127). This causes the paths to be sorted incorrectly since the SNR is invalid.

#### Changes
<!-- What are the changes made in this pull request? -->

- Downlink paths from non-LoRa modulated uplinks are now sorted descending by channel RSSI (which is always defined).
- Reformat all Go files with `tools/bin/mage go:fmt`.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

The path for LoRa modulated uplinks (i.e. 100% of the devices in the wild) is unchanged. Only non-LoRa modulated downlink paths are affected.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer please take a look.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
