### PR TITLE
Fix crashes after deleting organizations

### DIFF
--- a/cypress/integration/smoke/organizations/delete.js
+++ b/cypress/integration/smoke/organizations/delete.js
@@ -1,0 +1,53 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { defineSmokeTest } from '../utils'
+
+const organizationDelete = defineSmokeTest('succeeds deleting an organization', () => {
+  const user = {
+    ids: { user_id: 'org-delete-test-user' },
+    primary_email_address: 'test-user@example.com',
+    password: 'ABCDefg123!',
+    password_confirm: 'ABCDefg123!',
+    email: 'org-delete-test-user@example.com',
+  }
+  const organization = {
+    ids: { organization_id: 'org-delete-test' },
+  }
+  cy.createUser(user)
+  cy.createOrganization(organization, user.ids.user_id)
+  cy.loginConsole({ user_id: user.ids.user_id, password: user.password })
+  cy.visit(Cypress.config('consoleRootPath'))
+
+  cy.get('header').within(() => {
+    cy.findByRole('link', { name: /Organizations/ }).click()
+  })
+  cy.findByRole('rowgroup').within(() => {
+    cy.findByRole('cell', { name: organization.ids.organization_id }).click()
+  })
+  cy.findByRole('link', { name: /General settings/ }).click()
+  cy.findByRole('button', { name: /Delete organization/ }).click()
+  cy.findByTestId('modal-window').within(() => {
+    cy.findByRole('button', { name: /Delete organization/ }).click()
+  })
+
+  cy.findByTestId('full-error-view').should('not.exist')
+
+  cy.location('pathname').should('eq', `${Cypress.config('consoleRootPath')}/organizations`)
+  cy.findByRole('table').within(() => {
+    cy.findByRole('cell', { name: organization.ids.organization_id }).should('not.exist')
+  })
+})
+
+export default [organizationDelete]

--- a/cypress/integration/smoke/organizations/index.js
+++ b/cypress/integration/smoke/organizations/index.js
@@ -14,5 +14,6 @@
 
 import createTests from './create'
 import subpageTests from './subpages'
+import deleteTests from './delete'
 
-export default [...createTests, ...subpageTests]
+export default [...createTests, ...subpageTests, ...deleteTests]

--- a/pkg/webui/console/store/selectors/organizations.js
+++ b/pkg/webui/console/store/selectors/organizations.js
@@ -51,7 +51,7 @@ export const selectOrganizationError = createErrorSelector(GET_ORG_BASE)
 export const selectOrganizationCollaboratorCounts = state =>
   selectOrganizationStore(state).collaboratorCounts
 export const selectOrganizationCollaboratorCount = (state, id) =>
-  selectOrganizationCollaboratorCounts(state)[id]
+  selectOrganizationCollaboratorCounts(state)?.[id] || 0
 
 // Organizations.
 const selectOrgsIds = createPaginationIdsSelectorByEntity(ENTITY)


### PR DESCRIPTION
#### Summary
Closes https://github.com/TheThingsIndustries/lorawan-stack-support/issues/863

This PR fixes a bug leading to crashes when deleting an organization.

#### Changes
- Fix faulty selector
- Add a smoke test for deleting organizations

#### Testing

Manual and e2e.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
