### PR TITLE
Update phy version to lorawan versions mapping

### DIFF
--- a/cypress/integration/console/devices/onboarding/manual-registration.spec.js
+++ b/cypress/integration/console/devices/onboarding/manual-registration.spec.js
@@ -354,7 +354,7 @@ describe('End device manual create', () => {
           dev_eui: generateHexValue(16),
           lorawan_version: 'MAC_V1_0_4',
           frequency_plan_id: '863-870 MHz',
-          phy_version: 'PHY_V1_0',
+          phy_version: 'RP002_V1_0_0',
           app_key: generateHexValue(32),
         }
         cy.findByLabelText('Frequency plan').selectOption(device.frequency_plan_id)

--- a/pkg/webui/console/lib/device-utils.js
+++ b/pkg/webui/console/lib/device-utils.js
@@ -73,7 +73,7 @@ export const LORAWAN_VERSION_PAIRS = {
   101: [PHY_V1_0_1],
   102: [PHY_V1_0_2_REV_A, PHY_V1_0_2_REV_B],
   103: [PHY_V1_0_3_REV_A],
-  104: LORAWAN_PHY_VERSIONS,
+  104: [RP002_V1_0_0, RP002_V1_0_1, RP002_V1_0_2, RP002_V1_0_3],
   110: [PHY_V1_1_REV_A, PHY_V1_1_REV_B, RP002_V1_0_0, RP002_V1_0_1, RP002_V1_0_2, RP002_V1_0_3],
   0: LORAWAN_PHY_VERSIONS,
 }
@@ -105,7 +105,7 @@ const lwCache = {}
 /**
  * Parses string representation of the lorawan mac version to number.
  *
- * @param {string} strMacVersion - Formatted string representation fot the
+ * @param {string} strMacVersion - Formatted string representation for the
  * lorawan mac version, e.g. 1.1.0.
  * @returns {number} - Number representation of the lorawan mac version. Returns
  * 0 if provided


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5637 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add specific PHY versions for LoRaWAN Specification 1.0.4

<img width="453" alt="Screenshot 2022-09-27 at 16 57 48" src="https://user-images.githubusercontent.com/46600603/192561878-b554073c-ed98-4d83-9b3a-bf56d5dc1213.png">
<img width="448" alt="Screenshot 2022-09-27 at 16 57 40" src="https://user-images.githubusercontent.com/46600603/192561882-fd98a80f-b572-44d1-bb3a-dce455fdd656.png">

#### Testing

<!-- How did you verify that this change works? -->

Checked the frontend.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@adriansmares  @kschiffer 

There was no change  to LoRaWAN Specification 1.1.0 because in `pkg/webui/console/lib/device-utils.js` `RP001 - 1.1 Rev A` and `RP001 - 1.1 Rev B` seem to relate to `PHY_V1_1_REV_A` and `PHY_V1_1_REV_B` and not `RP001_V1_1_REV_A` and `RP001_V1_1_REV_B` is this correct?

```
export const PHY_V1_1_REV_A = {
  value: 'PHY_V1_1_REV_A',
  label: 'RP001 Regional Parameters 1.1 revision A',
}
export const PHY_V1_1_REV_B = {
  value: 'PHY_V1_1_REV_B',
  label: 'RP001 Regional Parameters 1.1 revision B',
}
```

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
