### PR TITLE
Reset Application and Join Server state in CLI reset

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -1024,6 +1024,13 @@ var (
 				device.UpdateTimestamps(jsDevice)
 			}
 
+			// Remove temporary fields (e.g. "supports_join") that were not selected by user
+			joinedPaths := ttnpb.AddFields(isPaths, ttnpb.AddFields(nsPaths, ttnpb.AddFields(asPaths, jsPaths...)...)...)
+			if diff := ttnpb.ExcludeFields(joinedPaths, paths...); len(diff) > 0 {
+				if err := device.SetFields(nil, diff...); err != nil {
+					return err
+				}
+			}
 			return io.Write(os.Stdout, config.OutputFormat, device)
 		},
 	}

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -922,7 +922,7 @@ var (
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectEndDeviceFlags)
 
-			isPaths, nsPaths, _, _ := splitEndDeviceGetPaths(paths...)
+			isPaths, nsPaths, asPaths, jsPaths := splitEndDeviceGetPaths(paths...)
 
 			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
@@ -949,23 +949,81 @@ var (
 			logger.WithField("paths", nsPaths).Debug("Reset end device to factory defaults on Network Server")
 			nsDevice, err := ttnpb.NewNsEndDeviceRegistryClient(ns).ResetFactoryDefaults(ctx, &ttnpb.ResetAndGetEndDeviceRequest{
 				EndDeviceIds: devID,
-				FieldMask:    ttnpb.FieldMask(nsPaths...),
+				FieldMask:    ttnpb.FieldMask(ttnpb.AddFields(nsPaths, "supports_join")...),
 			})
 			if err != nil {
 				return err
 			}
-			if err := device.SetFields(nsDevice, "ids.dev_addr"); err != nil {
+			if err = device.SetFields(nsDevice, "ids.dev_addr"); err != nil {
 				return err
 			}
-			if err := device.SetFields(nsDevice, ttnpb.AllowedBottomLevelFields(nsPaths, getEndDeviceFromNS)...); err != nil {
+			if err = device.SetFields(nsDevice, ttnpb.AllowedBottomLevelFields(nsPaths, getEndDeviceFromNS)...); err != nil {
 				return err
 			}
-			if device.CreatedAt == nil || (nsDevice.CreatedAt != nil && ttnpb.StdTime(nsDevice.CreatedAt).Before(*ttnpb.StdTime(device.CreatedAt))) {
-				device.CreatedAt = nsDevice.CreatedAt
+			device.UpdateTimestamps(nsDevice)
+
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
+			if err != nil {
+				return err
 			}
-			if nsDevice.UpdatedAt != nil && ttnpb.StdTime(nsDevice.UpdatedAt).After(*ttnpb.StdTime(device.UpdatedAt)) {
-				device.UpdatedAt = nsDevice.UpdatedAt
+			logger.WithField("paths", asPaths).Debug("Reset end device to factory defaults on Application Server")
+			asDevice, err := ttnpb.NewAsEndDeviceRegistryClient(as).Get(ctx, &ttnpb.GetEndDeviceRequest{
+				EndDeviceIds: devID,
+				FieldMask:    ttnpb.FieldMask(asPaths...),
+			})
+			if err != nil {
+				return err
 			}
+			var fieldsToReset []string
+			if device.SupportsJoin {
+				fieldsToReset = []string{"session", "pending_session"}
+			} else {
+				fieldsToReset = []string{"session.last_a_f_cnt_down"}
+			}
+			if err = asDevice.SetFields(nil, fieldsToReset...); err != nil {
+				return err
+			}
+			_, err = ttnpb.NewAsEndDeviceRegistryClient(as).Set(ctx, &ttnpb.SetEndDeviceRequest{
+				EndDevice: asDevice,
+				FieldMask: ttnpb.FieldMask(asPaths...),
+			})
+			if err != nil {
+				return err
+			}
+			if err := device.SetFields(asDevice, asPaths...); err != nil {
+				return err
+			}
+			device.UpdateTimestamps(asDevice)
+
+			if device.SupportsJoin {
+				js, err := api.Dial(ctx, config.JoinServerGRPCAddress)
+				if err != nil {
+					return err
+				}
+				logger.WithField("paths", jsPaths).Debug("Reset end device to factory defaults on Join Server")
+				jsDevice, err := ttnpb.NewJsEndDeviceRegistryClient(js).Get(ctx, &ttnpb.GetEndDeviceRequest{
+					EndDeviceIds: devID,
+					FieldMask:    ttnpb.FieldMask(jsPaths...),
+				})
+				if err != nil {
+					return err
+				}
+				if err = jsDevice.SetFields(nil, "last_dev_nonce", "used_dev_nonces", "last_join_nonce", "last_rj_count_0", "last_rj_count_1"); err != nil {
+					return err
+				}
+				_, err = ttnpb.NewJsEndDeviceRegistryClient(js).Set(ctx, &ttnpb.SetEndDeviceRequest{
+					EndDevice: jsDevice,
+					FieldMask: ttnpb.FieldMask(jsPaths...),
+				})
+				if err != nil {
+					return err
+				}
+				if err := device.SetFields(jsDevice, jsPaths...); err != nil {
+					return err
+				}
+				device.UpdateTimestamps(jsDevice)
+			}
+
 			return io.Write(os.Stdout, config.OutputFormat, device)
 		},
 	}

--- a/pkg/ttnpb/end_device.go
+++ b/pkg/ttnpb/end_device.go
@@ -1553,8 +1553,7 @@ func (m *EndDevice) ExtractRequestFields(dst map[string]interface{}) {
 	m.GetIds().ExtractRequestFields(dst)
 }
 
-// Utility
-
+// UpdateTimestamps sets earliest CreatedAt and latest UpdatedAt timestamps for EndDevice based on src device.
 func (d *EndDevice) UpdateTimestamps(src *EndDevice) {
 	if d.CreatedAt == nil || (src.CreatedAt != nil && StdTime(src.CreatedAt).Before(*StdTime(d.CreatedAt))) {
 		d.CreatedAt = src.CreatedAt

--- a/pkg/ttnpb/end_device.go
+++ b/pkg/ttnpb/end_device.go
@@ -1552,3 +1552,14 @@ func (m *GetEndDeviceRequest) ExtractRequestFields(dst map[string]interface{}) {
 func (m *EndDevice) ExtractRequestFields(dst map[string]interface{}) {
 	m.GetIds().ExtractRequestFields(dst)
 }
+
+// Utility
+
+func (d *EndDevice) UpdateTimestamps(src *EndDevice) {
+	if d.CreatedAt == nil || (src.CreatedAt != nil && StdTime(src.CreatedAt).Before(*StdTime(d.CreatedAt))) {
+		d.CreatedAt = src.CreatedAt
+	}
+	if d.UpdatedAt == nil || (src.UpdatedAt != nil && StdTime(src.UpdatedAt).After(*StdTime(d.UpdatedAt))) {
+		d.UpdatedAt = src.UpdatedAt
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4874

#### Changes
<!-- What are the changes made in this pull request? -->

- added `EndDevice.UpdateTimestamps()` method
- `reset` cli command now resets values for `js`/`as` servers as well

#### Testing

<!-- How did you verify that this change works? -->

Tested locally

- only necessary and requested fields are shown
![image](https://user-images.githubusercontent.com/73070465/193299729-0722a0f0-3714-48dd-ad0c-9092c956ac7c.png)

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

n/a

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- [util: Add UpdateTimestamps method to ttnpb.EndDevice](https://github.com/TheThingsNetwork/lorawan-stack/pull/5829/commits/8e6427586eacf1ece14cd306b34e8830b17d3131) makes the `EndDevice.UpdateTimestamps()` method standardised and possibly common with `lorawan-stack-migrate` instead of a proprietary [updateDeviceTimestamps()](https://github.com/TheThingsNetwork/lorawan-stack-migrate/blob/master/pkg/source/ttnv3/util.go#L49-L56)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
