### PR TITLE
Improve error handling for device onboarding

### DIFF
--- a/cypress/integration/console/devices/onboarding/repository-registration.spec.js
+++ b/cypress/integration/console/devices/onboarding/repository-registration.spec.js
@@ -269,8 +269,8 @@ describe('End device repository manual registration', () => {
 
       it('displays UI elements in place', () => {
         selectUno()
+        cy.findByLabelText('Frequency plan').should('be.visible').selectOption('EU_863_870_TTN')
 
-        cy.findByLabelText('Frequency plan').should('be.visible')
         cy.findByLabelText('JoinEUI').should('be.visible')
         cy.findByRole('button', { name: 'Confirm' }).should('be.visible').and('be.disabled')
         cy.findByRole('button', { name: 'Register end device' }).should('not.exist')

--- a/pkg/webui/console/containers/device-onboarding-form/messages.js
+++ b/pkg/webui/console/containers/device-onboarding-form/messages.js
@@ -28,6 +28,8 @@ export default defineMessages({
   changeDeviceTypeButton: 'Change input method',
   confirmedRegistration: 'This end device can be registered on the network',
   confirmedClaiming: 'This end device can be claimed',
+  cannotConfirmEui:
+    'There was an error and the JoinEUI could not be confirmed. Please try again later.',
   // Shared messages.
   classCapabilities: 'Additional LoRaWAN class capabilities',
   submitTitle: 'Register end device',

--- a/pkg/webui/console/containers/device-onboarding-form/type-form-section/repository-form-section/device-selection/brand-select/brand-select.js
+++ b/pkg/webui/console/containers/device-onboarding-form/type-form-section/repository-form-section/device-selection/brand-select/brand-select.js
@@ -74,7 +74,6 @@ BrandSelect.propTypes = {
   ),
   error: PropTypes.error,
   fetching: PropTypes.bool,
-  listBrands: PropTypes.func.isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
 }

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -516,6 +516,7 @@
   "console.containers.device-onboarding-form.messages.changeDeviceTypeButton": "Change input method",
   "console.containers.device-onboarding-form.messages.confirmedRegistration": "This end device can be registered on the network",
   "console.containers.device-onboarding-form.messages.confirmedClaiming": "This end device can be claimed",
+  "console.containers.device-onboarding-form.messages.cannotConfirmEui": "There was an error and the JoinEUI could not be confirmed. Please try again later.",
   "console.containers.device-onboarding-form.messages.classCapabilities": "Additional LoRaWAN class capabilities",
   "console.containers.device-onboarding-form.messages.submitTitle": "Register end device",
   "console.containers.device-onboarding-form.messages.afterRegistration": "After registration",


### PR DESCRIPTION
#### Summary
Small quickfix to improve how the device onboarding form handles errors when getting the claim info.

#### Changes
<!-- What are the changes made in this pull request? -->

- Catch errors when getting claiming info and display a toast
- Change the condition on when the JoinEUI field will be displayed
- Remove obsolete proptype


#### Testing

Manual testing.

#### Notes for Reviewers
Noticed this when using the new onboarding flow on claiming that hadn't set up TTJS.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
