### PR TITLE
Bunstore select end-devices constraints

### DIFF
--- a/pkg/identityserver/bunstore/entity_search.go
+++ b/pkg/identityserver/bunstore/entity_search.go
@@ -225,6 +225,17 @@ func (s *entitySearch) SearchEndDevices(
 
 	selectors = append(selectors, s.selectWithMetaFields(ctx, "end_device", req))
 
+	if v := req.DevEuiContains; v != "" {
+		selectors = append(selectors, func(q *bun.SelectQuery) *bun.SelectQuery {
+			return q.Where(ilike("dev_eui"), v)
+		})
+	}
+	if v := req.JoinEuiContains; v != "" {
+		selectors = append(selectors, func(q *bun.SelectQuery) *bun.SelectQuery {
+			return q.Where(ilike("join_eui"), v)
+		})
+	}
+
 	pbs, err := s.listEndDevicesBy(ctx, combineApply(selectors...), store.FieldMask{"ids"})
 	if err != nil {
 		return nil, err

--- a/pkg/identityserver/storetest/entity_search.go
+++ b/pkg/identityserver/storetest/entity_search.go
@@ -254,24 +254,46 @@ func (st *StoreTest) TestEntitySearch(t *T) {
 			}
 		})
 		t.Run("JoinEUI", func(t *T) {
-			a, ctx := test.New(t)
-			ids, err := s.SearchEndDevices(ctx, &ttnpb.SearchEndDevicesRequest{
-				ApplicationIds:  app1.GetIds(),
-				JoinEuiContains: "0101",
+			t.Run("Non Existent", func(t *T) {
+				a, ctx := test.New(t)
+				ids, err := s.SearchEndDevices(ctx, &ttnpb.SearchEndDevicesRequest{
+					ApplicationIds:  app1.GetIds(),
+					JoinEuiContains: "F00",
+				})
+				a.So(err, should.BeNil)
+				a.So(ids, should.HaveLength, 0)
 			})
-			if a.So(err, should.BeNil) && a.So(ids, should.NotBeNil) && a.So(ids, should.HaveLength, 1) {
-				a.So(ids[0], should.Resemble, dev1ID)
-			}
+			t.Run("Should be found", func(t *T) {
+				a, ctx := test.New(t)
+				ids, err := s.SearchEndDevices(ctx, &ttnpb.SearchEndDevicesRequest{
+					ApplicationIds:  app1.GetIds(),
+					JoinEuiContains: "0101",
+				})
+				if a.So(err, should.BeNil) && a.So(ids, should.NotBeNil) && a.So(ids, should.HaveLength, 1) {
+					a.So(ids[0], should.Resemble, dev1ID)
+				}
+			})
 		})
 		t.Run("DevEUI", func(t *T) {
-			a, ctx := test.New(t)
-			ids, err := s.SearchEndDevices(ctx, &ttnpb.SearchEndDevicesRequest{
-				ApplicationIds: app1.GetIds(),
-				DevEuiContains: "0202",
+			t.Run("Non Existent", func(t *T) {
+				a, ctx := test.New(t)
+				ids, err := s.SearchEndDevices(ctx, &ttnpb.SearchEndDevicesRequest{
+					ApplicationIds: app1.GetIds(),
+					DevEuiContains: "F00",
+				})
+				a.So(err, should.BeNil)
+				a.So(ids, should.HaveLength, 0)
 			})
-			if a.So(err, should.BeNil) && a.So(ids, should.NotBeNil) && a.So(ids, should.HaveLength, 1) {
-				a.So(ids[0], should.Resemble, dev1ID)
-			}
+			t.Run("Should be found", func(t *T) {
+				a, ctx := test.New(t)
+				ids, err := s.SearchEndDevices(ctx, &ttnpb.SearchEndDevicesRequest{
+					ApplicationIds: app1.GetIds(),
+					DevEuiContains: "0202",
+				})
+				if a.So(err, should.BeNil) && a.So(ids, should.NotBeNil) && a.So(ids, should.HaveLength, 1) {
+					a.So(ids[0], should.Resemble, dev1ID)
+				}
+			})
 		})
 		t.Run("Name", func(t *T) {
 			a, ctx := test.New(t)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5812

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `DevEui` and `JoinEui` usage on bunstore's `SearchEndDevices` method
- Add testcase to storetest


#### Testing

<!-- How did you verify that this change works? -->

Same process as described in [here](https://github.com/TheThingsNetwork/lorawan-stack/issues/5812#issuecomment-1263459048) while running bunstore locally.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This is a fix, to make it have the same behaviour as the gormstore implementation. Does/ not affect other methods

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Not adding to changelog since its changes to the bunstore, which is currently experimental.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
