### PR TITLE
Gateway EUI constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Gateway EUI is no longer unset when deleting a gateway, meaning it could be recovered if no other gateway claimed it. This requires a schema migration (`ttn-lw-stack is-db migrate`) because of the change in the database's `gateway_eui_index`.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/identityserver/gateway_registry.go
+++ b/pkg/identityserver/gateway_registry.go
@@ -625,6 +625,7 @@ func (is *IdentityServer) restoreGateway(ctx context.Context, ids *ttnpb.Gateway
 		if time.Since(*deletedAt) > is.configFromContext(ctx).Delete.Restore {
 			return errRestoreWindowExpired.New()
 		}
+		ids = ttnpb.Clone(gtw.Ids)
 		return st.RestoreGateway(ctx, ids)
 	})
 	if err != nil {

--- a/pkg/identityserver/gormstore/hooks.go
+++ b/pkg/identityserver/gormstore/hooks.go
@@ -13,10 +13,3 @@
 // limitations under the License.
 
 package store
-
-import "github.com/jinzhu/gorm"
-
-// AfterDelete releases the EUI of a Gateway after it is deleted.
-func (gtw *Gateway) AfterDelete(db *gorm.DB) error {
-	return db.Unscoped().Model(gtw).UpdateColumn("gateway_eui", nil).Error
-}

--- a/pkg/identityserver/store/migrations/20220913000000_update_gtw_eui_index.down.sql
+++ b/pkg/identityserver/store/migrations/20220913000000_update_gtw_eui_index.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX gateway_eui_index;
+CREATE UNIQUE INDEX gateway_eui_index ON gateways USING btree (gateway_eui);

--- a/pkg/identityserver/store/migrations/20220913000000_update_gtw_eui_index.up.sql
+++ b/pkg/identityserver/store/migrations/20220913000000_update_gtw_eui_index.up.sql
@@ -1,0 +1,4 @@
+-- The gateway_eui_index should be unique only amongst the non deleted gateways, otherwise it will prevent the creation
+-- of gateways with the same eui as deleted entities.
+DROP INDEX gateway_eui_index;
+CREATE UNIQUE INDEX gateway_eui_index ON gateways USING btree (gateway_eui) WHERE deleted_at IS NULL;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5615


#### Changes
<!-- What are the changes made in this pull request? -->

- Update `gateway_eui_index` to only account for non deleted gateways.
- Add more test cases regarding new gtw-eui behaviour.

#### Testing

<!-- How did you verify that this change works? -->

Manual testing and UT

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Couldn't think of any, it is a bit of an extension of what an user could do. Previously the EUI was cleared automatically but now there is a possibility of recovering but that is also not a guarantee.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
