### PR TITLE
Add support for suppressing logs for selected errors on selected gRPC methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Option to ignore logs from selected gRPC methods now supports ignoring logs for selected errors on method.
+    Examples:
+    - `--grpc.log-ignore-methods="/ttn.lorawan.v3.GsNs/HandleUplink"`: log is skipped when no error occurs.
+    - `--grpc.log-ignore-methods="/ttn.lorawan.v3.GsNs/HandleUplink:pkg/networkserver:duplicate_uplink;pkg/networkserver:device_not_found"`: log is skipped when either `pkg/networkserver:duplicate_uplink` or `pkg/networkserver:device_not_found` error occurs (but not on success).
+    - `--grpc.log-ignore-methods="/ttn.lorawan.v3.GsNs/HandleUplink:;pkg/networkserver:duplicate_uplink"`: log is skipped on success or when `pkg/networkserver:duplicate_uplink` error occurs.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/rpcmiddleware/rpclog/rpclog.go
+++ b/pkg/rpcmiddleware/rpclog/rpclog.go
@@ -118,3 +118,11 @@ func (l *ttnGrpcLogger) V(int) bool {
 func shouldSuppressError(err error) bool {
 	return errors.IsResourceExhausted(err)
 }
+
+func shouldSuppressLog(cfg methodLogConfig, err error) bool {
+	if err != nil {
+		wrapped, ok := errors.From(err)
+		return ok && cfg.shouldIgnorError(wrapped)
+	}
+	return cfg.IgnoreSuccess
+}

--- a/pkg/rpcmiddleware/rpclog/rpclog_test.go
+++ b/pkg/rpcmiddleware/rpclog/rpclog_test.go
@@ -1,0 +1,152 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpclog
+
+import (
+	"testing"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+)
+
+func TestShouldSuppressLogEvaluatesCorrectly(t *testing.T) {
+	ignoredError := errors.Define("ignored", "ignored")
+	nonIgnoredError := errors.Define("non_ignored", "non_ignored")
+	ignoredErrorKey := ignoredError.FullName()
+
+	tests := []struct {
+		inputCfg methodLogConfig
+		inputErr error
+		expected bool
+	}{
+		// test behavior when no error occurs
+		{
+			inputCfg: methodLogConfig{
+				IgnoreSuccess: true,
+				IgnoredErrors: map[string]struct{}{},
+			},
+			inputErr: nil,
+			expected: true,
+		},
+		{
+			inputCfg: methodLogConfig{
+				IgnoreSuccess: true,
+				IgnoredErrors: map[string]struct{}{
+					ignoredErrorKey: {},
+				},
+			},
+			inputErr: nil,
+			expected: true,
+		},
+		{
+			inputCfg: methodLogConfig{
+				IgnoreSuccess: false,
+				IgnoredErrors: map[string]struct{}{},
+			},
+			inputErr: nil,
+			expected: false,
+		},
+		{
+			inputCfg: methodLogConfig{
+				IgnoreSuccess: false,
+				IgnoredErrors: map[string]struct{}{
+					ignoredErrorKey: {},
+				},
+			},
+			inputErr: nil,
+			expected: false,
+		},
+		// test behavior when an error occurs that is ignored
+		{
+			inputCfg: methodLogConfig{
+				IgnoreSuccess: true,
+				IgnoredErrors: map[string]struct{}{},
+			},
+			inputErr: ignoredError,
+			expected: false,
+		},
+		{
+			inputCfg: methodLogConfig{
+				IgnoreSuccess: true,
+				IgnoredErrors: map[string]struct{}{
+					ignoredErrorKey: {},
+				},
+			},
+			inputErr: ignoredError,
+			expected: true,
+		},
+		{
+			inputCfg: methodLogConfig{
+				IgnoreSuccess: false,
+				IgnoredErrors: map[string]struct{}{},
+			},
+			inputErr: ignoredError,
+			expected: false,
+		},
+		{
+			inputCfg: methodLogConfig{
+				IgnoreSuccess: false,
+				IgnoredErrors: map[string]struct{}{
+					ignoredErrorKey: {},
+				},
+			},
+			inputErr: ignoredError,
+			expected: true,
+		},
+		// test behavior when an error occurs that is not ignored
+		{
+			inputCfg: methodLogConfig{
+				IgnoreSuccess: true,
+				IgnoredErrors: map[string]struct{}{},
+			},
+			inputErr: nonIgnoredError,
+			expected: false,
+		},
+		{
+			inputCfg: methodLogConfig{
+				IgnoreSuccess: true,
+				IgnoredErrors: map[string]struct{}{
+					ignoredErrorKey: {},
+				},
+			},
+			inputErr: nonIgnoredError,
+			expected: false,
+		},
+		{
+			inputCfg: methodLogConfig{
+				IgnoreSuccess: false,
+				IgnoredErrors: map[string]struct{}{},
+			},
+			inputErr: nonIgnoredError,
+			expected: false,
+		},
+		{
+			inputCfg: methodLogConfig{
+				IgnoreSuccess: false,
+				IgnoredErrors: map[string]struct{}{
+					ignoredErrorKey: {},
+				},
+			},
+			inputErr: nonIgnoredError,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		actual := shouldSuppressLog(test.inputCfg, test.inputErr)
+		if actual != test.expected {
+			t.Errorf("Expected %t, got %t", test.expected, actual)
+		}
+	}
+}

--- a/pkg/rpcmiddleware/rpclog/server_interceptors.go
+++ b/pkg/rpcmiddleware/rpclog/server_interceptors.go
@@ -36,11 +36,10 @@ func UnaryServerInterceptor(ctx context.Context, opts ...Option) grpc.UnaryServe
 		startTime := time.Now()
 		resp, err := handler(newCtx, req)
 
-		if err == nil {
-			if _, ok := o.ignoreMethods[info.FullMethod]; ok {
-				return resp, err
-			}
+		if cfg, ok := o.ignoreMethods[info.FullMethod]; ok && shouldSuppressLog(cfg, err) {
+			return resp, err
 		}
+
 		if shouldSuppressError(err) {
 			return resp, err
 		}
@@ -87,11 +86,10 @@ func StreamServerInterceptor(ctx context.Context, opts ...Option) grpc.StreamSer
 		startTime := time.Now()
 		err := handler(srv, wrapped)
 
-		if err == nil {
-			if _, ok := o.ignoreMethods[info.FullMethod]; ok {
-				return err
-			}
+		if cfg, ok := o.ignoreMethods[info.FullMethod]; ok && shouldSuppressLog(cfg, err) {
+			return err
 		}
+
 		if shouldSuppressError(err) {
 			return err
 		}

--- a/pkg/rpcmiddleware/rpclog/utils.go
+++ b/pkg/rpcmiddleware/rpclog/utils.go
@@ -107,3 +107,24 @@ func commit(i log.Interface, level log.Level, msg string) {
 		panic(fmt.Sprintf("rpclog: unknown log level %d", level))
 	}
 }
+
+func parseMethodLogCfg(opt string) (string, methodLogConfig) {
+	optParts := strings.SplitN(opt, ":", 2)
+	methodName := optParts[0]
+	if len(optParts) == 1 {
+		return methodName, methodLogConfig{IgnoreSuccess: true}
+	}
+	ignoredErrors := strings.Split(optParts[1], ";")
+	isSuccessIgnored := ignoredErrors[0] == ""
+	if isSuccessIgnored {
+		ignoredErrors = ignoredErrors[1:]
+	}
+	ignoredErrorSet := make(map[string]struct{}, len(ignoredErrors))
+	for _, ignoredMethodError := range ignoredErrors {
+		ignoredErrorSet[ignoredMethodError] = struct{}{}
+	}
+	return methodName, methodLogConfig{
+		IgnoreSuccess: isSuccessIgnored,
+		IgnoredErrors: ignoredErrorSet,
+	}
+}

--- a/pkg/rpcmiddleware/rpclog/utils_test.go
+++ b/pkg/rpcmiddleware/rpclog/utils_test.go
@@ -1,0 +1,88 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpclog
+
+import "testing"
+
+func TestParseMethodLogCfgParsesInputsCorrectly(t *testing.T) {
+	tests := []struct {
+		input              string
+		expectedMethodName string
+		expectedCfg        methodLogConfig
+	}{
+		{
+			input:              "/ttn.lorawan.v3.GsNs/HandleUplink",
+			expectedMethodName: "/ttn.lorawan.v3.GsNs/HandleUplink",
+			expectedCfg: methodLogConfig{
+				IgnoreSuccess: true,
+				IgnoredErrors: map[string]struct{}{},
+			},
+		},
+		{
+			input:              "/ttn.lorawan.v3.GsNs/HandleUplink:pkg/networkserver:duplicate_uplink",
+			expectedMethodName: "/ttn.lorawan.v3.GsNs/HandleUplink",
+			expectedCfg: methodLogConfig{
+				IgnoreSuccess: false,
+				IgnoredErrors: map[string]struct{}{
+					"pkg/networkserver:duplicate_uplink": {},
+				},
+			},
+		},
+		{
+			input:              "/ttn.lorawan.v3.GsNs/HandleUplink:pkg/networkserver:duplicate_uplink;pkg/networkserver:device_not_found",
+			expectedMethodName: "/ttn.lorawan.v3.GsNs/HandleUplink",
+			expectedCfg: methodLogConfig{
+				IgnoreSuccess: false,
+				IgnoredErrors: map[string]struct{}{
+					"pkg/networkserver:duplicate_uplink": {},
+					"pkg/networkserver:device_not_found": {},
+				},
+			},
+		},
+		{
+			input:              "/ttn.lorawan.v3.GsNs/HandleUplink:;pkg/networkserver:duplicate_uplink;pkg/networkserver:device_not_found",
+			expectedMethodName: "/ttn.lorawan.v3.GsNs/HandleUplink",
+			expectedCfg: methodLogConfig{
+				IgnoreSuccess: true,
+				IgnoredErrors: map[string]struct{}{
+					"pkg/networkserver:duplicate_uplink": {},
+					"pkg/networkserver:device_not_found": {},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			actualMethodName, actualCfg := parseMethodLogCfg(test.input)
+			expectedMethodName := test.expectedMethodName
+			expectedCfg := test.expectedCfg
+			if actualMethodName != expectedMethodName {
+				t.Fatalf("Expected method name to be %s, got %s", expectedMethodName, actualMethodName)
+			}
+			if actualCfg.IgnoreSuccess != expectedCfg.IgnoreSuccess {
+				t.Fatalf("Expected method log config to be %v, got %v", expectedCfg, actualCfg)
+			}
+			if len(actualCfg.IgnoredErrors) != len(expectedCfg.IgnoredErrors) {
+				t.Fatalf("Expected method log config to be %v, got %v", expectedCfg, actualCfg)
+			}
+			for err := range actualCfg.IgnoredErrors {
+				if _, ok := expectedCfg.IgnoredErrors[err]; !ok {
+					t.Fatalf("Expected method log config to be %v, got %v", expectedCfg, actualCfg)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
Added support for disabling logs for specific errors that occur on specific gRPC method.

Closes #5803.

#### Changes
- extended the `--grpc.log-ignore-methods` option to accept error names in addition to the method name as described in #5803.
- if any error occurs that matches the selected error names, do not log anything

#### Testing
- UT for the option parser
- Tested locally for the actual log filtering

##### Regressions
There are not any

#### Notes for Reviewers
...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
