### PR TITLE
Take into account frequency plan sub bands

### DIFF
--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -1741,13 +1741,13 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 				if dev.GetMacSettings() == nil || len(dev.MacSettings.FactoryPresetFrequencies) == 0 {
 					return nil
 				}
-				return withPHY(func(phy *band.Band, _ *frequencyplans.FrequencyPlan) error {
+				return withPHY(func(phy *band.Band, fp *frequencyplans.FrequencyPlan) error {
 					switch phy.CFListType {
 					case ttnpb.CFListType_FREQUENCIES:
 						// Factory preset frequencies in bands which provide frequencies as part of the CFList
 						// are interpreted as being used both for uplinks and downlinks.
 						for _, frequency := range dev.MacSettings.FactoryPresetFrequencies {
-							inSubBand := false
+							_, inSubBand := fp.FindSubBand(frequency)
 							for _, sb := range phy.SubBands {
 								if sb.MinFrequency <= frequency && frequency <= sb.MaxFrequency {
 									inSubBand = true


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://www.thethingsnetwork.org/forum/t/upgrade-to-the-things-network-v3-22-0-completed/59139/4

#### Changes
<!-- What are the changes made in this pull request? -->

- Take into account frequency plan sub bands while validation factory preset frequencies.
  - Certain frequency plans have different sub bands, in which the user provided frequencies may be valid.


#### Testing

<!-- How did you verify that this change works? -->

Local.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@ysmilda pleaase take a look.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
