### PR TITLE
Fix frequency validation in device onboarding form

### DIFF
--- a/pkg/webui/console/containers/device-onboarding-form/type-form-section/manual-form-section/validation-schema.js
+++ b/pkg/webui/console/containers/device-onboarding-form/type-form-section/manual-form-section/validation-schema.js
@@ -36,6 +36,8 @@ const factoryPresetFreqNumericTest = frequencies =>
     return true
   })
 
+const dynamicFrequencyTest = value => value === 0 || value >= 100000
+
 const advancedSettingsSchema = Yup.object({
   supports_class_b: Yup.boolean().required(sharedMessages.validateRequired),
   supports_class_c: Yup.boolean().required(sharedMessages.validateRequired),
@@ -81,13 +83,15 @@ const macSettingsSchema = Yup.object({
               factoryPresetFreqRequiredTest,
             ),
           rx2_frequency: Yup.number().min(100000, Yup.passValues(sharedMessages.validateNumberGte)),
-          beacon_frequency: Yup.number().min(
-            100000,
-            Yup.passValues(sharedMessages.validateNumberGte),
+          beacon_frequency: Yup.number().test(
+            'is-valid-freq',
+            sharedMessages.validateFreqDynamic,
+            dynamicFrequencyTest,
           ),
-          ping_slot_frequency: Yup.number().min(
-            100000,
-            Yup.passValues(sharedMessages.validateNumberGte),
+          ping_slot_frequency: Yup.number().test(
+            'is-valid-freq',
+            sharedMessages.validateFreqDynamic,
+            dynamicFrequencyTest,
           ),
           rx2_data_rate_index: Yup.number()
             .min(0, Yup.passValues(sharedMessages.validateNumberGte))

--- a/pkg/webui/lib/shared-messages.js
+++ b/pkg/webui/lib/shared-messages.js
@@ -442,6 +442,7 @@ export default defineMessages({
   validateEmail: 'An email address must use exactly one "@", one "." and use no special characters',
   validateFreqNumeric: 'All frequency values must be positive integers',
   validateFreqRequired: 'All frequency values are required. Please remove empty entries.',
+  validateFreqDynamic: '{field} must be 0 for dynamic frequencies or greater than 100000Hz',
   validateHexLength: '{field} must be a complete hex value',
   validateIdFormat: '{field} must contain only lowercase letters, numbers and dashes (-)',
   validateInt32: '{field} must be a whole number, negative or positive',

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -1490,6 +1490,7 @@
   "lib.shared-messages.validateEmail": "An email address must use exactly one \"@\", one \".\" and use no special characters",
   "lib.shared-messages.validateFreqNumeric": "All frequency values must be positive integers",
   "lib.shared-messages.validateFreqRequired": "All frequency values are required. Please remove empty entries.",
+  "lib.shared-messages.validateFreqDynamic": "{field} must be 0 for dynamic frequencies or greater than 100000Hz",
   "lib.shared-messages.validateHexLength": "{field} must be a complete hex value",
   "lib.shared-messages.validateIdFormat": "{field} must contain only lowercase letters, numbers and dashes (-)",
   "lib.shared-messages.validateInt32": "{field} must be a whole number, negative or positive",


### PR DESCRIPTION
#### Summary
Quickfix PR to fix validation for frequency fields that allow dynamic frequencies.

#### Changes
<!-- What are the changes made in this pull request? -->

- Allow zero values in dynamic frequency fields

#### Testing

Manual testing.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
