### PR TITLE
Fix Application Server panic on filter without identifiers

### DIFF
--- a/pkg/applicationserver/io/web/webhooks.go
+++ b/pkg/applicationserver/io/web/webhooks.go
@@ -395,6 +395,7 @@ func (w *webhooks) newRequest(
 	if !ok {
 		return nil, errFormatNotFound.WithAttributes("format", hook.Format)
 	}
+	deviceIDs := msg.EndDeviceIds
 	if paths := hook.FieldMask.GetPaths(); len(paths) > 0 {
 		mask := webhookUplinkMessageMask(msg)
 		included := ttnpb.IncludeFields(paths, mask)
@@ -420,8 +421,8 @@ func (w *webhooks) newRequest(
 	}
 	if hook.DownlinkApiKey != "" {
 		req.Header.Set(downlinkKeyHeader, hook.DownlinkApiKey)
-		req.Header.Set(downlinkPushHeader, w.downlinkURL(ctx, hook.Ids, msg.EndDeviceIds, "push"))
-		req.Header.Set(downlinkReplaceHeader, w.downlinkURL(ctx, hook.Ids, msg.EndDeviceIds, "replace"))
+		req.Header.Set(downlinkPushHeader, w.downlinkURL(ctx, hook.Ids, deviceIDs, "push"))
+		req.Header.Set(downlinkReplaceHeader, w.downlinkURL(ctx, hook.Ids, deviceIDs, "replace"))
 	}
 	if domain := w.domain(ctx); domain != "" {
 		req.Header.Set(domainHeader, domain)

--- a/pkg/applicationserver/io/web/webhooks.go
+++ b/pkg/applicationserver/io/web/webhooks.go
@@ -31,6 +31,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/gogoproto"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	"go.thethings.network/lorawan-stack/v3/pkg/task"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	ttnweb "go.thethings.network/lorawan-stack/v3/pkg/web"
@@ -268,23 +269,32 @@ func (w *webhooks) handleUp(ctx context.Context, msg *ttnpb.ApplicationUp) error
 		ctx := withWebhookID(ctx, hook.Ids)
 		ctx = WithCachedHealthStatus(ctx, hook.HealthStatus)
 		logger := log.FromContext(ctx).WithField("hook", hook.Ids.WebhookId)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		f := func(ctx context.Context) error {
 			req, err := w.newRequest(ctx, msg, hook)
 			if err != nil {
 				logger.WithError(err).Warn("Failed to create request")
-				return
+				return err
 			}
 			if req == nil {
-				return
+				return nil
 			}
 			logger.WithField("url", req.URL).Debug("Process message")
 			if err := w.target.Process(req); err != nil {
 				registerWebhookFailed(ctx, err)
 				logger.WithError(err).Warn("Failed to process message")
+				return err
 			}
-		}()
+			return nil
+		}
+		wg.Add(1)
+		w.server.StartTask(&task.Config{
+			Context: ctx,
+			ID:      "execute_webhook",
+			Func:    f,
+			Done:    wg.Done,
+			Restart: task.RestartNever,
+			Backoff: task.DefaultBackoffConfig,
+		})
 	}
 	wg.Wait()
 	return nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix ensures that the end device identifiers are still available after we filter out the webhook fields. Otherwise downlink header generation fails (since it needs device identifiers) and panics.

#### Changes
<!-- What are the changes made in this pull request? -->

- Execute webhooks in tasks to avoid stopping the full process.
- Save the identifiers before the field mask is applied.


#### Testing

<!-- How did you verify that this change works? -->

Local.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@happyRip please review.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
