### PR TITLE
BasicStation dutycycle alignment fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For details about compatibility between different releases, see the **Commitment
     - `--grpc.log-ignore-methods="/ttn.lorawan.v3.GsNs/HandleUplink"`: log is skipped when no error occurs.
     - `--grpc.log-ignore-methods="/ttn.lorawan.v3.GsNs/HandleUplink:pkg/networkserver:duplicate_uplink;pkg/networkserver:device_not_found"`: log is skipped when either `pkg/networkserver:duplicate_uplink` or `pkg/networkserver:device_not_found` error occurs (but not on success).
     - `--grpc.log-ignore-methods="/ttn.lorawan.v3.GsNs/HandleUplink:;pkg/networkserver:duplicate_uplink"`: log is skipped on success or when `pkg/networkserver:duplicate_uplink` error occurs.
+- The Gateway Server now takes into consideration the extra dutycycle checks present in the LoRa Basics Station forwarder. Previously the Gateway Server may accept the scheduling of downlinks which the packet forwarder would silently drop.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ For details about compatibility between different releases, see the **Commitment
     - `--grpc.log-ignore-methods="/ttn.lorawan.v3.GsNs/HandleUplink"`: log is skipped when no error occurs.
     - `--grpc.log-ignore-methods="/ttn.lorawan.v3.GsNs/HandleUplink:pkg/networkserver:duplicate_uplink;pkg/networkserver:device_not_found"`: log is skipped when either `pkg/networkserver:duplicate_uplink` or `pkg/networkserver:device_not_found` error occurs (but not on success).
     - `--grpc.log-ignore-methods="/ttn.lorawan.v3.GsNs/HandleUplink:;pkg/networkserver:duplicate_uplink"`: log is skipped on success or when `pkg/networkserver:duplicate_uplink` error occurs.
-- The Gateway Server now takes into consideration the extra dutycycle checks present in the LoRa Basics Station forwarder. Previously the Gateway Server may accept the scheduling of downlinks which the packet forwarder would silently drop.
+- The Gateway Server now takes into consideration the extra duty cycle checks present in the LoRa Basics Station forwarder. Previously the Gateway Server may accept the scheduling of downlinks which the packet forwarder would silently drop.
+  - Note that in some rare cases in which the LoRa Basics Station duty cycle is stricter than the windowed approach used by The Things Stack, the scheduling will fail and this will be visible via `ns.down.data.schedule.fail` events. Note that this is actually a positive outcome - it allows the Network Server to schedule the downlink via another gateway, while previously the downlink would be scheduled but get silently dropped on the gateway.
 
 ### Deprecated
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -4859,6 +4859,15 @@
       "file": "io.go"
     }
   },
+  "error:pkg/gatewayserver/scheduling:blocked": {
+    "translations": {
+      "en": "sub band is blocked for `{duration}`"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/scheduling",
+      "file": "sub_band.go"
+    }
+  },
   "error:pkg/gatewayserver/scheduling:conflict": {
     "translations": {
       "en": "scheduling conflict"

--- a/pkg/gatewayserver/io/grpc/grpc.go
+++ b/pkg/gatewayserver/io/grpc/grpc.go
@@ -26,6 +26,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
+	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/scheduling"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmetadata"
@@ -74,8 +75,9 @@ func New(server io.Server, opts ...Option) ttnpb.GtwGsServer {
 	return i
 }
 
-func (*impl) Protocol() string            { return "grpc" }
-func (*impl) SupportsDownlinkClaim() bool { return false }
+func (*impl) Protocol() string                          { return "grpc" }
+func (*impl) SupportsDownlinkClaim() bool               { return false }
+func (*impl) DutyCycleStyle() scheduling.DutyCycleStyle { return scheduling.DefaultDutyCycleStyle }
 
 var errConnect = errors.Define("connect", "failed to connect gateway `{gateway_uid}`")
 

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -48,6 +48,8 @@ type Frontend interface {
 	Protocol() string
 	// SupportsDownlinkClaim returns true if the frontend can itself claim downlinks.
 	SupportsDownlinkClaim() bool
+	// DutyCycleStyle returns the duty cycle style used by the frontend.
+	DutyCycleStyle() scheduling.DutyCycleStyle
 }
 
 // Server represents the Gateway Server to gateway frontends.
@@ -170,7 +172,9 @@ func NewConnection(
 	}
 
 	ctx, cancelCtx := errorcontext.New(ctx)
-	scheduler, err := scheduling.NewScheduler(ctx, gatewayFPs, enforceDutyCycle, scheduleAnytimeDelay, nil)
+	scheduler, err := scheduling.NewScheduler(
+		ctx, gatewayFPs, enforceDutyCycle, frontend.DutyCycleStyle(), scheduleAnytimeDelay, nil,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gatewayserver/io/mock/frontend.go
+++ b/pkg/gatewayserver/io/mock/frontend.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
+	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/scheduling"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
@@ -30,8 +31,9 @@ type Frontend struct {
 	Down   chan *ttnpb.DownlinkMessage
 }
 
-func (*Frontend) Protocol() string            { return "mock" }
-func (*Frontend) SupportsDownlinkClaim() bool { return true }
+func (*Frontend) Protocol() string                          { return "mock" }
+func (*Frontend) SupportsDownlinkClaim() bool               { return true }
+func (*Frontend) DutyCycleStyle() scheduling.DutyCycleStyle { return scheduling.DefaultDutyCycleStyle }
 
 // ConnectFrontend connects a new mock front-end to the given server.
 // The gateway time starts at Unix epoch.

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -29,6 +29,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
+	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/scheduling"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/mqtt"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
@@ -67,6 +68,9 @@ type connection struct {
 
 func (*connection) Protocol() string            { return "mqtt" }
 func (*connection) SupportsDownlinkClaim() bool { return false }
+func (*connection) DutyCycleStyle() scheduling.DutyCycleStyle {
+	return scheduling.DefaultDutyCycleStyle
+}
 
 func setupConnection(ctx context.Context, mqttConn mqttnet.Conn, format Format, server io.Server) error {
 	c := &connection{

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -48,8 +48,9 @@ type srv struct {
 	limitLogs ratelimit.Interface
 }
 
-func (*srv) Protocol() string            { return "udp" }
-func (*srv) SupportsDownlinkClaim() bool { return true }
+func (*srv) Protocol() string                          { return "udp" }
+func (*srv) SupportsDownlinkClaim() bool               { return true }
+func (*srv) DutyCycleStyle() scheduling.DutyCycleStyle { return scheduling.DefaultDutyCycleStyle }
 
 var (
 	limitLogsConfig      = config.RateLimitingProfile{MaxPerMin: 1}

--- a/pkg/gatewayserver/io/ws/ws.go
+++ b/pkg/gatewayserver/io/ws/ws.go
@@ -32,6 +32,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
+	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/scheduling"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/random"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
@@ -57,8 +58,11 @@ type srv struct {
 	formatter Formatter
 }
 
-func (s *srv) Protocol() string            { return "ws" }
-func (s *srv) SupportsDownlinkClaim() bool { return false }
+func (*srv) Protocol() string            { return "ws" }
+func (*srv) SupportsDownlinkClaim() bool { return false }
+func (*srv) DutyCycleStyle() scheduling.DutyCycleStyle {
+	return scheduling.DutyCycleStyleBlockingWindow
+}
 
 // New creates a new WebSocket frontend.
 func New(ctx context.Context, server io.Server, formatter Formatter, cfg Config) (*web.Server, error) {

--- a/pkg/gatewayserver/io/ws/ws_test.go
+++ b/pkg/gatewayserver/io/ws/ws_test.go
@@ -822,8 +822,9 @@ func TestTraffic(t *testing.T) {
 		t.Fatal("Connection timeout")
 	}
 
+	now := time.Now().UTC()
 	clock := mockClock{}
-	clock.Start(ctx, time.Now().UTC())
+	clock.Start(ctx, now)
 
 	for _, tc := range []struct {
 		Name                    string
@@ -1085,7 +1086,7 @@ func TestTraffic(t *testing.T) {
 						},
 						Rx1Frequency:    868100000,
 						FrequencyPlanId: test.EUFrequencyPlanID,
-						AbsoluteTime:    ttnpb.ProtoTimePtr(time.Unix(0x424242424, 0x42424242)),
+						AbsoluteTime:    ttnpb.ProtoTimePtr(now.Add(30 * time.Second)),
 					},
 				},
 				CorrelationIds: []string{"correlation1", "correlation2"},
@@ -1100,7 +1101,7 @@ func TestTraffic(t *testing.T) {
 				AbsoluteTimeDownlinkMessage: &lbslns.AbsoluteTimeDownlinkMessage{
 					Freq:    868100000,
 					DR:      5,
-					GPSTime: lbslns.TimeToGPSTime(time.Unix(0x424242424, 0x42424242)),
+					GPSTime: lbslns.TimeToGPSTime(now.Add(30 * time.Second)),
 				},
 			},
 		},

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -79,7 +79,14 @@ var (
 
 // NewScheduler instantiates a new Scheduler for the given frequency plan.
 // If no time source is specified, the system time is used.
-func NewScheduler(ctx context.Context, fps map[string]*frequencyplans.FrequencyPlan, enforceDutyCycle bool, scheduleAnytimeDelay *time.Duration, timeSource TimeSource) (*Scheduler, error) {
+func NewScheduler(
+	ctx context.Context,
+	fps map[string]*frequencyplans.FrequencyPlan,
+	enforceDutyCycle bool,
+	dutyCycleStyle DutyCycleStyle,
+	scheduleAnytimeDelay *time.Duration,
+	timeSource TimeSource,
+) (*Scheduler, error) {
 	logger := log.FromContext(ctx)
 	if timeSource == nil {
 		timeSource = SystemTimeSource
@@ -123,7 +130,7 @@ func NewScheduler(ctx context.Context, fps map[string]*frequencyplans.FrequencyP
 						MaxFrequency: subBand.MaxFrequency,
 						DutyCycle:    subBand.DutyCycle,
 					}
-					sb := NewSubBand(params, s.clock, nil)
+					sb := NewSubBand(params, s.clock, nil, dutyCycleStyle)
 					var isIdentical bool
 					for _, subBand := range s.subBands {
 						if subBand.IsIdentical(sb) {
@@ -149,7 +156,7 @@ func NewScheduler(ctx context.Context, fps map[string]*frequencyplans.FrequencyP
 						MaxFrequency: subBand.MaxFrequency,
 						DutyCycle:    subBand.DutyCycle,
 					}
-					sb := NewSubBand(params, s.clock, nil)
+					sb := NewSubBand(params, s.clock, nil, dutyCycleStyle)
 					var isIdentical bool
 					for _, subBand := range s.subBands {
 						if subBand.IsIdentical(sb) {
@@ -171,7 +178,7 @@ func NewScheduler(ctx context.Context, fps map[string]*frequencyplans.FrequencyP
 			MinFrequency: 0,
 			MaxFrequency: math.MaxUint64,
 		}
-		sb := NewSubBand(noDutyCycleParams, s.clock, nil)
+		sb := NewSubBand(noDutyCycleParams, s.clock, nil, dutyCycleStyle)
 		s.subBands = append(s.subBands, sb)
 	}
 	go s.gc(ctx)

--- a/pkg/gatewayserver/scheduling/scheduler_test.go
+++ b/pkg/gatewayserver/scheduling/scheduler_test.go
@@ -47,7 +47,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 	timeSource := &mockTimeSource{
 		Time: time.Unix(0, 0),
 	}
-	scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
+	scheduler, err := scheduling.NewScheduler(ctx, fps, true, scheduling.DefaultDutyCycleStyle, nil, timeSource)
 	a.So(err, should.BeNil)
 
 	for i, tc := range []struct {
@@ -365,7 +365,7 @@ func TestScheduleAtWithFrequencyPlanDutyCycle(t *testing.T) {
 	timeSource := &mockTimeSource{
 		Time: time.Unix(0, 0),
 	}
-	scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
+	scheduler, err := scheduling.NewScheduler(ctx, fps, true, scheduling.DefaultDutyCycleStyle, nil, timeSource)
 	a.So(err, should.BeNil)
 
 	for i, tc := range []struct {
@@ -447,7 +447,7 @@ func TestScheduleAnytime(t *testing.T) {
 			Duration:  durationPtr(2 * time.Second),
 		},
 	}}
-	scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, nil)
+	scheduler, err := scheduling.NewScheduler(ctx, fps, true, scheduling.DefaultDutyCycleStyle, nil, nil)
 	a.So(err, should.BeNil)
 	scheduler.SyncWithGatewayAbsolute(0, time.Now(), time.Unix(0, 0))
 
@@ -584,7 +584,9 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		timeSource := &mockTimeSource{
 			Time: time.Now(),
 		}
-		scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
+		scheduler, err := scheduling.NewScheduler(
+			ctx, fps, true, scheduling.DefaultDutyCycleStyle, nil, timeSource,
+		)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		em, _, err := scheduler.ScheduleAnytime(ctx, scheduling.Options{
@@ -602,7 +604,9 @@ func TestScheduleAnytimeShort(t *testing.T) {
 			Time: time.Now(),
 		}
 		scheduleAnytimeDelay := time.Second
-		scheduler, err := scheduling.NewScheduler(ctx, fps, true, &scheduleAnytimeDelay, timeSource)
+		scheduler, err := scheduling.NewScheduler(
+			ctx, fps, true, scheduling.DefaultDutyCycleStyle, &scheduleAnytimeDelay, timeSource,
+		)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		em, _, err := scheduler.ScheduleAnytime(ctx, scheduling.Options{
@@ -620,7 +624,9 @@ func TestScheduleAnytimeShort(t *testing.T) {
 			Time: time.Now(),
 		}
 		scheduleAnytimeDelay := time.Millisecond
-		scheduler, err := scheduling.NewScheduler(ctx, fps, true, &scheduleAnytimeDelay, timeSource)
+		scheduler, err := scheduling.NewScheduler(
+			ctx, fps, true, scheduling.DefaultDutyCycleStyle, &scheduleAnytimeDelay, timeSource,
+		)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		em, _, err := scheduler.ScheduleAnytime(ctx, scheduling.Options{
@@ -638,7 +644,9 @@ func TestScheduleAnytimeShort(t *testing.T) {
 			Time: time.Now(),
 		}
 		scheduleAnytimeDelay := time.Duration(0)
-		scheduler, err := scheduling.NewScheduler(ctx, fps, true, &scheduleAnytimeDelay, timeSource)
+		scheduler, err := scheduling.NewScheduler(
+			ctx, fps, true, scheduling.DefaultDutyCycleStyle, &scheduleAnytimeDelay, timeSource,
+		)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		em, _, err := scheduler.ScheduleAnytime(ctx, scheduling.Options{
@@ -655,7 +663,9 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		timeSource := &mockTimeSource{
 			Time: time.Now(),
 		}
-		scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
+		scheduler, err := scheduling.NewScheduler(
+			ctx, fps, true, scheduling.DefaultDutyCycleStyle, nil, timeSource,
+		)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		rtts := &mockRTTs{
@@ -677,7 +687,9 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		timeSource := &mockTimeSource{
 			Time: time.Now(),
 		}
-		scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
+		scheduler, err := scheduling.NewScheduler(
+			ctx, fps, true, scheduling.DefaultDutyCycleStyle, nil, timeSource,
+		)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		em, _, err := scheduler.ScheduleAnytime(ctx, scheduling.Options{
@@ -694,7 +706,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		timeSource := &mockTimeSource{
 			Time: time.Now(),
 		}
-		scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
+		scheduler, err := scheduling.NewScheduler(ctx, fps, true, scheduling.DefaultDutyCycleStyle, nil, timeSource)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		rtts := &mockRTTs{
@@ -716,7 +728,9 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		timeSource := &mockTimeSource{
 			Time: time.Now(),
 		}
-		scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
+		scheduler, err := scheduling.NewScheduler(
+			ctx, fps, true, scheduling.DefaultDutyCycleStyle, nil, timeSource,
+		)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		rtts := &mockRTTs{
@@ -751,7 +765,7 @@ func TestScheduleAnytimeClassC(t *testing.T) {
 	timeSource := &mockTimeSource{
 		Time: time.Unix(0, 0),
 	}
-	scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
+	scheduler, err := scheduling.NewScheduler(ctx, fps, true, scheduling.DefaultDutyCycleStyle, nil, timeSource)
 	a.So(err, should.BeNil)
 	scheduler.Sync(0, timeSource.Time)
 
@@ -993,7 +1007,9 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 			timeSource := &mockTimeSource{
 				Time: time.Unix(0, 0),
 			}
-			scheduler, err := scheduling.NewScheduler(ctx, tc.FrequencyPlans, true, nil, timeSource)
+			scheduler, err := scheduling.NewScheduler(
+				ctx, tc.FrequencyPlans, true, scheduling.DefaultDutyCycleStyle, nil, timeSource,
+			)
 			if err != nil {
 				if tc.ErrorAssertion == nil || !a.So(tc.ErrorAssertion(err), should.BeTrue) {
 					t.Fatalf("Unexpected error: %v", err)
@@ -1047,7 +1063,7 @@ func TestSchedulingWithMultipleFrequencyPlans(t *testing.T) {
 	timeSource := &mockTimeSource{
 		Time: time.Unix(0, 0),
 	}
-	scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
+	scheduler, err := scheduling.NewScheduler(ctx, fps, true, scheduling.DefaultDutyCycleStyle, nil, timeSource)
 	a.So(err, should.BeNil)
 	scheduler.Sync(0, timeSource.Time)
 
@@ -1139,7 +1155,9 @@ func TestScheduleSyncViaUplinkToken(t *testing.T) {
 		timeSource := &mockTimeSource{
 			Time: time.Now(),
 		}
-		scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
+		scheduler, err := scheduling.NewScheduler(
+			ctx, fps, true, scheduling.DefaultDutyCycleStyle, nil, timeSource,
+		)
 		a.So(err, should.BeNil)
 		_, _, err = scheduler.ScheduleAt(ctx, scheduling.Options{
 			PayloadSize: 10,
@@ -1165,7 +1183,9 @@ func TestScheduleSyncViaUplinkToken(t *testing.T) {
 		timeSource := &mockTimeSource{
 			Time: time.Unix(11, 0),
 		}
-		scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
+		scheduler, err := scheduling.NewScheduler(
+			ctx, fps, true, scheduling.DefaultDutyCycleStyle, nil, timeSource,
+		)
 		a.So(err, should.BeNil)
 		t := time.Unix(10, 0)
 		_, _, err = scheduler.ScheduleAt(ctx, scheduling.Options{
@@ -1198,7 +1218,9 @@ func TestScheduleSyncViaUplinkToken(t *testing.T) {
 		timeSource := &mockTimeSource{
 			Time: time.Unix(11, 0),
 		}
-		scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
+		scheduler, err := scheduling.NewScheduler(
+			ctx, fps, true, scheduling.DefaultDutyCycleStyle, nil, timeSource,
+		)
 		a.So(err, should.BeNil)
 		t := time.Unix(10, 0)
 		_, _, err = scheduler.ScheduleAt(ctx, scheduling.Options{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5844 

#### Changes
<!-- What are the changes made in this pull request? -->

- Introduce the concept of dutycycle styles for the Gateway Server sub band scheduler.
  - We have two styles - window (what we have been using so far) and blocking window.
  - The blocking window style adds an additional check that ensures that BasicStation-based forwarders do not reject downlinks, since in BasicStation duty cycle is enforced by 'blocking' the sub band for the inverse duration of the duty cycle. What this 'inverse' means in plain words is that a 1 second transmission keeps a 1% duty cycle sub band blocked for 100 seconds, or for 10 seconds in a sub band with 10% duty cycle.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing + `staging1` testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Users will now observe that we do not schedule downlinks on their duty-cycled Basic Station gateways which is an event visible in the Console. This may seem to them as a regression, but note that Basic Station would previously just silently drop the downlink. At least now the Network Server has the chance to try another gateway.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
