### PR TITLE
Fix cli version caching issues

### DIFF
--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -56,7 +56,7 @@ var (
 	inputDecoder io.Decoder
 
 	versionUpdate       chan pkgversion.Update
-	versionCheckTimeout = 500 * time.Millisecond
+	versionCheckTimeout = time.Second
 
 	// Root command is the entrypoint of the program
 	Root = &cobra.Command{

--- a/cmd/ttn-lw-stack/commands/root.go
+++ b/cmd/ttn-lw-stack/commands/root.go
@@ -46,7 +46,7 @@ var (
 	config = new(Config)
 
 	versionUpdate       chan pkgversion.Update
-	versionCheckTimeout = 500 * time.Millisecond
+	versionCheckTimeout = time.Second
 
 	// Root command is the entrypoint of the program.
 	Root = &cobra.Command{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5735 

#### Changes
<!-- What are the changes made in this pull request? -->

- Check if cached version matches current version

#### Testing

<!-- How did you verify that this change works? -->

Tested locally:
1. checkout `v3.21` → new version `v3.22.0` available
1. checkout `v3.22` → new version `v3.22.0` available
1. checkout `v3.21` → new version `v3.22.0` available
1. checkout `fix/5735-version-caching` → no new version warn

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

n/a

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Version check times out if `versionCheckTimeout` stays at **500ms**, increasing to **1000ms** gives enough time, but might be not ideal.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
