### PR TITLE
Use common error for device lookup on join request

### DIFF
--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1199,7 +1199,7 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 	)
 	if err != nil {
 		logRegistryRPCError(ctx, err, "Failed to load device from registry by EUIs")
-		return err
+		return errDeviceNotFound.WithCause(err)
 	}
 	ctx = matchedCtx
 	ctx = log.NewContextWithField(ctx, "device_uid", unique.ID(ctx, matched.Ids))

--- a/pkg/rpcmiddleware/rpclog/client_interceptors.go
+++ b/pkg/rpcmiddleware/rpclog/client_interceptors.go
@@ -47,7 +47,7 @@ func UnaryClientInterceptor(ctx context.Context, opts ...Option) grpc.UnaryClien
 			onceFields = onceFields.WithFields(logFieldsForError(err))
 		}
 
-		level := o.levelFunc(grpc.Code(err))
+		level := o.levelFunc(o.codeFunc(err))
 		entry := logger.WithFields(onceFields)
 		if err != nil {
 			entry = entry.WithError(err)

--- a/pkg/rpcmiddleware/rpclog/options.go
+++ b/pkg/rpcmiddleware/rpclog/options.go
@@ -26,7 +26,7 @@ type methodLogConfig struct {
 	IgnoredErrors map[string]struct{}
 }
 
-func (cfg *methodLogConfig) shouldIgnorError(err *errors.Error) bool {
+func (cfg *methodLogConfig) shouldIgnoreError(err *errors.Error) bool {
 	_, ok := cfg.IgnoredErrors[err.FullName()]
 	return ok
 }

--- a/pkg/rpcmiddleware/rpclog/rpclog.go
+++ b/pkg/rpcmiddleware/rpclog/rpclog.go
@@ -122,7 +122,7 @@ func shouldSuppressError(err error) bool {
 func shouldSuppressLog(cfg methodLogConfig, err error) bool {
 	if err != nil {
 		wrapped, ok := errors.From(err)
-		return ok && cfg.shouldIgnorError(wrapped)
+		return ok && cfg.shouldIgnoreError(wrapped)
 	}
 	return cfg.IgnoreSuccess
 }

--- a/pkg/rpcmiddleware/rpclog/server_interceptors.go
+++ b/pkg/rpcmiddleware/rpclog/server_interceptors.go
@@ -56,7 +56,7 @@ func UnaryServerInterceptor(ctx context.Context, opts ...Option) grpc.UnaryServe
 			onceFields = onceFields.With(fields.fields)
 		}
 
-		level := o.levelFunc(grpc.Code(err))
+		level := o.levelFunc(o.codeFunc(err))
 		if err == context.Canceled {
 			level = log.InfoLevel
 		}
@@ -106,7 +106,7 @@ func StreamServerInterceptor(ctx context.Context, opts ...Option) grpc.StreamSer
 			onceFields = onceFields.With(fields.fields)
 		}
 
-		level := o.levelFunc(grpc.Code(err))
+		level := o.levelFunc(o.codeFunc(err))
 		if err == context.Canceled {
 			level = log.InfoLevel
 		}

--- a/pkg/util/rpctest/server_test.go
+++ b/pkg/util/rpctest/server_test.go
@@ -81,7 +81,7 @@ func TestFooBarExampleServer(t *testing.T) {
 			a.So(err, should.BeNil)
 			cancel()
 			err = stream.RecvMsg(&rpctest.Bar{})
-			a.So(grpc.Code(err), should.Equal, codes.Canceled)
+			a.So(status.Code(err), should.Equal, codes.Canceled)
 		}
 
 		{
@@ -91,7 +91,7 @@ func TestFooBarExampleServer(t *testing.T) {
 			a.So(err, should.BeNil)
 			time.Sleep(150 * time.Millisecond)
 			err = stream.RecvMsg(&empty.Empty{})
-			a.So(grpc.Code(err), should.Equal, codes.Unknown)
+			a.So(status.Code(err), should.Equal, codes.Unknown)
 		}
 	})
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes join request handling return a common error (`errDeviceNotFound`), similar to uplink handling. This allows us to easily filter errors on RPC calls (https://github.com/TheThingsNetwork/lorawan-stack/pull/5850).

#### Changes
<!-- What are the changes made in this pull request? -->

- Make the error returned by join request handling be standardized.
  - Previously we would return a `pkg/redis:not_found` error directly, which I don't fully feel like filtering out on `HandleUplink`. But filtering the wrapped error is better since we can control the source of the error.
- Some small tech debt related to gRPC error code handling (`grpc.Code` is deprecated, `status.Code` is the up-to-date way of doing this).


#### Testing

<!-- How did you verify that this change works? -->

UT.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@johanstokking please take a look.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
