### PR TITLE
Use Node 16 action versions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,7 +46,7 @@ jobs:
         run: echo "::set-output name=hash::${{ hashFiles('.github/workflows/e2e.yml', '*.go', 'go.mod', 'go.sum', 'pkg/**', 'tools/**', 'config/**', 'package.json', 'pkg/webui/**', 'sdk/js/**', 'yarn.lock', 'cypress/**', 'docker-compose.yml') }}"
       - name: Get the cached result
         id: run-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .cache/passed
           key: run-cache-${{ steps.get-hash.outputs.hash }}-${{ github.run_id }}
@@ -76,7 +76,7 @@ jobs:
         uses: ./.github/actions/install-node-and-deps
       - name: Initialize SQL dump cache
         id: db-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .env/cache/database.pgdump
@@ -84,7 +84,7 @@ jobs:
           key: db-cache-${{ hashFiles('pkg/identityserver/store/**/*.go', 'cmd/ttn-lw-stack/commands/is-db.go', '.github/workflows/e2e.yml', 'docker-compose.yml') }}
       - name: Initialize device repository index cache
         id: dr-index-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: data/lorawan-devices-index
           key: dr-index-cache-${{ hashFiles('data/lorawan-devices') }}
@@ -98,7 +98,7 @@ jobs:
         uses: ./.github/actions/build-frontend
       - name: Initialize build cache
         id: build-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ttn-lw-stack
           key: build-cache-${{ hashFiles('go.mod', 'go.sum', 'pkg/**',  'config/**', 'cmd/**') }}
@@ -108,7 +108,7 @@ jobs:
       - name: Zip build artifacts
         run: zip -r build.zip .env/cache/database.pgdump .env/admin_api_key.txt data/lorawan-devices-index public ttn-lw-stack tools/bin/mage
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-files
           path: build.zip
@@ -141,7 +141,7 @@ jobs:
           sudo apt-get update
           sudo apt-get --only-upgrade install google-chrome-stable
           google-chrome --version
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         name: Download build artifacts
         with:
           name: 'build-files'
@@ -170,7 +170,7 @@ jobs:
       - name: Run stack
         run: tools/bin/mage dev:startDevStack &
       - name: Run previously failed test first
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         if: steps.get-failed-spec.outputs.failed-test != ''
         with:
           config-file: config/cypress.json
@@ -181,7 +181,7 @@ jobs:
           group: previously-failed-${{ needs.determine-if-required.outputs.hash }}
           spec: ${{ steps.get-failed-spec.outputs.failed-test }}
       - name: Run frontend end-to-end tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
           config-file: config/cypress.json
           config: baseUrl=https://localhost:8885
@@ -194,19 +194,19 @@ jobs:
             !cypress/integration/smoke/smoke.spec.js
             ${{ steps.get-failed-spec.outputs.neg-failed-test }}
       - name: Upload logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs
           path: .cache/devStack.log
       - name: Upload screenshots for failed tests
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
       - name: Upload name of failing test
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-failed-test-spec
@@ -231,7 +231,7 @@ jobs:
         uses: ./.github/actions/build-mage
       - name: Install Node and Dependencies
         uses: ./.github/actions/install-node-and-deps
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         name: Download build artifacts
         with:
           name: 'build-files'
@@ -250,7 +250,7 @@ jobs:
       - name: Run stack
         run: tools/bin/mage dev:startDevStack &
       - name: Run end-to-end smoke tests (Firefox)
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
           config-file: config/cypress.json
           config: baseUrl=https://localhost:8885
@@ -258,13 +258,13 @@ jobs:
           record: true
           spec: cypress/integration/smoke/smoke.spec.js
       - name: Upload logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs
           path: .cache/devStack.log
       - name: Upload screenshots for failed tests
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
@@ -277,7 +277,7 @@ jobs:
     steps:
       - name: Setup result cache to skip redundant runs
         id: run-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .cache/passed
           key: run-cache-${{ needs.determine-if-required.outputs.hash }}

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -40,7 +40,7 @@ jobs:
         uses: ./.github/actions/install-node-and-deps
       - name: Initialize device repository index cache
         id: dr-index-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: data/lorawan-devices-index
           key: dr-index-cache-${{ hashFiles('data/lorawan-devices') }}
@@ -64,7 +64,7 @@ jobs:
           export RC_VERSION=${RC_VERSION#release/v}
           echo "::set-output name=rc_version::$RC_VERSION"
       - name: Run Goreleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: 'v1.9.2'
           args: release --config .goreleaser.snapshot.yml --snapshot --timeout 60m

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -37,7 +37,7 @@ jobs:
         uses: ./.github/actions/install-node-and-deps
       - name: Initialize device repository index cache
         id: dr-index-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: data/lorawan-devices-index
           key: dr-index-cache-${{ hashFiles('data/lorawan-devices') }}
@@ -55,7 +55,7 @@ jobs:
           printf '%s' '${{ secrets.SIGNATURE_PASSPHRASE }}' >/tmp/gpg_passphrase
           cat /tmp/gpg_passphrase | gpg --passphrase-fd 0 --no-tty --batch --import gpg_signing_key
       - name: Run Goreleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: 'v1.9.2'
           args: release --config .goreleaser.snapshot.yml --snapshot --timeout 60m

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -70,7 +70,7 @@ jobs:
         uses: ./.github/actions/install-node-and-deps
       - name: Initialize device repository index cache
         id: dr-index-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: data/lorawan-devices-index
           key: dr-index-cache-${{ hashFiles('data/lorawan-devices') }}
@@ -94,7 +94,7 @@ jobs:
           printf '%s' '${{ secrets.SIGNATURE_PASSPHRASE }}' >/tmp/gpg_passphrase
           cat /tmp/gpg_passphrase | gpg --passphrase-fd 0 --no-tty --batch --import gpg_signing_key
       - name: Run Goreleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: 'v1.9.2'
           args: release --config .goreleaser.release.yml --release-notes /tmp/release-notes.md --timeout 120m


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

#### Changes
<!-- What are the changes made in this pull request? -->

- Use Node 16 versions of the actions
  - Upgrade `goreleaser/goreleaser-action` to `v3` from `v2`.
  - Upgrade `actions/cache` to `v3` from `v2`.
  - Upgrade `actions/upload-artifact` to `v3` from `v2`.
  - Upgrade `actions/download-artifact` to `v3` from `v2`.
  - Upgrade `cypress-io/github-action` to `v4` from `v2`.
  - Skip `dawidd6/action-download-artifact` as there does not seem to be a `v3` yet (maybe it is not required ?).


#### Testing

<!-- How did you verify that this change works? -->

Strictly CI.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
