### PR TITLE
Store Redis events with jittered TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For details about compatibility between different releases, see the **Commitment
 - Class B and C downlinks will no longer be automatically retried indefinitely if none of the gateways are available at the scheduling moment, and the downlink paths come from the last uplink.
   - This was already the behavior for downlinks which had their downlink path provided explicitly using the `class_b_c.gateways` field.
   - The downlinks will be evicted from the downlink queue and a downlink failure event will be generated. The failure event can be observed by the application using the `downlink_failed` message, which is available in all integrations.
+- Event history and payload storage TTL has now 1% jitter.
 
 ### Deprecated
 

--- a/pkg/events/redis/store.go
+++ b/pkg/events/redis/store.go
@@ -75,7 +75,7 @@ func (ps *PubSubStore) storeEvent(ctx context.Context, tx redis.Cmdable, evt eve
 		key := ps.eventIndexKey(evt.Context(), cid)
 		tx.LPush(ctx, key, evt.UniqueID())
 		tx.LTrim(ctx, key, 0, int64(ps.correlationIDHistoryCount))
-		tx.Expire(ctx, key, ttl)
+		tx.PExpire(ctx, key, ttl)
 	}
 	return nil
 }
@@ -418,7 +418,7 @@ func (ps *PubSubStore) Publish(evs ...events.Event) {
 				MaxLenApprox: int64(ps.entityHistoryCount),
 				Values:       streamValues,
 			})
-			tx.Expire(ps.ctx, eventStream, ttl)
+			tx.PExpire(ps.ctx, eventStream, ttl)
 			if devID := id.GetDeviceIds(); devID != nil && definition != nil && definition.PropagateToParent() {
 				eventStream := ps.eventStream(evt.Context(), devID.ApplicationIds.GetEntityIdentifiers())
 				tx.XAdd(ps.ctx, &redis.XAddArgs{
@@ -426,7 +426,7 @@ func (ps *PubSubStore) Publish(evs ...events.Event) {
 					MaxLenApprox: int64(ps.entityHistoryCount),
 					Values:       streamValues,
 				})
-				tx.Expire(ps.ctx, eventStream, ttl)
+				tx.PExpire(ps.ctx, eventStream, ttl)
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR ensures that event storage TTLs are de-correlated in order to avoid 'expiration bursts'. This is achieved by adding a 1% jitter to the event history and payload TTL.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add jitter to the event storage TTL, in order to ensure that events don't correlate accidentally.
- Add jitter to the blocking period of the event subscriptions done via `XRead`. This ensures that multiple streams reconnecting at the same time do not become correlated over time.
- Expire keys using `PEXPIRE` instead of `EXPIRE`. This has the advantage of having millisecond instead of second accuracy, thus reducing the correlation between events.

#### Testing

<!-- How did you verify that this change works? -->

UT.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

The history TTL (i.e. duration for which the event metadata, but not data, is visible) is 24 hours by default. 1% jitter for 24 hours is about 14.4 minutes - some events will expire a little earlier, some a little later. I think this is reasonable.

For the event data storage, which is only 15 minutes by default, 1% jitter is 9 seconds. Again, this should be reasonable.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The background here is that operations that touch the event storage Redis cluster inherently cause some events to become correlated over time. This happens via the following sequence of events:

1. The cluster is unavailable for a short while (say due to an infrastructure upgrade) - can be in the tens of seconds.
2. Some events are queued to be stored - TTL is relative (i.e. it is a duration, not a time in the future) so when all of them are stored, all of their expiration times are also virtually equal.
3. Redis has to expire these keys in the future, so it has to keep the cluster busy while deleting the keys. From the perspective of the application this looks like the downtime described in (1).
4. If more keys are queued than deleted, over time this will cause Redis to correlate more and more events.

You may wonder 'why does Redis need to block while doing this' and the answer is that normally you don't have to block, but in order to ensure that replicas also have the same expired keys, Redis will synthesize `DEL` commands in order to ensure that the keys also expired on the replica:
<img width="691" alt="image" src="https://user-images.githubusercontent.com/36161392/196937916-991b36ce-8e49-4e43-b54f-a7d5234f4e29.png">

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
