### PR TITLE
Use a thread safe `sync.Map` to store rights

### DIFF
--- a/pkg/applicationserver/grpc_deviceregistry_test.go
+++ b/pkg/applicationserver/grpc_deviceregistry_test.go
@@ -100,7 +100,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): nil,
 					}),
@@ -121,7 +121,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "Invalid application ID",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "bar-application"}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
@@ -144,7 +144,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "Not found",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
@@ -172,7 +172,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "Get formatters",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
@@ -213,7 +213,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "Get formatters, session/no key rights",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
@@ -236,7 +236,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "Get formatters,session/has rights",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
@@ -357,7 +357,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		{
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): nil,
 					}),
@@ -380,7 +380,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		{
 			Name: "Invalid application ID",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "bar-application"}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
@@ -405,7 +405,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		{
 			Name: "Create",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): {
 							Rights: []ttnpb.Right{
@@ -482,7 +482,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		{
 			Name: "Set",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
@@ -513,7 +513,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		{
 			Name: "Uplink formatter script size exceeds maximum allowed",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
@@ -541,7 +541,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		{
 			Name: "Downlink formatter script size exceeds maximum allowed",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
@@ -640,7 +640,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 		{
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): nil,
 					}),
@@ -664,7 +664,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 		{
 			Name: "Invalid application ID",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "bar-application"}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
@@ -690,7 +690,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 		{
 			Name: "Not found",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
@@ -722,7 +722,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 		{
 			Name: "Delete",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,

--- a/pkg/applicationserver/grpc_deviceregistry_test.go
+++ b/pkg/applicationserver/grpc_deviceregistry_test.go
@@ -101,7 +101,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): nil,
 					}),
 				})
@@ -122,7 +122,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Invalid application ID",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "bar-application"}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 						),
@@ -145,7 +145,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Not found",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 						),
@@ -173,7 +173,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get formatters",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 						),
@@ -214,7 +214,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get formatters, session/no key rights",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 						),
@@ -237,7 +237,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get formatters,session/has rights",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ_KEYS,
@@ -358,7 +358,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): nil,
 					}),
 				})
@@ -381,7 +381,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Invalid application ID",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "bar-application"}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
@@ -406,7 +406,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Create",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
@@ -483,7 +483,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Set",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
@@ -514,7 +514,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Uplink formatter script size exceeds maximum allowed",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
@@ -542,7 +542,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Downlink formatter script size exceeds maximum allowed",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
@@ -641,7 +641,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): nil,
 					}),
 				})
@@ -665,7 +665,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Invalid application ID",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "bar-application"}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
@@ -691,7 +691,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Not found",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
@@ -723,7 +723,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Delete",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),

--- a/pkg/applicationserver/grpc_deviceregistry_test.go
+++ b/pkg/applicationserver/grpc_deviceregistry_test.go
@@ -101,9 +101,9 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): nil,
-					},
+					}),
 				})
 			},
 			GetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string) (*ttnpb.EndDevice, error) {
@@ -122,11 +122,11 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Invalid application ID",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "bar-application"}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 						),
-					},
+					}),
 				})
 			},
 			GetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string) (*ttnpb.EndDevice, error) {
@@ -145,11 +145,11 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Not found",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 						),
-					},
+					}),
 				})
 			},
 			GetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string) (*ttnpb.EndDevice, error) {
@@ -173,11 +173,11 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get formatters",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 						),
-					},
+					}),
 				})
 			},
 			GetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string) (*ttnpb.EndDevice, error) {
@@ -214,11 +214,11 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get formatters, session/no key rights",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 						),
-					},
+					}),
 				})
 			},
 			GetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string) (*ttnpb.EndDevice, error) {
@@ -237,12 +237,12 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get formatters,session/has rights",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ_KEYS,
 						),
-					},
+					}),
 				})
 			},
 			GetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string) (*ttnpb.EndDevice, error) {
@@ -358,9 +358,9 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): nil,
-					},
+					}),
 				})
 			},
 			SetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -381,11 +381,11 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Invalid application ID",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "bar-application"}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			SetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -406,13 +406,13 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Create",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 							},
 						},
-					},
+					}),
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
@@ -483,11 +483,11 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Set",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
@@ -514,11 +514,11 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Uplink formatter script size exceeds maximum allowed",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
@@ -542,11 +542,11 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Downlink formatter script size exceeds maximum allowed",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
@@ -641,9 +641,9 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): nil,
-					},
+					}),
 				})
 			},
 			SetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -665,11 +665,11 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Invalid application ID",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "bar-application"}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			SetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -691,11 +691,11 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Not found",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			SetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -723,11 +723,11 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Delete",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			SetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {

--- a/pkg/applicationserver/io/grpc/grpc.go
+++ b/pkg/applicationserver/io/grpc/grpc.go
@@ -143,6 +143,9 @@ func (s *impl) Subscribe(ids *ttnpb.ApplicationIdentifiers, stream ttnpb.AppAs_S
 		case <-sub.Context().Done():
 			return sub.Context().Err()
 		case up := <-sub.Up():
+			if err := rights.RequireApplication(ctx, ids, ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ); err != nil {
+				return err
+			}
 			if err := stream.Send(up.ApplicationUp); err != nil {
 				logger.WithError(err).Warn("Failed to send message")
 				sub.Disconnect(err)

--- a/pkg/auth/rights/list.go
+++ b/pkg/auth/rights/list.go
@@ -26,11 +26,12 @@ import (
 func ListApplication(ctx context.Context, id *ttnpb.ApplicationIdentifiers) (rights *ttnpb.Rights, err error) {
 	uid := unique.ID(ctx, id)
 	if inCtx, ok := fromContext(ctx); ok {
-		return inCtx.ApplicationRights[uid], nil
+		r, _ := inCtx.ApplicationRights.GetRights(uid)
+		return r, nil
 	}
 	if inCtx, ok := cacheFromContext(ctx); ok {
-		if rights, ok := inCtx.ApplicationRights[uid]; ok {
-			return rights, nil
+		if r, ok := inCtx.ApplicationRights.GetRights(uid); ok {
+			return r, nil
 		}
 	}
 	defer func() {
@@ -56,11 +57,12 @@ func ListApplication(ctx context.Context, id *ttnpb.ApplicationIdentifiers) (rig
 func ListClient(ctx context.Context, id *ttnpb.ClientIdentifiers) (rights *ttnpb.Rights, err error) {
 	uid := unique.ID(ctx, id)
 	if inCtx, ok := fromContext(ctx); ok {
-		return inCtx.ClientRights[uid], nil
+		r, _ := inCtx.ClientRights.GetRights(uid)
+		return r, nil
 	}
 	if inCtx, ok := cacheFromContext(ctx); ok {
-		if rights, ok := inCtx.ClientRights[uid]; ok {
-			return rights, nil
+		if r, ok := inCtx.ClientRights.GetRights(uid); ok {
+			return r, nil
 		}
 	}
 	defer func() {
@@ -86,11 +88,12 @@ func ListClient(ctx context.Context, id *ttnpb.ClientIdentifiers) (rights *ttnpb
 func ListGateway(ctx context.Context, id *ttnpb.GatewayIdentifiers) (rights *ttnpb.Rights, err error) {
 	uid := unique.ID(ctx, id)
 	if inCtx, ok := fromContext(ctx); ok {
-		return inCtx.GatewayRights[uid], nil
+		r, _ := inCtx.GatewayRights.GetRights(uid)
+		return r, nil
 	}
 	if inCtx, ok := cacheFromContext(ctx); ok {
-		if rights, ok := inCtx.GatewayRights[uid]; ok {
-			return rights, nil
+		if r, ok := inCtx.GatewayRights.GetRights(uid); ok {
+			return r, nil
 		}
 	}
 	defer func() {
@@ -116,11 +119,12 @@ func ListGateway(ctx context.Context, id *ttnpb.GatewayIdentifiers) (rights *ttn
 func ListOrganization(ctx context.Context, id *ttnpb.OrganizationIdentifiers) (rights *ttnpb.Rights, err error) {
 	uid := unique.ID(ctx, id)
 	if inCtx, ok := fromContext(ctx); ok {
-		return inCtx.OrganizationRights[uid], nil
+		r, _ := inCtx.OrganizationRights.GetRights(uid)
+		return r, nil
 	}
 	if inCtx, ok := cacheFromContext(ctx); ok {
-		if rights, ok := inCtx.OrganizationRights[uid]; ok {
-			return rights, nil
+		if r, ok := inCtx.OrganizationRights.GetRights(uid); ok {
+			return r, nil
 		}
 	}
 	defer func() {
@@ -146,11 +150,12 @@ func ListOrganization(ctx context.Context, id *ttnpb.OrganizationIdentifiers) (r
 func ListUser(ctx context.Context, id *ttnpb.UserIdentifiers) (rights *ttnpb.Rights, err error) {
 	uid := unique.ID(ctx, id)
 	if inCtx, ok := fromContext(ctx); ok {
-		return inCtx.UserRights[uid], nil
+		r, _ := inCtx.UserRights.GetRights(uid)
+		return r, nil
 	}
 	if inCtx, ok := cacheFromContext(ctx); ok {
-		if rights, ok := inCtx.UserRights[uid]; ok {
-			return rights, nil
+		if r, ok := inCtx.UserRights.GetRights(uid); ok {
+			return r, nil
 		}
 	}
 	defer func() {

--- a/pkg/auth/rights/require_test.go
+++ b/pkg/auth/rights/require_test.go
@@ -122,27 +122,27 @@ func TestRequire(t *testing.T) {
 		fooID  = "foo"
 	)
 	fooCtx = NewContext(fooCtx, &Rights{
-		ApplicationRights: NewMap(map[string]*ttnpb.Rights{
+		ApplicationRights: *NewMap(map[string]*ttnpb.Rights{
 			unique.ID(fooCtx, &ttnpb.ApplicationIdentifiers{
 				ApplicationId: fooID,
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_APPLICATION_INFO),
 		}),
-		ClientRights: NewMap(map[string]*ttnpb.Rights{
+		ClientRights: *NewMap(map[string]*ttnpb.Rights{
 			unique.ID(fooCtx, &ttnpb.ClientIdentifiers{
 				ClientId: fooID,
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_CLIENT_INFO),
 		}),
-		GatewayRights: NewMap(map[string]*ttnpb.Rights{
+		GatewayRights: *NewMap(map[string]*ttnpb.Rights{
 			unique.ID(fooCtx, &ttnpb.GatewayIdentifiers{
 				GatewayId: fooID,
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_GATEWAY_INFO),
 		}),
-		OrganizationRights: NewMap(map[string]*ttnpb.Rights{
+		OrganizationRights: *NewMap(map[string]*ttnpb.Rights{
 			unique.ID(fooCtx, &ttnpb.OrganizationIdentifiers{
 				OrganizationId: fooID,
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_ORGANIZATION_INFO),
 		}),
-		UserRights: NewMap(map[string]*ttnpb.Rights{
+		UserRights: *NewMap(map[string]*ttnpb.Rights{
 			unique.ID(fooCtx, &ttnpb.UserIdentifiers{
 				UserId: fooID,
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_USER_INFO),

--- a/pkg/auth/rights/require_test.go
+++ b/pkg/auth/rights/require_test.go
@@ -121,7 +121,7 @@ func TestRequire(t *testing.T) {
 		fooCtx = ctx
 		fooID  = "foo"
 	)
-	fooCtx = NewContext(fooCtx, Rights{
+	fooCtx = NewContext(fooCtx, &Rights{
 		ApplicationRights: NewMap(map[string]*ttnpb.Rights{
 			unique.ID(fooCtx, &ttnpb.ApplicationIdentifiers{
 				ApplicationId: fooID,

--- a/pkg/auth/rights/require_test.go
+++ b/pkg/auth/rights/require_test.go
@@ -117,33 +117,36 @@ func TestRequire(t *testing.T) {
 		_ = RequireUser(ctx, &ttnpb.UserIdentifiers{}, ttnpb.Right_RIGHT_USER_INFO)
 	}, should.Panic)
 
-	fooCtx := ctx
+	var (
+		fooCtx = ctx
+		fooID  = "foo"
+	)
 	fooCtx = NewContext(fooCtx, Rights{
-		ApplicationRights: map[string]*ttnpb.Rights{
+		ApplicationRights: NewMap(map[string]*ttnpb.Rights{
 			unique.ID(fooCtx, &ttnpb.ApplicationIdentifiers{
-				ApplicationId: "foo",
+				ApplicationId: fooID,
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_APPLICATION_INFO),
-		},
-		ClientRights: map[string]*ttnpb.Rights{
+		}),
+		ClientRights: NewMap(map[string]*ttnpb.Rights{
 			unique.ID(fooCtx, &ttnpb.ClientIdentifiers{
-				ClientId: "foo",
+				ClientId: fooID,
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_CLIENT_INFO),
-		},
-		GatewayRights: map[string]*ttnpb.Rights{
+		}),
+		GatewayRights: NewMap(map[string]*ttnpb.Rights{
 			unique.ID(fooCtx, &ttnpb.GatewayIdentifiers{
-				GatewayId: "foo",
+				GatewayId: fooID,
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_GATEWAY_INFO),
-		},
-		OrganizationRights: map[string]*ttnpb.Rights{
+		}),
+		OrganizationRights: NewMap(map[string]*ttnpb.Rights{
 			unique.ID(fooCtx, &ttnpb.OrganizationIdentifiers{
-				OrganizationId: "foo",
+				OrganizationId: fooID,
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_ORGANIZATION_INFO),
-		},
-		UserRights: map[string]*ttnpb.Rights{
+		}),
+		UserRights: NewMap(map[string]*ttnpb.Rights{
 			unique.ID(fooCtx, &ttnpb.UserIdentifiers{
-				UserId: "foo",
+				UserId: fooID,
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_USER_INFO),
-		},
+		}),
 	})
 	fooCtx = NewContextWithAuthInfo(fooCtx, &ttnpb.AuthInfoResponse{
 		UniversalRights: ttnpb.RightsFrom(ttnpb.Right_RIGHT_SEND_INVITES),

--- a/pkg/auth/rights/rights.go
+++ b/pkg/auth/rights/rights.go
@@ -147,15 +147,15 @@ type rightsKeyType struct{}
 
 var rightsKey rightsKeyType
 
-func fromContext(ctx context.Context) (Rights, bool) {
-	if rights, ok := ctx.Value(rightsKey).(Rights); ok {
+func fromContext(ctx context.Context) (*Rights, bool) {
+	if rights, ok := ctx.Value(rightsKey).(*Rights); ok {
 		return rights, true
 	}
-	return Rights{}, false
+	return &Rights{}, false
 }
 
 // NewContext returns a derived context with the given rights.
-func NewContext(ctx context.Context, rights Rights) context.Context {
+func NewContext(ctx context.Context, rights *Rights) context.Context {
 	return context.WithValue(ctx, rightsKey, rights)
 }
 
@@ -175,11 +175,11 @@ func cacheInContext(ctx context.Context, f func(*Rights)) {
 	}
 }
 
-func cacheFromContext(ctx context.Context) (Rights, bool) {
+func cacheFromContext(ctx context.Context) (*Rights, bool) {
 	if rights, ok := ctx.Value(rightsCacheKey).(*Rights); ok {
-		return *rights, true
+		return rights, true
 	}
-	return Rights{}, false
+	return &Rights{}, false
 }
 
 type authInfoKeyType struct{}

--- a/pkg/auth/rights/rights.go
+++ b/pkg/auth/rights/rights.go
@@ -28,8 +28,8 @@ type Map struct {
 }
 
 // NewMap ...
-func NewMap(rights map[string]*ttnpb.Rights) Map {
-	m := Map{}
+func NewMap(rights map[string]*ttnpb.Rights) *Map {
+	m := &Map{}
 	for k, v := range rights {
 		m.SetRights(k, v)
 	}

--- a/pkg/auth/rights/rights.go
+++ b/pkg/auth/rights/rights.go
@@ -17,106 +17,129 @@ package rights
 
 import (
 	"context"
+	"sync"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
+// Map ...
+type Map struct {
+	syncMap sync.Map
+}
+
+// NewMap ...
+func NewMap(rights map[string]*ttnpb.Rights) Map {
+	m := Map{}
+	for k, v := range rights {
+		m.SetRights(k, v)
+	}
+	return m
+}
+
+// SetRights sets the rights for the given UID.
+func (m *Map) SetRights(uid string, rights *ttnpb.Rights) {
+	m.syncMap.Store(uid, rights)
+}
+
+// GetRights returns the rights stored in the map for a given UID,
+// or nil if no value is present.
+// The ok result indicates whether value was found in the map.
+func (m *Map) GetRights(uid string) (*ttnpb.Rights, bool) {
+	if r, ok := m.syncMap.Load(uid); ok {
+		return r.(*ttnpb.Rights), ok
+	}
+	return nil, false
+}
+
+// MissingRights returns the rights that are missing for the given RightsMap.
+func (m *Map) MissingRights(uid string, rights ...ttnpb.Right) []ttnpb.Right {
+	if r, ok := m.GetRights(uid); ok {
+		return ttnpb.RightsFrom(rights...).Sub(r).GetRights()
+	}
+	return rights
+}
+
 // Rights for the request.
 type Rights struct {
-	ApplicationRights  map[string]*ttnpb.Rights
-	ClientRights       map[string]*ttnpb.Rights
-	GatewayRights      map[string]*ttnpb.Rights
-	OrganizationRights map[string]*ttnpb.Rights
-	UserRights         map[string]*ttnpb.Rights
+	ApplicationRights  Map
+	ClientRights       Map
+	GatewayRights      Map
+	OrganizationRights Map
+	UserRights         Map
 }
 
 // SetApplicationRights sets the rights for the given application.
 func (r *Rights) setApplicationRights(appUID string, rights *ttnpb.Rights) {
-	if r.ApplicationRights == nil {
-		r.ApplicationRights = make(map[string]*ttnpb.Rights)
-	}
-	r.ApplicationRights[appUID] = rights
+	r.ApplicationRights.SetRights(appUID, rights)
 }
 
 // SetClientRights sets the rights for the given client.
 func (r *Rights) setClientRights(cliUID string, rights *ttnpb.Rights) {
-	if r.ClientRights == nil {
-		r.ClientRights = make(map[string]*ttnpb.Rights)
-	}
-	r.ClientRights[cliUID] = rights
+	r.ClientRights.SetRights(cliUID, rights)
 }
 
 // SetGatewayRights sets the rights for the given gateway.
 func (r *Rights) setGatewayRights(gtwUID string, rights *ttnpb.Rights) {
-	if r.GatewayRights == nil {
-		r.GatewayRights = make(map[string]*ttnpb.Rights)
-	}
-	r.GatewayRights[gtwUID] = rights
+	r.GatewayRights.SetRights(gtwUID, rights)
 }
 
 // SetOrganizationRights sets the rights for the given organization.
 func (r *Rights) setOrganizationRights(orgUID string, rights *ttnpb.Rights) {
-	if r.OrganizationRights == nil {
-		r.OrganizationRights = make(map[string]*ttnpb.Rights)
-	}
-	r.OrganizationRights[orgUID] = rights
+	r.OrganizationRights.SetRights(orgUID, rights)
 }
 
 // SetUserRights sets the rights for the given user.
 func (r *Rights) setUserRights(usrUID string, rights *ttnpb.Rights) {
-	if r.UserRights == nil {
-		r.UserRights = make(map[string]*ttnpb.Rights)
-	}
-	r.UserRights[usrUID] = rights
+	r.UserRights.SetRights(usrUID, rights)
 }
 
 // MissingApplicationRights returns the rights that are missing for the given application.
-func (r Rights) MissingApplicationRights(appUID string, rights ...ttnpb.Right) []ttnpb.Right {
-	return ttnpb.RightsFrom(rights...).Sub(r.ApplicationRights[appUID]).GetRights()
+func (r *Rights) MissingApplicationRights(appUID string, rights ...ttnpb.Right) []ttnpb.Right {
+	return r.ApplicationRights.MissingRights(appUID, rights...)
 }
 
 // MissingClientRights returns the rights that are missing for the given client.
-func (r Rights) MissingClientRights(cliUID string, rights ...ttnpb.Right) []ttnpb.Right {
-	return ttnpb.RightsFrom(rights...).Sub(r.ClientRights[cliUID]).GetRights()
+func (r *Rights) MissingClientRights(cliUID string, rights ...ttnpb.Right) []ttnpb.Right {
+	return r.ClientRights.MissingRights(cliUID, rights...)
 }
 
 // MissingGatewayRights returns the rights that are missing for the given gateway.
-func (r Rights) MissingGatewayRights(gtwUID string, rights ...ttnpb.Right) []ttnpb.Right {
-	return ttnpb.RightsFrom(rights...).Sub(r.GatewayRights[gtwUID]).GetRights()
+func (r *Rights) MissingGatewayRights(gtwUID string, rights ...ttnpb.Right) []ttnpb.Right {
+	return r.GatewayRights.MissingRights(gtwUID, rights...)
 }
 
 // MissingOrganizationRights returns the rights that are missing for the given organization.
-func (r Rights) MissingOrganizationRights(orgUID string, rights ...ttnpb.Right) []ttnpb.Right {
-	return ttnpb.RightsFrom(rights...).Sub(r.OrganizationRights[orgUID]).GetRights()
+func (r *Rights) MissingOrganizationRights(orgUID string, rights ...ttnpb.Right) []ttnpb.Right {
+	return r.OrganizationRights.MissingRights(orgUID, rights...)
 }
 
 // MissingUserRights returns the rights that are missing for the given user.
-func (r Rights) MissingUserRights(usrUID string, rights ...ttnpb.Right) []ttnpb.Right {
-	return ttnpb.RightsFrom(rights...).Sub(r.UserRights[usrUID]).GetRights()
+func (r *Rights) MissingUserRights(usrUID string, rights ...ttnpb.Right) []ttnpb.Right {
+	return r.UserRights.MissingRights(usrUID, rights...)
 }
 
 // IncludesApplicationRights returns whether the given rights are included for the given application.
-func (r Rights) IncludesApplicationRights(appUID string, rights ...ttnpb.Right) bool {
+func (r *Rights) IncludesApplicationRights(appUID string, rights ...ttnpb.Right) bool {
 	return len(r.MissingApplicationRights(appUID, rights...)) == 0
 }
 
 // IncludesClientRights returns whether the given rights are included for the given client.
-func (r Rights) IncludesClientRights(cliUID string, rights ...ttnpb.Right) bool {
+func (r *Rights) IncludesClientRights(cliUID string, rights ...ttnpb.Right) bool {
 	return len(r.MissingClientRights(cliUID, rights...)) == 0
 }
 
 // IncludesGatewayRights returns whether the given rights are included for the given gateway.
-func (r Rights) IncludesGatewayRights(gtwUID string, rights ...ttnpb.Right) bool {
+func (r *Rights) IncludesGatewayRights(gtwUID string, rights ...ttnpb.Right) bool {
 	return len(r.MissingGatewayRights(gtwUID, rights...)) == 0
 }
 
 // IncludesOrganizationRights returns whether the given rights are included for the given organization.
-func (r Rights) IncludesOrganizationRights(orgUID string, rights ...ttnpb.Right) bool {
+func (r *Rights) IncludesOrganizationRights(orgUID string, rights ...ttnpb.Right) bool {
 	return len(r.MissingOrganizationRights(orgUID, rights...)) == 0
 }
 
 // IncludesUserRights returns whether the given rights are included for the given user.
-func (r Rights) IncludesUserRights(usrUID string, rights ...ttnpb.Right) bool {
+func (r *Rights) IncludesUserRights(usrUID string, rights ...ttnpb.Right) bool {
 	return len(r.MissingUserRights(usrUID, rights...)) == 0
 }
 

--- a/pkg/auth/rights/rights.go
+++ b/pkg/auth/rights/rights.go
@@ -22,12 +22,12 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
-// Map ...
+// Map stores rights for a given ID.
 type Map struct {
 	syncMap sync.Map
 }
 
-// NewMap ...
+// NewMap returns a pointer to a new Map.
 func NewMap(rights map[string]*ttnpb.Rights) *Map {
 	m := &Map{}
 	for k, v := range rights {

--- a/pkg/auth/rights/rights_test.go
+++ b/pkg/auth/rights/rights_test.go
@@ -30,9 +30,9 @@ func TestContext(t *testing.T) {
 	ctx := test.Context()
 	rights, ok := fromContext(ctx)
 	a.So(ok, should.BeFalse)
-	a.So(rights, should.Resemble, Rights{})
+	a.So(rights, should.Resemble, &Rights{})
 
-	fooRights := Rights{
+	fooRights := &Rights{
 		ApplicationRights: NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, &ttnpb.ApplicationIdentifiers{
 				ApplicationId: "foo-app",

--- a/pkg/auth/rights/rights_test.go
+++ b/pkg/auth/rights/rights_test.go
@@ -33,27 +33,27 @@ func TestContext(t *testing.T) {
 	a.So(rights, should.Resemble, &Rights{})
 
 	fooRights := &Rights{
-		ApplicationRights: NewMap(map[string]*ttnpb.Rights{
+		ApplicationRights: *NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, &ttnpb.ApplicationIdentifiers{
 				ApplicationId: "foo-app",
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_APPLICATION_INFO),
 		}),
-		ClientRights: NewMap(map[string]*ttnpb.Rights{
+		ClientRights: *NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, &ttnpb.ClientIdentifiers{
 				ClientId: "foo-cli",
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_CLIENT_INFO),
 		}),
-		GatewayRights: NewMap(map[string]*ttnpb.Rights{
+		GatewayRights: *NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, &ttnpb.GatewayIdentifiers{
 				GatewayId: "foo-gtw",
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_GATEWAY_INFO),
 		}),
-		OrganizationRights: NewMap(map[string]*ttnpb.Rights{
+		OrganizationRights: *NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, &ttnpb.OrganizationIdentifiers{
 				OrganizationId: "foo-org",
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_ORGANIZATION_INFO),
 		}),
-		UserRights: NewMap(map[string]*ttnpb.Rights{
+		UserRights: *NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, &ttnpb.UserIdentifiers{
 				UserId: "foo-usr",
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_USER_INFO),

--- a/pkg/auth/rights/rights_test.go
+++ b/pkg/auth/rights/rights_test.go
@@ -33,31 +33,31 @@ func TestContext(t *testing.T) {
 	a.So(rights, should.Resemble, Rights{})
 
 	fooRights := Rights{
-		ApplicationRights: map[string]*ttnpb.Rights{
+		ApplicationRights: NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, &ttnpb.ApplicationIdentifiers{
 				ApplicationId: "foo-app",
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_APPLICATION_INFO),
-		},
-		ClientRights: map[string]*ttnpb.Rights{
+		}),
+		ClientRights: NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, &ttnpb.ClientIdentifiers{
 				ClientId: "foo-cli",
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_CLIENT_INFO),
-		},
-		GatewayRights: map[string]*ttnpb.Rights{
+		}),
+		GatewayRights: NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, &ttnpb.GatewayIdentifiers{
 				GatewayId: "foo-gtw",
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_GATEWAY_INFO),
-		},
-		OrganizationRights: map[string]*ttnpb.Rights{
+		}),
+		OrganizationRights: NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, &ttnpb.OrganizationIdentifiers{
 				OrganizationId: "foo-org",
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_ORGANIZATION_INFO),
-		},
-		UserRights: map[string]*ttnpb.Rights{
+		}),
+		UserRights: NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, &ttnpb.UserIdentifiers{
 				UserId: "foo-usr",
 			}): ttnpb.RightsFrom(ttnpb.Right_RIGHT_USER_INFO),
-		},
+		}),
 	}
 
 	ctx = NewContext(ctx, fooRights)

--- a/pkg/gatewayserver/io/io_test.go
+++ b/pkg/gatewayserver/io/io_test.go
@@ -74,7 +74,7 @@ func TestFlow(t *testing.T) {
 	}
 	gs.RegisterGateway(ctx, ids, gtw)
 
-	gtwCtx := rights.NewContext(ctx, rights.Rights{
+	gtwCtx := rights.NewContext(ctx, &rights.Rights{
 		GatewayRights: rights.NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, ids): ttnpb.RightsFrom(ttnpb.Right_RIGHT_GATEWAY_LINK),
 		}),
@@ -567,7 +567,7 @@ func TestSubBandEIRPOverride(t *testing.T) {
 	}
 	gs.RegisterGateway(ctx, ids, gtw)
 
-	gtwCtx := rights.NewContext(ctx, rights.Rights{
+	gtwCtx := rights.NewContext(ctx, &rights.Rights{
 		GatewayRights: rights.NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, ids): ttnpb.RightsFrom(ttnpb.Right_RIGHT_GATEWAY_LINK),
 		}),

--- a/pkg/gatewayserver/io/io_test.go
+++ b/pkg/gatewayserver/io/io_test.go
@@ -75,9 +75,9 @@ func TestFlow(t *testing.T) {
 	gs.RegisterGateway(ctx, ids, gtw)
 
 	gtwCtx := rights.NewContext(ctx, rights.Rights{
-		GatewayRights: map[string]*ttnpb.Rights{
+		GatewayRights: rights.NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, ids): ttnpb.RightsFrom(ttnpb.Right_RIGHT_GATEWAY_LINK),
-		},
+		}),
 	})
 	frontend, err := mock.ConnectFrontend(gtwCtx, ids, gs)
 	if err != nil {
@@ -568,9 +568,9 @@ func TestSubBandEIRPOverride(t *testing.T) {
 	gs.RegisterGateway(ctx, ids, gtw)
 
 	gtwCtx := rights.NewContext(ctx, rights.Rights{
-		GatewayRights: map[string]*ttnpb.Rights{
+		GatewayRights: rights.NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, ids): ttnpb.RightsFrom(ttnpb.Right_RIGHT_GATEWAY_LINK),
-		},
+		}),
 	})
 	frontend, err := mock.ConnectFrontend(gtwCtx, ids, gs)
 	if err != nil {

--- a/pkg/gatewayserver/io/io_test.go
+++ b/pkg/gatewayserver/io/io_test.go
@@ -75,7 +75,7 @@ func TestFlow(t *testing.T) {
 	gs.RegisterGateway(ctx, ids, gtw)
 
 	gtwCtx := rights.NewContext(ctx, &rights.Rights{
-		GatewayRights: rights.NewMap(map[string]*ttnpb.Rights{
+		GatewayRights: *rights.NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, ids): ttnpb.RightsFrom(ttnpb.Right_RIGHT_GATEWAY_LINK),
 		}),
 	})
@@ -568,7 +568,7 @@ func TestSubBandEIRPOverride(t *testing.T) {
 	gs.RegisterGateway(ctx, ids, gtw)
 
 	gtwCtx := rights.NewContext(ctx, &rights.Rights{
-		GatewayRights: rights.NewMap(map[string]*ttnpb.Rights{
+		GatewayRights: *rights.NewMap(map[string]*ttnpb.Rights{
 			unique.ID(ctx, ids): ttnpb.RightsFrom(ttnpb.Right_RIGHT_GATEWAY_LINK),
 		}),
 	})

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -223,11 +223,11 @@ func (s *srv) connect(ctx context.Context, eui types.EUI64, addr *net.UDPAddr) (
 		uid := unique.ID(ctx, ids)
 		ctx = log.NewContextWithField(ctx, "gateway_uid", uid)
 		ctx = rights.NewContext(ctx, rights.Rights{
-			GatewayRights: map[string]*ttnpb.Rights{
+			GatewayRights: rights.NewMap(map[string]*ttnpb.Rights{
 				uid: {
 					Rights: []ttnpb.Right{ttnpb.Right_RIGHT_GATEWAY_LINK},
 				},
-			},
+			}),
 		})
 
 		conn, err = s.server.Connect(ctx, s, ids, &ttnpb.GatewayRemoteAddress{

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -222,7 +222,7 @@ func (s *srv) connect(ctx context.Context, eui types.EUI64, addr *net.UDPAddr) (
 		}
 		uid := unique.ID(ctx, ids)
 		ctx = log.NewContextWithField(ctx, "gateway_uid", uid)
-		ctx = rights.NewContext(ctx, rights.Rights{
+		ctx = rights.NewContext(ctx, &rights.Rights{
 			GatewayRights: rights.NewMap(map[string]*ttnpb.Rights{
 				uid: {
 					Rights: []ttnpb.Right{ttnpb.Right_RIGHT_GATEWAY_LINK},

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -223,7 +223,7 @@ func (s *srv) connect(ctx context.Context, eui types.EUI64, addr *net.UDPAddr) (
 		uid := unique.ID(ctx, ids)
 		ctx = log.NewContextWithField(ctx, "gateway_uid", uid)
 		ctx = rights.NewContext(ctx, &rights.Rights{
-			GatewayRights: rights.NewMap(map[string]*ttnpb.Rights{
+			GatewayRights: *rights.NewMap(map[string]*ttnpb.Rights{
 				uid: {
 					Rights: []ttnpb.Right{ttnpb.Right_RIGHT_GATEWAY_LINK},
 				},

--- a/pkg/gatewayserver/io/ws/ws.go
+++ b/pkg/gatewayserver/io/ws/ws.go
@@ -248,11 +248,11 @@ func (s *srv) handleTraffic(w http.ResponseWriter, r *http.Request) (err error) 
 		}
 		// If the server allows unauthenticated connections (for local testing), we provide the link rights ourselves.
 		ctx = rights.NewContext(ctx, rights.Rights{
-			GatewayRights: map[string]*ttnpb.Rights{
+			GatewayRights: rights.NewMap(map[string]*ttnpb.Rights{
 				uid: {
 					Rights: []ttnpb.Right{ttnpb.Right_RIGHT_GATEWAY_LINK},
 				},
-			},
+			}),
 		})
 	}
 

--- a/pkg/gatewayserver/io/ws/ws.go
+++ b/pkg/gatewayserver/io/ws/ws.go
@@ -248,7 +248,7 @@ func (s *srv) handleTraffic(w http.ResponseWriter, r *http.Request) (err error) 
 		}
 		// If the server allows unauthenticated connections (for local testing), we provide the link rights ourselves.
 		ctx = rights.NewContext(ctx, &rights.Rights{
-			GatewayRights: rights.NewMap(map[string]*ttnpb.Rights{
+			GatewayRights: *rights.NewMap(map[string]*ttnpb.Rights{
 				uid: {
 					Rights: []ttnpb.Right{ttnpb.Right_RIGHT_GATEWAY_LINK},
 				},

--- a/pkg/gatewayserver/io/ws/ws.go
+++ b/pkg/gatewayserver/io/ws/ws.go
@@ -247,7 +247,7 @@ func (s *srv) handleTraffic(w http.ResponseWriter, r *http.Request) (err error) 
 			return errNoAuthProvided.WithAttributes("uid", uid)
 		}
 		// If the server allows unauthenticated connections (for local testing), we provide the link rights ourselves.
-		ctx = rights.NewContext(ctx, rights.Rights{
+		ctx = rights.NewContext(ctx, &rights.Rights{
 			GatewayRights: rights.NewMap(map[string]*ttnpb.Rights{
 				uid: {
 					Rights: []ttnpb.Right{ttnpb.Right_RIGHT_GATEWAY_LINK},

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -99,11 +99,11 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): nil,
-					},
+					}),
 				})
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
@@ -124,11 +124,11 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Not found",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 						),
-					},
+					}),
 				})
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
@@ -162,13 +162,13 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Invalid application ID",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: "bar-application",
 						}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 						),
-					},
+					}),
 				})
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
@@ -204,13 +204,13 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get without key",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 						),
-					},
+					}),
 				})
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
@@ -240,13 +240,13 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get keys without permission",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 						),
-					},
+					}),
 				})
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
@@ -267,14 +267,14 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get keys/AppKey encrypted/NwkKey plaintext",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ_KEYS,
 						),
-					},
+					}),
 				})
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
@@ -328,14 +328,14 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get keys/AppKey plaintext/NwkKey encrypted",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ_KEYS,
 						),
-					},
+					}),
 				})
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
@@ -487,11 +487,11 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): nil,
-					},
+					}),
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
@@ -511,11 +511,11 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "No JoinEUI",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), ttnpb.Clone(registeredDevice.Ids.ApplicationIds)): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
@@ -543,11 +543,11 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "No DevEUI",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), ttnpb.Clone(registeredDevice.Ids.ApplicationIds)): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
@@ -575,13 +575,13 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Create",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
@@ -642,13 +642,13 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Set without keys",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
@@ -693,13 +693,13 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Set keys without permission",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
@@ -720,14 +720,14 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Set keys",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE_KEYS,
 						),
-					},
+					}),
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
@@ -895,11 +895,11 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): nil,
-					},
+					}),
 				})
 			},
 			DeviceRequest: ttnpb.Clone(registeredDevice.Ids),
@@ -917,13 +917,13 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Not found",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			DeviceRequest: &ttnpb.EndDeviceIdentifiers{
@@ -955,13 +955,13 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Delete",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
-					},
+					}),
 				})
 			},
 			DeviceRequest: ttnpb.Clone(registeredDevice.Ids),

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -98,7 +98,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
@@ -123,7 +123,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "Not found",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
@@ -161,7 +161,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "Invalid application ID",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: "bar-application",
@@ -203,7 +203,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "Get without key",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
@@ -239,7 +239,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "Get keys without permission",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
@@ -266,7 +266,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "Get keys/AppKey encrypted/NwkKey plaintext",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
@@ -327,7 +327,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "Get keys/AppKey plaintext/NwkKey encrypted",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
@@ -486,7 +486,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		{
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
@@ -510,7 +510,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		{
 			Name: "No JoinEUI",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), ttnpb.Clone(registeredDevice.Ids.ApplicationIds)): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
@@ -542,7 +542,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		{
 			Name: "No DevEUI",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), ttnpb.Clone(registeredDevice.Ids.ApplicationIds)): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
@@ -574,7 +574,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		{
 			Name: "Create",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
@@ -641,7 +641,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		{
 			Name: "Set without keys",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
@@ -692,7 +692,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		{
 			Name: "Set keys without permission",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
@@ -719,7 +719,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		{
 			Name: "Set keys",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
@@ -894,7 +894,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 		{
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
@@ -916,7 +916,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 		{
 			Name: "Not found",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
@@ -954,7 +954,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 		{
 			Name: "Delete",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -99,7 +99,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): nil,
@@ -124,7 +124,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Not found",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 						),
@@ -162,7 +162,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Invalid application ID",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: "bar-application",
 						}): ttnpb.RightsFrom(
@@ -204,7 +204,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get without key",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
@@ -240,7 +240,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get keys without permission",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
@@ -267,7 +267,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get keys/AppKey encrypted/NwkKey plaintext",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
@@ -328,7 +328,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "Get keys/AppKey plaintext/NwkKey encrypted",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
@@ -487,7 +487,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): nil,
@@ -511,7 +511,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "No JoinEUI",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), ttnpb.Clone(registeredDevice.Ids.ApplicationIds)): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
@@ -543,7 +543,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "No DevEUI",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), ttnpb.Clone(registeredDevice.Ids.ApplicationIds)): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
@@ -575,7 +575,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Create",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
@@ -642,7 +642,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Set without keys",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
@@ -693,7 +693,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Set keys without permission",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
@@ -720,7 +720,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			Name: "Set keys",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
@@ -895,7 +895,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Permission denied",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): nil,
@@ -917,7 +917,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Not found",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(
@@ -955,7 +955,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Delete",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{
 							ApplicationId: registeredApplicationID,
 						}): ttnpb.RightsFrom(

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -2896,11 +2896,11 @@ func TestGetAppSKey(t *testing.T) {
 			ContextFunc: func(ctx context.Context) context.Context {
 				ctx = rights.NewContextWithAuthInfo(ctx, &ttnpb.AuthInfoResponse{})
 				ctx = rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(ctx, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app"}): {
 							Rights: []ttnpb.Right{ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ}, // Require READ_KEYS
 						},
-					},
+					}),
 				})
 				return ctx
 			},
@@ -2984,11 +2984,11 @@ func TestGetAppSKey(t *testing.T) {
 			ContextFunc: func(ctx context.Context) context.Context {
 				ctx = rights.NewContextWithAuthInfo(ctx, &ttnpb.AuthInfoResponse{})
 				ctx = rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(ctx, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app"}): {
 							Rights: []ttnpb.Right{ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ_KEYS},
 						},
-					},
+					}),
 				})
 				return ctx
 			},

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -2895,7 +2895,7 @@ func TestGetAppSKey(t *testing.T) {
 			Name: "No application rights",
 			ContextFunc: func(ctx context.Context) context.Context {
 				ctx = rights.NewContextWithAuthInfo(ctx, &ttnpb.AuthInfoResponse{})
-				ctx = rights.NewContext(ctx, rights.Rights{
+				ctx = rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(ctx, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app"}): {
 							Rights: []ttnpb.Right{ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ}, // Require READ_KEYS
@@ -2983,7 +2983,7 @@ func TestGetAppSKey(t *testing.T) {
 			Name: "Matching request/application auth",
 			ContextFunc: func(ctx context.Context) context.Context {
 				ctx = rights.NewContextWithAuthInfo(ctx, &ttnpb.AuthInfoResponse{})
-				ctx = rights.NewContext(ctx, rights.Rights{
+				ctx = rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(ctx, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app"}): {
 							Rights: []ttnpb.Right{ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ_KEYS},

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -2896,7 +2896,7 @@ func TestGetAppSKey(t *testing.T) {
 			ContextFunc: func(ctx context.Context) context.Context {
 				ctx = rights.NewContextWithAuthInfo(ctx, &ttnpb.AuthInfoResponse{})
 				ctx = rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(ctx, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app"}): {
 							Rights: []ttnpb.Right{ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ}, // Require READ_KEYS
 						},
@@ -2984,7 +2984,7 @@ func TestGetAppSKey(t *testing.T) {
 			ContextFunc: func(ctx context.Context) context.Context {
 				ctx = rights.NewContextWithAuthInfo(ctx, &ttnpb.AuthInfoResponse{})
 				ctx = rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(ctx, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app"}): {
 							Rights: []ttnpb.Right{ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ_KEYS},
 						},

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -51,7 +51,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "No device read rights",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
@@ -85,7 +85,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "no keys",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
@@ -130,7 +130,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "with keys",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
@@ -197,7 +197,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "with specific key envelope",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
@@ -259,7 +259,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 		{
 			Name: "with specific key",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
@@ -1218,7 +1218,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 		{
 			Name: "No device write rights",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
@@ -1249,7 +1249,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 		{
 			Name: "Non-existing device",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
@@ -1284,7 +1284,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 		{
 			Name: "Existing device",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
+				return rights.NewContext(ctx, &rights.Rights{
 					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -52,13 +52,13 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "No device read rights",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_GATEWAY_SETTINGS_BASIC,
 							},
 						},
-					},
+					}),
 				})
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
@@ -86,13 +86,13 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "no keys",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 							},
 						},
-					},
+					}),
 				})
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
@@ -131,7 +131,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "with keys",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
@@ -139,7 +139,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 								ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ,
 							},
 						},
-					},
+					}),
 				})
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
@@ -198,14 +198,14 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "with specific key envelope",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ_KEYS,
 							},
 						},
-					},
+					}),
 				})
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
@@ -260,14 +260,14 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "with specific key",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ_KEYS,
 							},
 						},
-					},
+					}),
 				})
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
@@ -1219,13 +1219,13 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "No device write rights",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_GATEWAY_SETTINGS_BASIC,
 							},
 						},
-					},
+					}),
 				})
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
@@ -1250,13 +1250,13 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Non-existing device",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 							},
 						},
-					},
+					}),
 				})
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
@@ -1285,13 +1285,13 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Existing device",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
+					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 							},
 						},
-					},
+					}),
 				})
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -52,7 +52,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "No device read rights",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_GATEWAY_SETTINGS_BASIC,
@@ -86,7 +86,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "no keys",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
@@ -131,7 +131,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "with keys",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
@@ -198,7 +198,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "with specific key envelope",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
@@ -260,7 +260,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			Name: "with specific key",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ,
@@ -1219,7 +1219,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "No device write rights",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_GATEWAY_SETTINGS_BASIC,
@@ -1250,7 +1250,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Non-existing device",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
@@ -1285,7 +1285,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			Name: "Existing device",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, &rights.Rights{
-					ApplicationRights: rights.NewMap(map[string]*ttnpb.Rights{
+					ApplicationRights: *rights.NewMap(map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #5534 

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `sync.Map` to store rights (instead of `map[string]*ttnpb.Rights`)

#### Testing

<!-- How did you verify that this change works? -->

- Added unit tests for `rights.Map`

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Using `rights.Map` requires to use it's interface instead of relying on a native `map`.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
