### PR TITLE
Don't require AppKey when skipping JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Do not require AppKey when skipping Join Server registration in end device onboarding in the Console.
+- Fix auto generation of device ID when using DevEUI generator in the Console.
+
 ### Security
 
 ## [3.22.1] - 2022-10-19

--- a/cypress/integration/console/devices/onboarding/manual-registration.spec.js
+++ b/cypress/integration/console/devices/onboarding/manual-registration.spec.js
@@ -230,7 +230,6 @@ describe('End device manual create', () => {
         cy.findByLabelText('JoinEUI').type(device.join_eui)
         cy.findByRole('button', { name: 'Confirm' }).click()
         cy.findByLabelText('DevEUI').type(device.dev_eui)
-        cy.findByLabelText('AppKey').type(device.app_key)
 
         cy.findByRole('button', { name: 'Register end device' }).click()
 

--- a/pkg/webui/console/containers/dev-eui-component/index.js
+++ b/pkg/webui/console/containers/dev-eui-component/index.js
@@ -71,23 +71,9 @@ const DevEUIComponent = props => {
     return result.dev_eui
   }, [appId, dispatch, fetchDevEUICounter, promisifiedIssueDevEUI])
 
-  const handleGenerate = useCallback(async () => {
-    try {
-      const result = await handleDevEUIRequest()
-      setDevEUIGenerated(true)
-      setErrorMessage(undefined)
-      return result
-    } catch (error) {
-      if (getBackendErrorName(error) === 'global_eui_limit_reached') {
-        setErrorMessage(sharedMessages.devEUIBlockLimitReached)
-      } else setErrorMessage(sharedMessages.unknownError)
-      setDevEUIGenerated(true)
-    }
-  }, [handleDevEUIRequest])
-
   const handleIdPrefill = useCallback(
-    event => {
-      const value = event.target.value
+    eventOrEui => {
+      const value = typeof eventOrEui === 'string' ? eventOrEui : eventOrEui.target.value
       if (value.length === 16 && (!idTouched || hasEuiId)) {
         const generatedId = `eui-${value.toLowerCase()}`
         setFieldValue('target_device_id', generatedId)
@@ -96,6 +82,21 @@ const DevEUIComponent = props => {
     },
     [hasEuiId, idTouched, setFieldValue],
   )
+
+  const handleGenerate = useCallback(async () => {
+    try {
+      const result = await handleDevEUIRequest()
+      setDevEUIGenerated(true)
+      setErrorMessage(undefined)
+      handleIdPrefill(result)
+      return result
+    } catch (error) {
+      if (getBackendErrorName(error) === 'global_eui_limit_reached') {
+        setErrorMessage(sharedMessages.devEUIBlockLimitReached)
+      } else setErrorMessage(sharedMessages.unknownError)
+      setDevEUIGenerated(true)
+    }
+  }, [handleDevEUIRequest, handleIdPrefill])
 
   const devEUIGenerateDisabled =
     applicationDevEUICounter === env.devEUIConfig.applicationLimit ||

--- a/pkg/webui/console/containers/device-onboarding-form/provisioning-form-section/registration-form-section/index.js
+++ b/pkg/webui/console/containers/device-onboarding-form/provisioning-form-section/registration-form-section/index.js
@@ -52,6 +52,7 @@ const DeviceRegistrationFormSection = () => {
   const isABP = !values.supports_join && !values.multicast
   const isOTAA = values.supports_join
   const lwVersion = parseLorawanMacVersion(values.lorawan_version)
+  const skipJs = values.join_server_address === undefined
 
   const showDevEUI =
     (!isMulticast && values._inputMethod === 'manual') ||
@@ -71,7 +72,7 @@ const DeviceRegistrationFormSection = () => {
           autoFocus
         />
       )}
-      {isOTAA && (
+      {isOTAA && !skipJs && (
         <>
           <Form.Field
             required

--- a/pkg/webui/console/containers/device-onboarding-form/provisioning-form-section/registration-form-section/validation-schema.js
+++ b/pkg/webui/console/containers/device-onboarding-form/provisioning-form-section/registration-form-section/validation-schema.js
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* eslint-disable react/forbid-prop-types */
+
+import { isUndefined } from 'lodash'
+
 import Yup from '@ttn-lw/lib/yup'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
@@ -25,12 +29,16 @@ const networkKeySchema = Yup.object({
   }),
 })
 
-const appKeySchema = Yup.object({
-  app_key: Yup.object({
-    key: Yup.string()
-      .length(16 * 2, Yup.passValues(sharedMessages.validateLength))
-      .required(sharedMessages.validateRequired),
-  }),
+const appKeySchema = Yup.object().when('join_server_address', {
+  is: isUndefined,
+  otherwise: schema =>
+    schema.shape({
+      app_key: Yup.object({
+        key: Yup.string()
+          .length(16 * 2, Yup.passValues(sharedMessages.validateLength))
+          .required(sharedMessages.validateRequired),
+      }),
+    }),
 })
 
 const devAddrSchema = Yup.string()

--- a/pkg/webui/console/containers/device-onboarding-form/type-form-section/manual-form-section/validation-schema.js
+++ b/pkg/webui/console/containers/device-onboarding-form/type-form-section/manual-form-section/validation-schema.js
@@ -50,7 +50,6 @@ const advancedSettingsSchema = Yup.object({
     then: schema => schema.oneOf([false]),
   }),
   _default_ns_settings: Yup.bool(),
-  _skip_js_registration: Yup.bool(),
 })
 
 const macSettingsSchema = Yup.object({


### PR DESCRIPTION
#### Summary
This PR fixes the Console insisting on entering an AppKey when skipping the registration on the JS. It also fixes a small bug with the automatic device ID generation.

Closes #5886 

#### Changes
<!-- What are the changes made in this pull request? -->

- Update validation schema and rendering logic for AppKey
- Explicitly generate device ID when generating the DevEUI

#### Testing

Manual and existing e2es.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
