### PR TITLE
Avoid infinite network initiated downlink retries 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Class B and C downlinks will no longer be automatically retried indefinitely if none of the gateways are available at the scheduling moment, and the downlink paths come from the last uplink.
+  - This was already the behavior for downlinks which had their downlink path provided explicitly using the `class_b_c.gateways` field.
+  - The downlinks will be evicted from the downlink queue and a downlink failure event will be generated. The failure event can be observed by the application using the `downlink_failed` message, which is available in all integrations.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/applicationserver/observability.go
+++ b/pkg/applicationserver/observability.go
@@ -88,11 +88,13 @@ var (
 		"as.up.location.forward", "forward location solved message",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithDataType(&ttnpb.ApplicationUp{}),
+		events.WithPropagateToParent(),
 	)
 	evtForwardServiceData = events.Define(
 		"as.up.service.forward", "forward service data message",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithDataType(&ttnpb.ApplicationUp{}),
+		events.WithPropagateToParent(),
 	)
 	evtReceiveDataDown = events.Define(
 		"as.down.data.receive", "receive downlink data message",

--- a/pkg/gatewayserver/io/udp/observability.go
+++ b/pkg/gatewayserver/io/udp/observability.go
@@ -103,9 +103,9 @@ func registerMessageDropped(_ context.Context, err error) {
 	errorLabel := "unknown"
 	if ttnErr, ok := errors.From(err); ok {
 		errorLabel = ttnErr.FullName()
-	} else if jsonErr := (&json.SyntaxError{}); errors.Is(err, jsonErr) {
+	} else if jsonErr := (&json.SyntaxError{}); errors.As(err, &jsonErr) {
 		errorLabel = "encoding/json:syntax"
-	} else if jsonErr := (&json.UnmarshalTypeError{}); errors.Is(err, jsonErr) {
+	} else if jsonErr := (&json.UnmarshalTypeError{}); errors.As(err, &jsonErr) {
 		errorLabel = "encoding/json:unmarshal_type"
 		udpMetrics.unmarshalTypeErrors.WithLabelValues(jsonErr.Value, jsonErr.Field).Inc()
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes the NS fail (that is, drop from the queue and generate an application downlink failed message) class B/C downlinks for which the downlink paths come from an uplink.

---

Previously we would do this drop only if the downlink paths were provided via `class_b_c.gateways`. If the device was in class B/C, and we took the downlink paths from historical traffic (i.e. the gateways of the last uplink), we would not fail the downlink. This means that if an end device in class C had a downlink scheduled, and the gateways of the last uplink were not available, we would try indefinitely to schedule the downlink.

We now fail this downlink if the paths really are not available, in order to avoid retrying forever. The application layer has the option to look at the error in the failure message and decide if it wants to try again. I consider this to be sane, since we at NS/AS level cannot really know for how long this downlink should be enqueued (for a class B/C device).

#### Changes
<!-- What are the changes made in this pull request? -->

- Relax the 'no path available' downlink failure condition to affect downlink paths coming from uplink messages.
- Quickfix: Forward the `as.up.location.forward` and `as.up.service.forward` to the application too. This makes them visible in the application live data view.
- Some small technical debt related to error assertions vs `errors.Is`/`errors.As`.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Applications that depended on this infinite retry behavior will not be very happy with this change, unless they already were handling application downlink failed messages. I do think that this change is good, given that it actually reports a failure to the application layer, instead of retrying to schedule the downlink potentially indefinitely - right now unless you are watching the events yourself, you wouldn't know that these downlinks are failing contiguously.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
