### PR TITLE
Fix gateway stats debouncing doubling behavior

### DIFF
--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -102,21 +102,21 @@ func NewScheduler(
 		scheduleAnytimeDelay = &ScheduleTimeShort
 	}
 
-	var toa *frequencyplans.TimeOffAir
+	var timeOffAir *frequencyplans.TimeOffAir
 	for _, fp := range fps {
-		if toa != nil && fp.TimeOffAir != *toa {
+		if timeOffAir != nil && fp.TimeOffAir != *timeOffAir {
 			return nil, errFrequencyPlansTimeOffAir.New()
 		}
-		toa = &fp.TimeOffAir
+		timeOffAir = fp.TimeOffAir.Clone()
 	}
 
-	if toa.Duration < QueueDelay {
-		toa.Duration = QueueDelay
+	if timeOffAir.Duration < QueueDelay {
+		timeOffAir.Duration = QueueDelay
 	}
 
 	s := &Scheduler{
 		clock:                &RolloverClock{},
-		timeOffAir:           *toa,
+		timeOffAir:           *timeOffAir,
 		fps:                  fps,
 		timeSource:           timeSource,
 		scheduleAnytimeDelay: *scheduleAnytimeDelay,

--- a/pkg/webui/console/components/events/messages.js
+++ b/pkg/webui/console/components/events/messages.js
@@ -36,7 +36,6 @@ const messages = defineMessages({
   rx1Frequency: 'Rx1 Frequency',
   rx2DataRateIndex: 'Rx2 Data Rate Index',
   rx2Frequency: 'Rx2 Frequency',
-  gatewayEUI: 'Gtw EUI',
   class: 'Class',
   // Generic messages
   eventDetails: 'Event details',

--- a/pkg/webui/console/components/events/previews/downlink-message.js
+++ b/pkg/webui/console/components/events/previews/downlink-message.js
@@ -43,7 +43,6 @@ const DownLinkMessagePreview = React.memo(({ event }) => {
   if ('request' in data) {
     const { name } = event
     if (name.startsWith('gs')) {
-      const gatewayEUI = event.identifiers[0].gateway_ids.eui
       const lorawanClass = getByPath(data, 'request.class')
       const rx1Delay = getByPath(data, 'request.rx1_delay')
       const rx1DataRateIndex = getByPath(data, 'request.rx1_data_rate_index')
@@ -52,7 +51,6 @@ const DownLinkMessagePreview = React.memo(({ event }) => {
       const rx2DataRateIndex = getByPath(data, 'request.rx2_data_rate_index')
       return (
         <DescriptionList>
-          <DescriptionList.Byte title={messages.gatewayEUI} data={gatewayEUI} />
           <DescriptionList.Item title={messages.class} data={lorawanClass} />
           <DescriptionList.Item title={messages.rx1Delay} data={rx1Delay} />
           <DescriptionList.Item title={messages.rx1DataRateIndex} data={rx1DataRateIndex} />

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -258,7 +258,6 @@
   "console.components.events.messages.rx1Frequency": "Rx1 Frequency",
   "console.components.events.messages.rx2DataRateIndex": "Rx2 Data Rate Index",
   "console.components.events.messages.rx2Frequency": "Rx2 Frequency",
-  "console.components.events.messages.gatewayEUI": "Gtw EUI",
   "console.components.events.messages.class": "Class",
   "console.components.events.messages.eventDetails": "Event details",
   "console.components.events.messages.rawEvent": "Raw event",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the following double stats emission event:
<img width="1536" alt="image" src="https://user-images.githubusercontent.com/36161392/198277415-7c6b4a45-bbdd-49f1-9548-a68a4c7546e5.png">

It also removes the gateway EUI from the gateway downlink scheduling event:
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/36161392/198277566-91eff3ae-6ecd-4c45-9a26-732db0bf5c4d.png">

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix timestamp saving during gateway stats debounce.
- Remove gateway EUI from downlink scheduling events.
- Fix modification of frequency plans as part of scheduler initialization.


#### Testing

<!-- How did you verify that this change works? -->

Unit tests.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
