### PR TITLE
Set bunstore as default store implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,21 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- The `is.gormstore` experimental flag has been added. Swaps the underlying Identity Server store implementation if set to true.
+
 ### Changed
 
 - Class B and C downlinks will no longer be automatically retried indefinitely if none of the gateways are available at the scheduling moment, and the downlink paths come from the last uplink.
   - This was already the behavior for downlinks which had their downlink path provided explicitly using the `class_b_c.gateways` field.
   - The downlinks will be evicted from the downlink queue and a downlink failure event will be generated. The failure event can be observed by the application using the `downlink_failed` message, which is available in all integrations.
 - Event history and payload storage TTL has now 1% jitter.
+- The underlying store implementation has been changed to be by default based on `bun` instead of `gorm`. The previous store implementation can be reactivated using the `is.gormstore` experimental flag.
 
 ### Deprecated
 
 ### Removed
+
+- The `is.bunstore` experimental flag has been removed.
 
 ### Fixed
 

--- a/pkg/identityserver/bunstore/oauth_store.go
+++ b/pkg/identityserver/bunstore/oauth_store.go
@@ -763,7 +763,7 @@ func (s *oauthStore) DeleteClientAuthorizations(ctx context.Context, clientIDs *
 	))
 	defer span.End()
 
-	clientUUID, err := s.getClientUUID(ctx, clientIDs)
+	clientUUID, err := s.getClientUUID(store.WithSoftDeleted(ctx, false), clientIDs)
 	if err != nil {
 		return err
 	}

--- a/pkg/identityserver/store.go
+++ b/pkg/identityserver/store.go
@@ -24,15 +24,16 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 )
 
-var bunstoreFeatureFlag = experimental.DefineFeature("is.bunstore", false)
+var gormFeatureFlag = experimental.DefineFeature("is.gormstore", false)
 
 func (is *IdentityServer) setupStore() error {
-	if bunstoreFeatureFlag.GetValue(is.Context()) {
-		return is.setupBunStore()
+	if gormFeatureFlag.GetValue(is.Context()) {
+		return is.setupGormStore()
 	}
-	return is.setupGormStore()
+	return is.setupBunStore()
 }
 
+// TODO: Remove the gormstore implementation. (https://github.com/TheThingsNetwork/lorawan-stack/issues/5643)
 func (is *IdentityServer) setupGormStore() error {
 	gormDB, err := gormstore.Open(is.Context(), is.config.DatabaseURI)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #5643 but does not close it.
The main change of this PR is to swap the default store implementation used for TTS deployments. Secondary changes are just things noticed while looking at the code.

#### Changes
<!-- What are the changes made in this pull request? -->

- Change the experimental flag to make gormstore the optional implementation.
- Remove gormstore from the `ttn-lw-stack/commands/is_db.go` file.
- One line fix to the purge of deleted clients on bunstore.


#### Testing

<!-- How did you verify that this change works? -->

Bunstore has been used in the community version for quite a while.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Like mentioned above there is the time that the `bunstore` has been used as a form of confirmation that it doesn't have unintended side effects but it might be cautelous to wait for tests regarding multiple tenants behaviour before making `bunstore` the default store. Would like to have the reviewers opinion on this.

I ended up removing the `bunstore` experimental flag, checked from the implementation and the removal of such experimental flag should not impact the community edition deployment.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Left the `gormstore` implementation for now but as the issue entails it should be removed, the idea behind this was to have the gormstore implementation as a reference for the tenant isolation tests. After that its finished I believe we can delete the gormstore implementation, its setup and its experimental flag.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
