### PR TITLE
Discard errors originating from firewall blocks

### DIFF
--- a/pkg/webui/components/input/byte.js
+++ b/pkg/webui/components/input/byte.js
@@ -25,7 +25,6 @@ const PLACEHOLDER_CHAR = '·'
 
 const hex = /[0-9a-f]/i
 const voidChars = RegExp(`[ ${PLACEHOLDER_CHAR}]`, 'g')
-const onlyVoidChars = RegExp(`^[ ${PLACEHOLDER_CHAR}]+$`, 'g')
 
 const masks = {}
 const mask = (min, max, showPerChar = false) => {

--- a/pkg/webui/lib/errors/utils.js
+++ b/pkg/webui/lib/errors/utils.js
@@ -299,6 +299,12 @@ export const isSentryWorthy = error => {
   // Forward any other unknown errors without relevant status code,
   // that are not network related.
   if (isUnknown(error) && statusCode === undefined) {
+    if (typeof error === 'string' && /<html.*>|<!DOCTYPE/i.test(error)) {
+      // If the error is a string and resembles a HTML document, it is likely
+      // caused by a client side firewall or other security middleware.
+      // Such errors can be discarded.
+      return false
+    }
     return true
   }
 


### PR DESCRIPTION
#### Summary
This quickfix PR will prevent errors originating from client-side firewall setups from being reported to sentry.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a check to see whether an error is an HTML document (happening when API requests are blocked and the response replaced with an HTML site)

#### Testing

Manual testing.

#### Notes for Reviewers
These errors are very annoying because they will cause a new error event being generated for each request. An example event can be seen here:
https://sentry.io/organizations/the-things-industries/issues/3712835017/?project=2682566

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
