### PR TITLE
Fix field mask updates in webhook form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ For details about compatibility between different releases, see the **Commitment
   - Do not ask for a JoinEUI.
   - Reinitialize form properly when switching between ABP and OTAA.
 - Issue with pasting values into byte input at the wrong position in the Console.
+- Issue with updating field masks in the webhook edit form in the Console.
 
 ### Security
 

--- a/pkg/webui/account/containers/profile-settings-form/index.js
+++ b/pkg/webui/account/containers/profile-settings-form/index.js
@@ -142,9 +142,9 @@ const ProfileEditForm = () => {
   const handleSubmit = useCallback(
     async (values, { setSubmitting, resetForm }) => {
       setError(undefined)
-      let patch = diff(user, validationSchema.cast(values, { context: validationContext }), [
-        '_profile_picture_source',
-      ])
+      let patch = diff(user, validationSchema.cast(values, { context: validationContext }), {
+        exclude: ['_profile_picture_source'],
+      })
       if (Object.keys(patch).length === 0) {
         patch = { ...values }
         delete patch.profile_picture

--- a/pkg/webui/console/containers/organization-form/update.js
+++ b/pkg/webui/console/containers/organization-form/update.js
@@ -78,7 +78,7 @@ const OrganizationUpdateForm = ({ onDeleteSuccess }) => {
       try {
         setError()
 
-        const changed = diff(organization, updated, ['created_at', 'updated_at'])
+        const changed = diff(organization, updated, { exclude: ['created_at', 'updated_at'] })
         await dispatch(attachPromise(updateOrganization(orgId, changed)))
 
         toast({

--- a/pkg/webui/console/containers/webhook-edit/webhook-edit.js
+++ b/pkg/webui/console/containers/webhook-edit/webhook-edit.js
@@ -45,13 +45,11 @@ const WebhookEdit = props => {
 
   const handleUpdateWebhook = React.useCallback(
     async updatedWebhook => {
-      const patch = diff(selectedWebhook, updatedWebhook, ['ids'])
-
-      // Ensure that the header prop is always patched fully, otherwise we loose
-      // old header entries.
-      if ('headers' in patch) {
-        patch.headers = updatedWebhook.headers
-      }
+      const patch = diff(selectedWebhook, updatedWebhook, {
+        exclude: ['ids'],
+        patchArraysItems: false,
+        patchInFull: ['headers'],
+      })
 
       if (Object.keys(patch).length === 0) {
         await updateWebhook(updatedWebhook)

--- a/pkg/webui/console/views/device-general-settings/identity-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/identity-server-form/index.js
@@ -117,7 +117,7 @@ const IdentityServerForm = React.memo(props => {
         delete castedValues.attributes
       }
 
-      const updatedValues = diff(initialValues, castedValues, ['_external_js'])
+      const updatedValues = diff(initialValues, castedValues, { exclude: ['_external_js'] })
 
       const update =
         'attributes' in updatedValues ? { ...updatedValues, attributes } : updatedValues

--- a/pkg/webui/console/views/device-general-settings/network-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/network-server-form/index.js
@@ -251,17 +251,19 @@ const NetworkServerForm = React.memo(props => {
         stripUnknown: true,
       })
 
-      const updatedValues = diff(device, castedValues, [
-        '_activation_mode',
-        '_device_classes',
-        'class_b',
-        'class_c',
-        'mac_settings',
-        'f_nwk_s_int_key',
-        's_nwk_s_int_key',
-        'nwk_s_enc_key',
-        'app_s_key',
-      ])
+      const updatedValues = diff(device, castedValues, {
+        exclude: [
+          '_activation_mode',
+          '_device_classes',
+          'class_b',
+          'class_c',
+          'mac_settings',
+          'f_nwk_s_int_key',
+          's_nwk_s_int_key',
+          'nwk_s_enc_key',
+          'app_s_key',
+        ],
+      })
 
       const patch = updatedValues
       // Always submit current `mac_settings` values to avoid overwriting nested entries.


### PR DESCRIPTION
#### Summary
This quickfix fixes issues with updating field masks in the webhook form.

More info: https://github.com/TheThingsIndustries/lorawan-stack-support/issues/848#event-7711973851

#### Changes
<!-- What are the changes made in this pull request? -->

- Change `diff()` util to not include array items if wished
- Use new functionality in webhook edit form
- Refactor function signature of `diff()` util to be more expressive

#### Testing

Manual testing.

#### Notes for Reviewers
The issue was that `diff()` would also diff array items instead of the array as a whole. The backend will not patch over individual array items but only the whole array. So it's required to include the whole updated array, when in this case the patched array with empty items was sent.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
