### PR TITLE
Remove the required constraint from `server_url` in LoRa Cloud integration

### DIFF
--- a/pkg/webui/console/containers/lora-cloud-das-form/index.js
+++ b/pkg/webui/console/containers/lora-cloud-das-form/index.js
@@ -68,9 +68,7 @@ const validationSchema = Yup.object()
     data: Yup.object().shape({
       token: Yup.string().required(sharedMessages.validateRequired),
       use_tlv_encoding: Yup.boolean(),
-      server_url: Yup.string()
-        .url(sharedMessages.validateUrl)
-        .required(sharedMessages.validateRequired),
+      server_url: Yup.string().url(sharedMessages.validateUrl),
       f_port_set: Yup.string()
         .transform(value => {
           let returning = value

--- a/pkg/webui/console/containers/lora-cloud-das-form/index.js
+++ b/pkg/webui/console/containers/lora-cloud-das-form/index.js
@@ -110,7 +110,9 @@ const LoRaCloudDASForm = () => {
     selectApplicationPackageDefaultAssociation(state, LORA_CLOUD_DAS.DEFAULT_PORT),
   )
   const packageError = useSelector(selectGetApplicationPackagesError)
-  const initialValues = validationSchema.cast(defaultAssociation || defaultValues)
+  const initialValues = validationSchema.cast(
+    defaultAssociation ? { server_url: '', ...defaultAssociation } : defaultValues,
+  )
 
   const handleSubmit = useCallback(
     async values => {

--- a/pkg/webui/console/containers/lora-cloud-gls-form/index.js
+++ b/pkg/webui/console/containers/lora-cloud-gls-form/index.js
@@ -133,8 +133,9 @@ const LoRaCloudGLSForm = () => {
     selectApplicationPackageDefaultAssociation(state, LORA_CLOUD_GLS.DEFAULT_PORT),
   )
   const packageError = useSelector(selectGetApplicationPackagesError)
-  const initialValues = validationSchema.cast(defaultAssociation || defaultValues)
-
+  const initialValues = validationSchema.cast(
+    defaultAssociation ? { server_url: '', ...defaultAssociation } : defaultValues,
+  )
   const handleSubmit = useCallback(
     async values => {
       try {

--- a/pkg/webui/console/containers/lora-cloud-gls-form/index.js
+++ b/pkg/webui/console/containers/lora-cloud-gls-form/index.js
@@ -81,9 +81,7 @@ const validationSchema = Yup.object()
         .oneOf(LORACLOUD_GLS_QUERY_VALUES)
         .default(LORACLOUD_GLS_QUERY_TYPES.TOARSSI)
         .required(sharedMessages.validateRequired),
-      server_url: Yup.string()
-        .url(sharedMessages.validateUrl)
-        .required(sharedMessages.validateRequired),
+      server_url: Yup.string().url(sharedMessages.validateUrl),
       multi_frame: Yup.boolean().when('query', {
         is: LORACLOUD_GLS_QUERY_TYPES.TOARSSI,
         then: schema => schema.default(false).required(sharedMessages.validateRequired),


### PR DESCRIPTION
#### Summary
With the recent update to the LoRa Cloud integration the `server_url` field in the LoRa Cloud Modem & Geolocation Services form was marked as required with a default initial value. Existing integrations may have an empty value here, and the backend does not require it either, therefore this PR removes the `required` constraint.

#### Changes
- Removed the required constraint in the yup validation scheme for the `server_url` field in the forms for the LoRa Cloud Modem & Geolocation Services

#### Testing
Manual.

##### Regressions
There shouldn't be any.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
