### PR TITLE
Make CFList optional in interop calls

### DIFF
--- a/pkg/interop/client_test.go
+++ b/pkg/interop/client_test.go
@@ -293,7 +293,6 @@ func TestHandleJoinRequest(t *testing.T) { //nolint:paralleltest
 						"DevAddr":         "01020304",
 						"DLSettings":      "00",
 						"RxDelay":         5.0,
-						"CFList":          "",
 					})
 					test.Must(nil, json.NewEncoder(w).Encode(map[string]interface{}{
 						"ProtocolVersion": "1.0",
@@ -352,7 +351,6 @@ func TestHandleJoinRequest(t *testing.T) { //nolint:paralleltest
 						"DevAddr":         "01020304",
 						"DLSettings":      "00",
 						"RxDelay":         5.0,
-						"CFList":          "",
 					})
 					test.Must(nil, json.NewEncoder(w).Encode(map[string]interface{}{
 						"ProtocolVersion": "1.1",
@@ -411,7 +409,6 @@ func TestHandleJoinRequest(t *testing.T) { //nolint:paralleltest
 						"DevAddr":         "01020304",
 						"DLSettings":      "00",
 						"RxDelay":         5.0,
-						"CFList":          "",
 					})
 					test.Must(nil, json.NewEncoder(w).Encode(map[string]interface{}{
 						"ProtocolVersion": "1.0",
@@ -496,7 +493,6 @@ func TestHandleJoinRequest(t *testing.T) { //nolint:paralleltest
 						"DevAddr":         "01020304",
 						"DLSettings":      "00",
 						"RxDelay":         5.0,
-						"CFList":          "",
 					})
 					test.Must(nil, json.NewEncoder(w).Encode(map[string]interface{}{
 						"ProtocolVersion": "1.1",
@@ -582,7 +578,6 @@ func TestHandleJoinRequest(t *testing.T) { //nolint:paralleltest
 						"DevAddr":         "01020304",
 						"DLSettings":      "00",
 						"RxDelay":         5.0,
-						"CFList":          "",
 					})
 					test.Must(nil, json.NewEncoder(w).Encode(map[string]interface{}{
 						"ProtocolVersion": "1.1",

--- a/pkg/interop/messages.go
+++ b/pkg/interop/messages.go
@@ -123,7 +123,7 @@ type JoinReq struct {
 	DevAddr    DevAddr
 	DLSettings Buffer
 	RxDelay    ttnpb.RxDelay
-	CFList     Buffer
+	CFList     Buffer `json:",omitempty"`
 }
 
 // JoinAns is an answer to a JoinReq message.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-join-server/issues/39

#### Changes
<!-- What are the changes made in this pull request? -->

Do not set `CFList` when it is empty.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

CFList is specified Optional in Backend Interfaces 1.0 and 1.1. I think that both set-and-empty and unset can be considered "Optional". I think, however, it is safer and cleaner to just unset it.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
