### PR TITLE
Fix pending MAC state import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Devices with pending session and MAC state may now successfully be imported.
+
 ### Security
 
 ## [3.22.2] - 2022-11-10

--- a/pkg/ttnpb/fieldmask_utils.go
+++ b/pkg/ttnpb/fieldmask_utils.go
@@ -267,7 +267,7 @@ func FieldsWithPrefix(prefix string, paths ...string) []string {
 func FieldsWithoutPrefix(prefix string, paths ...string) []string {
 	ret := make([]string, 0, len(paths))
 	for _, p := range paths {
-		if i := strings.Index(p, prefix+"."); i >= 0 {
+		if strings.HasPrefix(p, prefix+".") {
 			ret = append(ret, p[1+len(prefix):])
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/5926

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix the behavior of `FieldsWithoutPrefix`, which was causing the import `pending_mac_state` to fail with the very weird `invalid field c_state` error.


#### Testing

<!-- How did you verify that this change works? -->

Local testing + JSON from the original issue.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This was broken completely previously.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
