### PR TITLE
Fix cleaning of unbounded byte inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For details about compatibility between different releases, see the **Commitment
 - Devices with pending session and MAC state may now successfully be imported.
 - Client creation with an organization API key will no longer send an email without user information to the admins. Instead, the API key name will be used and if that is empty the API key ID will be the default.
 - Allow providing DevEUI for ABP end devices with a LoRaWAN specification lower or equal to 1.0.4 in the end device onboarding screen in the Console.
+- Faulty field validation for byte payloads in the uplink payload formatter panel in the Console.
 
 ### Security
 

--- a/pkg/webui/components/input/byte.js
+++ b/pkg/webui/components/input/byte.js
@@ -103,8 +103,8 @@ export default class ByteInput extends React.Component {
       ...rest
     } = this.props
 
-    // Instead of calculating the max width dynamically, which leads to various issues,
-    // it's better to use a high max value for unbounded inputs instead.
+    // Instead of calculating the max width dynamically, which leads to various issues
+    // with pasting, it's better to use a high max value for unbounded inputs instead.
     const calculatedMax = max || 4096
 
     if (!unbounded && typeof max !== 'number') {
@@ -141,8 +141,12 @@ export default class ByteInput extends React.Component {
     const { value: oldValue, unbounded } = this.props
     const data = evt?.nativeEvent?.data
 
-    // Clean the value for unbounded inputs, to prevent adding bytes after
-    // placeholders instead of at the end of the current values.
+    // Due to the way that react-text-mask works, it is not possible to
+    // store the cleaned value, since it would create ambiguity between
+    // values like `AA` and `AA `. This causes backspaces to not work
+    // if it targets the space character, since the deleted space would
+    // be re-added right away. Hence, unbounded inputs need to remove
+    // the space paddings manually.
     let value = unbounded ? evt.target.value : clean(evt.target.value)
 
     // Make sure values entered at the end of the input (with placeholders)

--- a/pkg/webui/console/components/downlink-form/downlink-form.js
+++ b/pkg/webui/console/components/downlink-form/downlink-form.js
@@ -62,7 +62,7 @@ const validationSchema = Yup.object({
       schema.test(
         'len',
         Yup.passValues(sharedMessages.validateHexLength),
-        val => !Boolean(val) || val.length % 2 === 0,
+        val => !Boolean(val) || val.length % 3 === 0,
       ),
     otherwise: schema => schema.strip(),
   }),

--- a/pkg/webui/console/components/payload-formatters-form/test-form/index.js
+++ b/pkg/webui/console/components/payload-formatters-form/test-form/index.js
@@ -62,7 +62,7 @@ const validationSchema = Yup.object({
       return schema.test(
         'len',
         Yup.passValues(sharedMessages.validateHexLength),
-        payload => !Boolean(payload) || payload.length % 2 === 0,
+        payload => !Boolean(payload) || payload.length % 3 === 0,
       )
     }
 

--- a/pkg/webui/console/components/uplink-form/uplink-form.js
+++ b/pkg/webui/console/components/uplink-form/uplink-form.js
@@ -44,7 +44,7 @@ const validationSchema = Yup.object({
   frm_payload: Yup.string().test(
     'len',
     Yup.passValues(sharedMessages.validateHexLength),
-    payload => !Boolean(payload) || payload.length % 2 === 0,
+    payload => !Boolean(payload) || payload.length % 3 === 0,
   ),
 })
 

--- a/pkg/webui/console/lib/bytes_test.js
+++ b/pkg/webui/console/lib/bytes_test.js
@@ -15,13 +15,31 @@
 import { hexToBase64, base64ToHex } from './bytes'
 
 describe('Bytes utils', () => {
-  const base64 = ['AQ==', 'Ag==', '/w==', 'vyUs3Q==', 'MEijVA==', 'EjRWeJCrze8=', 'CZxkIN2eINE=']
-  const hex = ['01', '02', 'ff', 'bf252cdd', '3048a354', '1234567890abcdef', '099c6420dd9e20d1']
+  const base64 = [
+    'AQ==',
+    'Ag==',
+    '/w==',
+    'vyUs3Q==',
+    'MEijVA==',
+    'EjRWeJCrze8=',
+    'CZxkIN2eINE=',
+    'AQIDBA==',
+  ]
+  const hex = [
+    '01',
+    '02',
+    'ff',
+    'bf252cdd',
+    '3048a354',
+    '1234567890abcdef',
+    '099c6420dd9e20d1',
+    '01 02 03 04 ',
+  ]
 
   describe('when using base64ToHex', () => {
     const testTable = base64.map((value, index) => [value, hex[index]])
     it.each(testTable)('yields base64ToHex(%s) = %s', (base64Str, expectedHex) => {
-      expect(base64ToHex(base64Str)).toBe(expectedHex)
+      expect(base64ToHex(base64Str)).toBe(expectedHex.replace(/ /g, ''))
     })
   })
 


### PR DESCRIPTION
#### Summary
This quickfix issue adds back value cleaning for unbounded byte input values, which can cause validation issues.

#### Changes
- Update validation of byte values from unbounded byte inputs

#### Testing

- Manual

#### Notes for Reviewers
Unfortunately, there is no other satisfactory way to resolve this without refactoring byte inputs completely to use a different masking module. Fortunately, all our byte values that come from unbounded inputs are converted to base64 with a function that ignores whitespaces. That's why I only had to update the validation to account for the spacing of byte-character pairs.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
