### PR TITLE
Partition Redis event streams on subscribe

### DIFF
--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -110,6 +110,7 @@ var DefaultEventsConfig = func() config.Events {
 	c.Redis.Store.EntityTTL = 24 * time.Hour
 	c.Redis.Store.EntityCount = 100
 	c.Redis.Store.CorrelationIDCount = 100
+	c.Redis.Store.StreamPartitionSize = 64
 	c.Redis.Workers = 16
 	c.Redis.Publish.QueueSize = 8192
 	c.Redis.Publish.MaxWorkers = 1024

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -130,11 +130,12 @@ type Cache struct {
 type RedisEvents struct {
 	redis.Config `name:",squash"`
 	Store        struct {
-		Enable             bool          `name:"enable" description:"Enable events store"`
-		TTL                time.Duration `name:"ttl" description:"How long event payloads are retained"`
-		EntityCount        int           `name:"entity-count" description:"How many events are indexed for a entity ID"`
-		EntityTTL          time.Duration `name:"entity-ttl" description:"How long events are indexed for a entity ID"`
-		CorrelationIDCount int           `name:"correlation-id-count" description:"How many events are indexed for a correlation ID"` //nolint:lll
+		Enable              bool          `name:"enable" description:"Enable events store"`
+		TTL                 time.Duration `name:"ttl" description:"How long event payloads are retained"`
+		EntityCount         int           `name:"entity-count" description:"How many events are indexed for a entity ID"`
+		EntityTTL           time.Duration `name:"entity-ttl" description:"How long events are indexed for a entity ID"`
+		CorrelationIDCount  int           `name:"correlation-id-count" description:"How many events are indexed for a correlation ID"`     //nolint:lll
+		StreamPartitionSize int           `name:"stream-partition-size" description:"How many streams to listen to in a single partition"` //nolint:lll
 	} `name:"store"`
 	Workers int `name:"workers"`
 	Publish struct {

--- a/pkg/events/redis/redis.go
+++ b/pkg/events/redis/redis.go
@@ -81,11 +81,15 @@ func NewPubSub(ctx context.Context, component workerpool.Component, conf config.
 	}
 
 	pss := &PubSubStore{
-		PubSub:                    ps,
+		PubSub: ps,
+
+		taskStarter: component,
+
 		historyTTL:                conf.Store.TTL,
 		entityHistoryCount:        conf.Store.EntityCount,
 		entityHistoryTTL:          conf.Store.EntityTTL,
 		correlationIDHistoryCount: conf.Store.CorrelationIDCount,
+		streamPartitionSize:       conf.Store.StreamPartitionSize,
 	}
 	if pss.historyTTL == 0 {
 		pss.historyTTL = 10 * time.Minute
@@ -98,6 +102,9 @@ func NewPubSub(ctx context.Context, component workerpool.Component, conf config.
 	}
 	if pss.correlationIDHistoryCount == 0 {
 		pss.correlationIDHistoryCount = 100
+	}
+	if pss.streamPartitionSize == 0 {
+		pss.streamPartitionSize = 64
 	}
 
 	return pss


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR introduces a partitioning mechanism to our Redis historical event stream subscriptions. The context here is that subscribers are allowed to subscribe to multiple streams at once (that is, a stream per entity), and this in turn causes issues when the number of subscribed streams is in the hundreds to thousands.

The problem is that subscribing to historical streams is inherently an `XRead` operation - we give Redis a set of streams in which we are interested, and Redis returns back when at least one of the streams (or the timeout) has a message available. 

The trouble is that when we provide hundreds of streams at once per call, we ask Redis to always walk through these streams and check if a message is available. This scales terribly when the arrival pattern of these streams is de-correlated (think gateway event streams for gateways without overlapping coverage), because every message causes a full set traversal, but with little chances of actually returning too many messages (due to de-correlation).

The proposed fix is to partition this set of streams and to listen to these subsets in parallel, but to process the partitions serially. This reduces the concurrency of a events subscribe call to a fixed size, while still allowing the caller to subscribe to multiple streams in a unified manner.

#### Changes
<!-- What are the changes made in this pull request? -->

- Partition the set of event streams and listen to them in parallel while using the Redis Store events backend.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing and local testing.

Edit: Also tested on `staging1`.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This change affects the `SubscribeWithHistory` RPC which is used by the Console and some monitoring integrations.

The unit tests and local testing cover this, ~and I will run some tests on `staging1` and 2 while preparing this PR~.
Edit: Also tested on `staging1`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
