### PR TITLE
Do not report common task errors

### DIFF
--- a/pkg/errors/conversion.go
+++ b/pkg/errors/conversion.go
@@ -57,10 +57,14 @@ var (
 		"x509_certificate_invalid", "certificate invalid", "detail", "reason",
 	)
 
-	errContextCancelled = DefineCanceled(
-		"context_canceled", "context canceled",
-	)
-	errContextDeadlineExceeded = DefineDeadlineExceeded(
+	// ErrContextCanceled is the Definition of the standard context.Cancelled error.
+	// This variant exists in order to allow the error code to be properly propagated
+	// over gRPC calls, otherwise the error code is unknown.
+	ErrContextCanceled = DefineCanceled("context_canceled", "context canceled")
+	// ErrContextDeadlineExceeded is the definition of the standard context.DeadlineExceeded error.
+	// This variant exists in order to allow the error code to be properly propagated
+	// over gRPC calls, otherwise the error code is unknown.
+	ErrContextDeadlineExceeded = DefineDeadlineExceeded(
 		"context_deadline_exceeded", "context deadline exceeded",
 	)
 )
@@ -78,10 +82,10 @@ func From(err error) (out *Error, ok bool) { //nolint:gocyclo
 		}
 	}()
 	if errors.Is(err, context.Canceled) {
-		return build(errContextCancelled, 0), true
+		return build(ErrContextCanceled, 0), true
 	}
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, os.ErrDeadlineExceeded) {
-		return build(errContextDeadlineExceeded, 0), true
+		return build(ErrContextDeadlineExceeded, 0), true
 	}
 	if matched := (*Error)(nil); errors.As(err, &matched) {
 		if matched == nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes our task mechanism not report `context.Cancelled`, `context.DeadlineExceeded` and `io.EOF` errors as warnings when they occur. They generally show that the RPC has been cancelled by the caller and do not add any additional information.

#### Changes
<!-- What are the changes made in this pull request? -->

- Expose the `ErrContextCancelled` and `ErrContextDeadlineExceeded`, which are the wire versions of the standard errors.
- Do not log warnings for the above mentioned errors.


#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. These warnings are not really useful and only pollute the reporting.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
