### PR TITLE
Relax JoinEUI zero check for in-memory crypto

### DIFF
--- a/pkg/crypto/cryptoservices/mem.go
+++ b/pkg/crypto/cryptoservices/mem.go
@@ -101,7 +101,7 @@ func (d *mem) JoinAcceptMIC(
 	dn types.DevNonce,
 	payload []byte,
 ) ([4]byte, error) {
-	if dev.Ids == nil || types.MustEUI64(dev.Ids.JoinEui).OrZero().IsZero() {
+	if dev.Ids == nil || len(dev.Ids.JoinEui) == 0 {
 		return [4]byte{}, errNoJoinEUI.New()
 	}
 	if types.MustEUI64(dev.Ids.DevEui).OrZero().IsZero() {
@@ -138,7 +138,7 @@ func (d *mem) EncryptRejoinAccept(
 	if !macspec.UseNwkKey(version) {
 		panic("This statement is unreachable. Please version check.")
 	}
-	if dev.Ids == nil || types.MustEUI64(dev.Ids.JoinEui).OrZero().IsZero() {
+	if dev.Ids == nil || len(dev.Ids.JoinEui) == 0 {
 		return nil, errNoJoinEUI.New()
 	}
 	if types.MustEUI64(dev.Ids.DevEui).OrZero().IsZero() {
@@ -161,7 +161,7 @@ func (d *mem) DeriveNwkSKeys(
 	dn types.DevNonce,
 	nid types.NetID,
 ) (NwkSKeys, error) {
-	if dev.Ids == nil || types.MustEUI64(dev.Ids.JoinEui).OrZero().IsZero() {
+	if dev.Ids == nil || len(dev.Ids.JoinEui) == 0 {
 		return NwkSKeys{}, errNoJoinEUI.New()
 	}
 	if types.MustEUI64(dev.Ids.DevEui).OrZero().IsZero() {
@@ -203,7 +203,7 @@ func (d *mem) DeriveAppSKey(
 	dn types.DevNonce,
 	nid types.NetID,
 ) (types.AES128Key, error) {
-	if dev.Ids == nil || types.MustEUI64(dev.Ids.JoinEui).OrZero().IsZero() {
+	if dev.Ids == nil || len(dev.Ids.JoinEui) == 0 {
 		return types.AES128Key{}, errNoJoinEUI.New()
 	}
 	if types.MustEUI64(dev.Ids.DevEui).OrZero().IsZero() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/pull/3483

#### Changes
<!-- What are the changes made in this pull request? -->

- Allow all-zero JoinEUIs as part of the in-memory crypto services.

#### Testing

<!-- How did you verify that this change works? -->

Local testing and `staging1`.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This is a regression in itself.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
