### PR TITLE
Support more pointer types in config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -238,6 +238,7 @@ func (m *Manager) Unmarshal(result interface{}) error {
 			stringToADRAckLimitExponentPointerHook,
 			stringToAggregatedDutyCyclePointerHook,
 			stringToRxDelayPointerHook,
+			stringToEUI64PointerHook,
 		),
 	})
 	if err != nil {
@@ -427,6 +428,14 @@ func (m *Manager) setDefaults(prefix string, flags *pflag.FlagSet, config interf
 				m.viper.SetDefault(name, val)
 				flags.BoolP(name, shorthand, val, description)
 
+			case *bool:
+				m.viper.SetDefault(name, val)
+				value := false
+				if val != nil && *val {
+					value = true
+				}
+				flags.BoolP(name, shorthand, value, description)
+
 			case int:
 				m.viper.SetDefault(name, val)
 				flags.IntP(name, shorthand, val, description)
@@ -563,6 +572,14 @@ func (m *Manager) setDefaults(prefix string, flags *pflag.FlagSet, config interf
 			case types.EUI64:
 				str := val.String()
 				m.viper.SetDefault(name, str)
+				flags.StringP(name, shorthand, str, description)
+
+			case *types.EUI64:
+				var str string
+				if val != nil {
+					m.viper.SetDefault(name, str)
+					str = val.String()
+				}
 				flags.StringP(name, shorthand, str, description)
 
 			case ttnpb.RxDelay:

--- a/pkg/config/hooks.go
+++ b/pkg/config/hooks.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
 )
 
 var errFormat = errors.DefineInvalidArgument("format", "invalid format `{input}`")
@@ -285,6 +286,21 @@ func stringToRxDelayPointerHook(f reflect.Type, t reflect.Type, data interface{}
 		enum = ttnpb.RxDelay(n)
 	}
 	return &enum, nil
+}
+
+func stringToEUI64PointerHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+	var eui types.EUI64
+	if f.Kind() != reflect.String || t != reflect.TypeOf(&eui) {
+		return data, nil
+	}
+	s := data.(string)
+	if s == "" {
+		return (*types.EUI64)(nil), nil
+	}
+	if err := eui.UnmarshalText([]byte(s)); err != nil {
+		return nil, err
+	}
+	return &eui, nil
 }
 
 func stringToADRAckDelayExponentPointerHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5941 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `*bool` and `*types.EUI64`
- Add supporting functions.


#### Testing

<!-- How did you verify that this change works? -->

Local compilation

```
Set: blob.aws.s3-force-path-style: false

Get: 
blob:
  aws:
    access-key-id: ""
    endpoint: ""
    region: ""
    s3-force-path-style: false

Set: blob.aws.s3-force-path-style: true

Get:
blob:
  aws:
    access-key-id: ""
    endpoint: ""
    region: ""
    s3-force-path-style: true

Set: No value in config

GET
blob:
  aws:
    access-key-id: ""
    endpoint: ""
    region: ""
    s3-force-path-style: null
```


```
Set: No Value 

dcs:
  edcs:
    network-server:
      home-ns-id: ""

Set: dcs.edcs.network-server.home-ns-id: "1111111111111111"

dcs:
  edcs:
    network-server:
      home-ns-id: "1111111111111111"
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This is a bug fix.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
