### PR TITLE
Report proprietary frame rejection more clearly

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -4013,6 +4013,15 @@
       "file": "mac.go"
     }
   },
+  "error:pkg/encoding/lorawan:proprietary": {
+    "translations": {
+      "en": "expected standard LoRaWAN frame"
+    },
+    "description": {
+      "package": "pkg/encoding/lorawan",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/encoding/lorawan:unknown_field": {
     "translations": {
       "en": "unknown `{lorawan_field}`"

--- a/pkg/encoding/lorawan/errors.go
+++ b/pkg/encoding/lorawan/errors.go
@@ -31,6 +31,7 @@ var (
 	errFieldLengthHasMin            = errors.DefineInvalidArgument("field_length_with_min", "`{lorawan_field}` length `{value}` should be higher or equal to `{min}`", valueKey)
 	errFieldLengthTwoChoices        = errors.DefineInvalidArgument("field_length_with_multiple_choices", "`{lorawan_field}` length `{value}` should be equal to `{expected_1}` or `{expected_2}`", valueKey)
 	errUnknownField                 = errors.DefineInvalidArgument("unknown_field", "unknown `{lorawan_field}`", valueKey)
+	errProprietary                  = errors.DefineInvalidArgument("proprietary", "expected standard LoRaWAN frame")
 )
 
 const valueKey = "value"

--- a/pkg/encoding/lorawan/messages.go
+++ b/pkg/encoding/lorawan/messages.go
@@ -526,6 +526,8 @@ func AppendMessage(dst []byte, msg *ttnpb.Message) ([]byte, error) {
 			return nil, errEncryptedJoinAcceptPayloadLength(n)
 		}
 		dst = append(dst, pld.Encrypted...)
+	case ttnpb.MType_PROPRIETARY:
+		return nil, errProprietary.New()
 	default:
 		return nil, errUnknown("MType")(msg.MHdr.MType.String())
 	}
@@ -551,6 +553,8 @@ func MarshalMessage(msg *ttnpb.Message) ([]byte, error) {
 	case ttnpb.MType_JOIN_ACCEPT:
 		// MHDR(1) + Encrypted payload(16|32)
 		return AppendMessage(make([]byte, 0, 33), msg)
+	case ttnpb.MType_PROPRIETARY:
+		return nil, errProprietary.New()
 	default:
 		return nil, errUnknown("MType")(msg.MHdr.MType.String())
 	}
@@ -623,6 +627,8 @@ func UnmarshalMessage(b []byte, msg *ttnpb.Message) error {
 			return errExpectedLengthTwoChoices("JoinAcceptPHYPayload", 17, 33)(n)
 		}
 		msg.Payload = &ttnpb.Message_JoinAcceptPayload{JoinAcceptPayload: &ttnpb.JoinAcceptPayload{Encrypted: b[1:]}}
+	case ttnpb.MType_PROPRIETARY:
+		return errProprietary.New()
 	default:
 		return errUnknown("MType")(msg.MHdr.MType.String())
 	}
@@ -678,6 +684,8 @@ func GetUplinkMessageIdentifiers(phyPayload []byte) (*ttnpb.EndDeviceIdentifiers
 		default:
 			return nil, errUnknown("RejoinType")(phyPayload[1])
 		}
+	case ttnpb.MType_PROPRIETARY:
+		return nil, errProprietary.New()
 	default:
 		return nil, errUnknown("MType")(mhdr.MType.String())
 	}

--- a/pkg/networkserver/mac/adr.go
+++ b/pkg/networkserver/mac/adr.go
@@ -191,7 +191,7 @@ func adrLossRate(ups ...*ttnpb.MACState_UplinkMessage) float32 {
 		}
 		lastFCnt = fCnt
 	}
-	return float32(lost) / float32(1+internal.LastUplink(ups...).GetPayload().GetMacPayload().GetFullFCnt()-min)
+	return float32(lost) / float32(1+lastFCnt-min)
 }
 
 func maxSNRFromMetadata(mds ...*ttnpb.MACState_UplinkMessage_RxMetadata) (float32, bool) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/5956

#### Changes
<!-- What are the changes made in this pull request? -->

- Report proprietary frame marshalling errors with a dedicated error.
- Simplify ADR loss rate computation.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
