### PR TITLE
console: Allow dynamic frequencies and hide desired fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- It is now allowed to set `0` for ping slot frequency and beacon frequency in the Network Layer Settings of the end device general settings in the Console.
+- MAC parameters that have the `desired_` will be hidden from the end device general settings for multicast end devices in the Console.
+
 ### Security
 
 ## [3.23.0] - 2022-11-30

--- a/pkg/webui/console/components/mac-settings-section/index.js
+++ b/pkg/webui/console/components/mac-settings-section/index.js
@@ -201,18 +201,20 @@ const MacSettingsSection = props => {
                 fieldWidth="xs"
               />
             )}
-            <Form.Field
-              title={m.desiredRx1DelayTitle}
-              type="number"
-              name="mac_settings.desired_rx1_delay"
-              append={<Message content={sharedMessages.secondsAbbreviated} />}
-              tooltipId={tooltipIds.RX1_DELAY}
-              component={Input}
-              min={1}
-              max={15}
-              inputWidth="xs"
-              fieldWidth="xs"
-            />
+            {!isMulticast && (
+              <Form.Field
+                title={m.desiredRx1DelayTitle}
+                type="number"
+                name="mac_settings.desired_rx1_delay"
+                append={<Message content={sharedMessages.secondsAbbreviated} />}
+                tooltipId={tooltipIds.RX1_DELAY}
+                component={Input}
+                min={1}
+                max={15}
+                inputWidth="xs"
+                fieldWidth="xs"
+              />
+            )}
           </Form.FieldContainer>
           <Form.FieldContainer horizontal>
             {!isOTAA && (
@@ -228,17 +230,19 @@ const MacSettingsSection = props => {
                 tooltipId={tooltipIds.DATA_RATE_OFFSET}
               />
             )}
-            <Form.Field
-              title={m.desiredRx1DataRateOffsetTitle}
-              type="number"
-              inputWidth="xxs"
-              fieldWidth="xs"
-              name="mac_settings.desired_rx1_data_rate_offset"
-              component={Input}
-              min={0}
-              max={7}
-              tooltipId={tooltipIds.DATA_RATE_OFFSET}
-            />
+            {!isMulticast && (
+              <Form.Field
+                title={m.desiredRx1DataRateOffsetTitle}
+                type="number"
+                inputWidth="xxs"
+                fieldWidth="xs"
+                name="mac_settings.desired_rx1_data_rate_offset"
+                component={Input}
+                min={0}
+                max={7}
+                tooltipId={tooltipIds.DATA_RATE_OFFSET}
+              />
+            )}
           </Form.FieldContainer>
           {!isOTAA && (
             <Form.Field
@@ -266,17 +270,19 @@ const MacSettingsSection = props => {
             fieldWidth="xs"
           />
         )}
-        <Form.Field
-          title={m.desiredRx2DataRateIndexTitle}
-          type="number"
-          name="mac_settings.desired_rx2_data_rate_index"
-          component={Input}
-          min={0}
-          max={15}
-          inputWidth="xxs"
-          tooltipId={tooltipIds.RX2_DATA_RATE_INDEX}
-          fieldWidth="xs"
-        />
+        {!isMulticast && (
+          <Form.Field
+            title={m.desiredRx2DataRateIndexTitle}
+            type="number"
+            name="mac_settings.desired_rx2_data_rate_index"
+            component={Input}
+            min={0}
+            max={15}
+            inputWidth="xxs"
+            tooltipId={tooltipIds.RX2_DATA_RATE_INDEX}
+            fieldWidth="xs"
+          />
+        )}
       </Form.FieldContainer>
       <Form.FieldContainer horizontal>
         {!isOTAA && (
@@ -291,16 +297,18 @@ const MacSettingsSection = props => {
             fieldWidth="xs"
           />
         )}
-        <Form.Field
-          type="number"
-          min={100000}
-          step={100}
-          title={m.desiredRx2FrequencyTitle}
-          name="mac_settings.desired_rx2_frequency"
-          component={UnitInput.Hertz}
-          tooltipId={tooltipIds.RX2_FREQUENCY}
-          fieldWidth="xs"
-        />
+        {!isMulticast && (
+          <Form.Field
+            type="number"
+            min={100000}
+            step={100}
+            title={m.desiredRx2FrequencyTitle}
+            name="mac_settings.desired_rx2_frequency"
+            component={UnitInput.Hertz}
+            tooltipId={tooltipIds.RX2_FREQUENCY}
+            fieldWidth="xs"
+          />
+        )}
       </Form.FieldContainer>
       <Form.FieldContainer horizontal>
         {!isOTAA && (
@@ -313,14 +321,16 @@ const MacSettingsSection = props => {
             tooltipId={tooltipIds.MAX_DUTY_CYCLE}
           />
         )}
-        <Form.Field
-          title={m.desiredMaxDutyCycle}
-          name="mac_settings.desired_max_duty_cycle"
-          component={Select}
-          options={maxDutyCycleOptions}
-          fieldWidth="xs"
-          tooltipId={tooltipIds.MAX_DUTY_CYCLE}
-        />
+        {!isMulticast && (
+          <Form.Field
+            title={m.desiredMaxDutyCycle}
+            name="mac_settings.desired_max_duty_cycle"
+            component={Select}
+            options={maxDutyCycleOptions}
+            fieldWidth="xs"
+            tooltipId={tooltipIds.MAX_DUTY_CYCLE}
+          />
+        )}
       </Form.FieldContainer>
       <Form.Field
         indexAsKey
@@ -377,16 +387,18 @@ const MacSettingsSection = props => {
                 fieldWidth="xs"
               />
             )}
-            <Form.Field
-              type="number"
-              min={100000}
-              title={m.desiredBeaconFrequency}
-              placeholder={m.frequencyPlaceholder}
-              name="mac_settings.desired_beacon_frequency"
-              tooltipId={tooltipIds.BEACON_FREQUENCY}
-              component={UnitInput.Hertz}
-              fieldWidth="xs"
-            />
+            {!isMulticast && (
+              <Form.Field
+                type="number"
+                min={100000}
+                title={m.desiredBeaconFrequency}
+                placeholder={m.frequencyPlaceholder}
+                name="mac_settings.desired_beacon_frequency"
+                tooltipId={tooltipIds.BEACON_FREQUENCY}
+                component={UnitInput.Hertz}
+                fieldWidth="xs"
+              />
+            )}
           </Form.FieldContainer>
           <Form.FieldContainer horizontal>
             {!isOTAA && (
@@ -402,17 +414,19 @@ const MacSettingsSection = props => {
                 fieldWidth="xs"
               />
             )}
-            <Form.Field
-              type="number"
-              min={100000}
-              step={100}
-              title={m.desiredPingSlotFrequencyTitle}
-              placeholder={m.frequencyPlaceholder}
-              name="mac_settings.desired_ping_slot_frequency"
-              tooltipId={tooltipIds.PING_SLOT_FREQUENCY}
-              component={UnitInput.Hertz}
-              fieldWidth="xs"
-            />
+            {!isMulticast && (
+              <Form.Field
+                type="number"
+                min={100000}
+                step={100}
+                title={m.desiredPingSlotFrequencyTitle}
+                placeholder={m.frequencyPlaceholder}
+                name="mac_settings.desired_ping_slot_frequency"
+                tooltipId={tooltipIds.PING_SLOT_FREQUENCY}
+                component={UnitInput.Hertz}
+                fieldWidth="xs"
+              />
+            )}
           </Form.FieldContainer>
           <Form.FieldContainer horizontal>
             {!isOTAA && (
@@ -428,17 +442,19 @@ const MacSettingsSection = props => {
                 max={15}
               />
             )}
-            <Form.Field
-              title={m.desiredPingSlotDataRateTitle}
-              name="mac_settings.desired_ping_slot_data_rate_index"
-              tooltipId={tooltipIds.PING_SLOT_DATA_RATE_INDEX}
-              component={Input}
-              type="number"
-              fieldWidth="xs"
-              inputWidth="xxs"
-              min={0}
-              max={15}
-            />
+            {!isMulticast && (
+              <Form.Field
+                title={m.desiredPingSlotDataRateTitle}
+                name="mac_settings.desired_ping_slot_data_rate_index"
+                tooltipId={tooltipIds.PING_SLOT_DATA_RATE_INDEX}
+                component={Input}
+                type="number"
+                fieldWidth="xs"
+                inputWidth="xxs"
+                min={0}
+                max={15}
+              />
+            )}
           </Form.FieldContainer>
         </>
       )}
@@ -513,7 +529,7 @@ const MacSettingsSection = props => {
           />
         </>
       )}
-      {isNewLorawanVersion && (
+      {isNewLorawanVersion && !isMulticast && (
         <>
           <Form.Field
             title={m.desiredAdrAckLimit}

--- a/pkg/webui/console/containers/device-onboarding-form/type-form-section/manual-form-section/validation-schema.js
+++ b/pkg/webui/console/containers/device-onboarding-form/type-form-section/manual-form-section/validation-schema.js
@@ -17,6 +17,8 @@ import { isUndefined } from 'lodash'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import Yup from '@ttn-lw/lib/yup'
 
+import { dynamicFrequencyTest } from '@console/lib/device-utils'
+
 // Validation schemas of the device type manual form section.
 // Please observe the following rules to keep the validation schemas maintainable:
 // 1. DO NOT USE ANY TYPE CONVERSIONS HERE. Use decocer/encoder on field level instead.
@@ -35,8 +37,6 @@ const factoryPresetFreqNumericTest = frequencies =>
 
     return true
   })
-
-const dynamicFrequencyTest = value => value === 0 || value >= 100000
 
 const advancedSettingsSchema = Yup.object({
   supports_class_b: Yup.boolean().required(sharedMessages.validateRequired),

--- a/pkg/webui/console/lib/device-utils.js
+++ b/pkg/webui/console/lib/device-utils.js
@@ -177,3 +177,9 @@ const ALL_ZERO_KEY = '0'.repeat(32)
  * @returns {boolean} - `true` if the key is non-zero, `false` otherwise.
  */
 export const isNonZeroSessionKey = key => key !== ALL_ZERO_KEY
+
+/**
+ * @param {string} value - The frequency value.
+ * @returns {boolean} - True if the frequency value is valid, false otherwise.
+ */
+export const dynamicFrequencyTest = value => value === 0 || value >= 100000


### PR DESCRIPTION
#### Summary
Fixes #5893

#### Changes
<!-- What are the changes made in this pull request? -->

- Allow setting `0` as a frequency value for ping slot and beacon frequency (meaning dynamic frequency)
- Hide desired MAC fields when using multicast end devices


#### Testing

Manual testing.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
