### PR TITLE
Fix webhook health status

### DIFF
--- a/pkg/webui/console/components/webhook-form/index.js
+++ b/pkg/webui/console/components/webhook-form/index.js
@@ -240,6 +240,7 @@ export default class WebhookForm extends Component {
   static propTypes = {
     error: PropTypes.error,
     existCheck: PropTypes.func,
+    hasUnhealthyWebhookConfig: PropTypes.bool,
     healthStatusEnabled: PropTypes.bool,
     initialWebhookValue: PropTypes.shape({
       ids: PropTypes.shape({
@@ -252,7 +253,6 @@ export default class WebhookForm extends Component {
         Authorization: PropTypes.string,
       }),
     }),
-    isUnhealthyWebhook: PropTypes.bool,
     onDelete: PropTypes.func,
     onDeleteFailure: PropTypes.func,
     onDeleteSuccess: PropTypes.func,
@@ -276,7 +276,7 @@ export default class WebhookForm extends Component {
     error: undefined,
     existCheck: () => null,
     webhookRetryInterval: null,
-    isUnhealthyWebhook: false,
+    hasUnhealthyWebhookConfig: false,
   }
 
   form = React.createRef()
@@ -376,7 +376,7 @@ export default class WebhookForm extends Component {
       webhookTemplate,
       healthStatusEnabled,
       webhookRetryInterval,
-      isUnhealthyWebhook,
+      hasUnhealthyWebhookConfig,
       error,
     } = this.props
 
@@ -391,7 +391,11 @@ export default class WebhookForm extends Component {
 
     const hasTemplate = Boolean(webhookTemplate)
 
-    const mayReactivate = update && initialWebhookValue && isUnhealthyWebhook
+    const mayReactivate =
+      update &&
+      initialWebhookValue &&
+      hasUnhealthyWebhookConfig &&
+      !('healthy' in initialWebhookValue.health_status)
 
     const isPending =
       healthStatusEnabled &&

--- a/pkg/webui/console/containers/webhook-edit/webhook-edit.js
+++ b/pkg/webui/console/containers/webhook-edit/webhook-edit.js
@@ -41,7 +41,7 @@ const WebhookEdit = props => {
     healthStatusEnabled,
     webhookId,
     updateHealthStatus,
-    isUnhealthyWebhook,
+    hasUnhealthyWebhookConfig,
     webhookRetryInterval,
   } = props
 
@@ -122,7 +122,7 @@ const WebhookEdit = props => {
       onReactivateSuccess={handleReactivateSuccess}
       healthStatusEnabled={healthStatusEnabled}
       webhookRetryInterval={webhookRetryInterval}
-      isUnhealthyWebhook={isUnhealthyWebhook}
+      hasUnhealthyWebhookConfig={hasUnhealthyWebhookConfig}
       error={error}
     />
   )
@@ -130,8 +130,8 @@ const WebhookEdit = props => {
 
 WebhookEdit.propTypes = {
   appId: PropTypes.string.isRequired,
+  hasUnhealthyWebhookConfig: PropTypes.bool.isRequired,
   healthStatusEnabled: PropTypes.bool.isRequired,
-  isUnhealthyWebhook: PropTypes.bool.isRequired,
   navigateToList: PropTypes.func.isRequired,
   selectedWebhook: PropTypes.webhook.isRequired,
   updateHealthStatus: PropTypes.func.isRequired,

--- a/pkg/webui/console/store/selectors/application-server.js
+++ b/pkg/webui/console/store/selectors/application-server.js
@@ -46,7 +46,7 @@ export const selectWebhooksHealthStatusEnabled = state => {
   )
 }
 
-export const selectIsWebhookUnhealthy = state => {
+export const selectWebhookHasUnhealthyConfig = state => {
   const webhooksConfig = selectWebhooksConfiguration(state)
 
   if (!webhooksConfig) {

--- a/pkg/webui/console/views/application-integrations-webhook-edit/application-integrations-webhook-edit.js
+++ b/pkg/webui/console/views/application-integrations-webhook-edit/application-integrations-webhook-edit.js
@@ -40,7 +40,7 @@ const ApplicationWebhookEdit = props => {
     match,
     healthStatusEnabled,
     webhookRetryInterval,
-    isUnhealthyWebhook,
+    hasUnhealthyWebhookConfig,
   } = props
   const { webhookId } = match.params
   useBreadcrumbs(
@@ -64,7 +64,7 @@ const ApplicationWebhookEdit = props => {
             webhookTemplate={webhookTemplate}
             healthStatusEnabled={healthStatusEnabled}
             webhookRetryInterval={webhookRetryInterval}
-            isUnhealthyWebhook={isUnhealthyWebhook}
+            hasUnhealthyWebhookConfig={hasUnhealthyWebhookConfig}
           />
         </Col>
       </Row>
@@ -74,8 +74,8 @@ const ApplicationWebhookEdit = props => {
 
 ApplicationWebhookEdit.propTypes = {
   appId: PropTypes.string.isRequired,
+  hasUnhealthyWebhookConfig: PropTypes.bool.isRequired,
   healthStatusEnabled: PropTypes.bool.isRequired,
-  isUnhealthyWebhook: PropTypes.bool.isRequired,
   match: PropTypes.match.isRequired,
   webhook: PropTypes.webhook.isRequired,
   webhookRetryInterval: PropTypes.string,

--- a/pkg/webui/console/views/application-integrations-webhook-edit/connect.js
+++ b/pkg/webui/console/views/application-integrations-webhook-edit/connect.js
@@ -30,7 +30,7 @@ import { selectSelectedApplicationId } from '@console/store/selectors/applicatio
 import {
   selectWebhooksHealthStatusEnabled,
   selectWebhookRetryInterval,
-  selectIsWebhookUnhealthy,
+  selectWebhookHasUnhealthyConfig,
 } from '@console/store/selectors/application-server'
 
 const webhookEntitySelector = [
@@ -57,7 +57,7 @@ const webhookEntitySelector = [
 const mapStateToProps = state => {
   const healthStatusEnabled = selectWebhooksHealthStatusEnabled(state)
   const webhookRetryInterval = selectWebhookRetryInterval(state)
-  const isUnhealthyWebhook = selectIsWebhookUnhealthy(state)
+  const hasUnhealthyWebhookConfig = selectWebhookHasUnhealthyConfig(state)
   const webhook = selectSelectedWebhook(state)
   const webhookTemplateId = getWebhookTemplateId(webhook)
   const webhookTemplate = Boolean(webhookTemplateId)
@@ -69,7 +69,7 @@ const mapStateToProps = state => {
     webhookTemplate,
     healthStatusEnabled,
     webhookRetryInterval,
-    isUnhealthyWebhook,
+    hasUnhealthyWebhookConfig,
     fetching: selectWebhookFetching(state),
     error: selectWebhookError(state),
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the condition which determined that shows a reactivation warning.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a check for the presence of `health_status.healthy`  before showing the warning.
- Rename variable and selector for better understanding.


#### Testing

<!-- How did you verify that this change works? -->

manually


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Apparently the Console was showing the `reactivate` notification, even if the webhook was healthy, because it assumed that having the Webhook Config with valid values for `unhealthy-attempts-threshold` and `unhealthy-retry-interval` meant that the webhook is unhealthy. However, that is not the case. What determines the health of a webhook is the `health_status`. The AS Config has mere info about when the Application Server would retry a failing webhook.

References: #5896  [#4526 (comment)](https://github.com/TheThingsNetwork/lorawan-stack/issues/4526#issuecomment-988697068)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
