### PR TITLE
Add proto unimplemented to GRPC Servers

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -60,6 +60,9 @@ import (
 //
 // The Application Server exposes the As, AppAs and AsEndDeviceRegistry services.
 type ApplicationServer struct {
+	ttnpb.UnimplementedAsServer
+	ttnpb.UnimplementedNsAsServer
+
 	*component.Component
 	ctx context.Context
 

--- a/pkg/applicationserver/grpc_deviceregistry.go
+++ b/pkg/applicationserver/grpc_deviceregistry.go
@@ -56,6 +56,8 @@ var (
 )
 
 type asEndDeviceRegistryServer struct {
+	ttnpb.UnimplementedAsEndDeviceRegistryServer
+
 	AS       *ApplicationServer
 	kekLabel string
 }

--- a/pkg/applicationserver/io/grpc/grpc.go
+++ b/pkg/applicationserver/io/grpc/grpc.go
@@ -60,6 +60,8 @@ func (p *defaultMessageProcessor) DecodeDownlink(ctx context.Context, ids *ttnpb
 type SkipPayloadCryptoFunc func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers) (bool, error)
 
 type impl struct {
+	ttnpb.UnimplementedAppAsServer
+
 	server             io.Server
 	getIdentifiers     GetEndDeviceIdentifiersFunc
 	mqttConfigProvider config.MQTTConfigProvider

--- a/pkg/applicationserver/io/packages/packages.go
+++ b/pkg/applicationserver/io/packages/packages.go
@@ -32,6 +32,8 @@ import (
 const namespace = "applicationserver/io/packages"
 
 type server struct {
+	ttnpb.UnimplementedApplicationPackageRegistryServer
+
 	ctx context.Context
 
 	server   io.Server

--- a/pkg/applicationserver/io/pubsub/pubsub.go
+++ b/pkg/applicationserver/io/pubsub/pubsub.go
@@ -34,7 +34,7 @@ import (
 
 // PubSub is an pub/sub frontend that exposes ttnpb.ApplicationPubSubRegistryServer.
 type PubSub struct {
-	ttnpb.ApplicationPubSubRegistryServer
+	ttnpb.UnimplementedApplicationPubSubRegistryServer
 
 	*component.Component
 	ctx      context.Context

--- a/pkg/applicationserver/io/web/grpc_webhooks.go
+++ b/pkg/applicationserver/io/web/grpc_webhooks.go
@@ -38,6 +38,8 @@ func appendImplicitWebhookGetPaths(paths ...string) []string {
 }
 
 type webhookRegistryRPC struct {
+	ttnpb.UnimplementedApplicationWebhookRegistryServer
+
 	webhooks  WebhookRegistry
 	templates TemplateStore
 }

--- a/pkg/applicationserver/util_test.go
+++ b/pkg/applicationserver/util_test.go
@@ -60,6 +60,8 @@ func withDevAddr(ids *ttnpb.EndDeviceIdentifiers, devAddr types.DevAddr) *ttnpb.
 }
 
 type mockNS struct {
+	ttnpb.UnimplementedAsNsServer
+
 	linkCh          chan ttnpb.ApplicationIdentifiers
 	unlinkCh        chan ttnpb.ApplicationIdentifiers
 	upCh            chan *ttnpb.ApplicationUp
@@ -151,6 +153,8 @@ func (ns *mockNS) DownlinkQueueList(ctx context.Context, ids *ttnpb.EndDeviceIde
 var errNotFound = errors.DefineNotFound("not_found", "not found")
 
 type mockJS struct {
+	ttnpb.UnimplementedAsJsServer
+
 	keys map[string]*ttnpb.KeyEnvelope
 }
 

--- a/pkg/auth/rights/fetcher_test.go
+++ b/pkg/auth/rights/fetcher_test.go
@@ -74,32 +74,32 @@ func fetchAuthInfo(ctx context.Context, f AuthInfoFetcher) (*ttnpb.AuthInfoRespo
 }
 
 type mockEntityAccessServer struct {
-	ttnpb.EntityAccessServer
+	ttnpb.UnimplementedEntityAccessServer
 	*mockFetcher
 }
 
 type mockApplicationAccessServer struct {
-	ttnpb.ApplicationAccessServer
+	ttnpb.UnimplementedApplicationAccessServer
 	*mockFetcher
 }
 
 type mockClientAccessServer struct {
-	ttnpb.ClientAccessServer
+	ttnpb.UnimplementedClientAccessServer
 	*mockFetcher
 }
 
 type mockGatewayAccessServer struct {
-	ttnpb.GatewayAccessServer
+	ttnpb.UnimplementedGatewayAccessServer
 	*mockFetcher
 }
 
 type mockOrganizationAccessServer struct {
-	ttnpb.OrganizationAccessServer
+	ttnpb.UnimplementedOrganizationAccessServer
 	*mockFetcher
 }
 
 type mockUserAccessServer struct {
-	ttnpb.UserAccessServer
+	ttnpb.UnimplementedUserAccessServer
 	*mockFetcher
 }
 

--- a/pkg/component/configuration_grpc.go
+++ b/pkg/component/configuration_grpc.go
@@ -31,6 +31,8 @@ func NewConfigurationServer(c *Component) *ConfigurationServer {
 
 // ConfigurationServer implements the Configuration RPC service.
 type ConfigurationServer struct {
+	ttnpb.UnimplementedConfigurationServer
+
 	component *Component
 }
 

--- a/pkg/component/grpc_test.go
+++ b/pkg/component/grpc_test.go
@@ -40,9 +40,9 @@ var (
 )
 
 type asImplementation struct {
-	*component.Component
 	ttnpb.UnimplementedAppAsServer
 
+	*component.Component
 	up chan *ttnpb.ApplicationUp
 }
 
@@ -61,6 +61,8 @@ func (as *asImplementation) Subscribe(id *ttnpb.ApplicationIdentifiers, stream t
 }
 
 type gsImplementation struct {
+	ttnpb.UnimplementedGsServer
+
 	*component.Component
 }
 

--- a/pkg/crypto/cryptoservices/cryptoservices_test.go
+++ b/pkg/crypto/cryptoservices/cryptoservices_test.go
@@ -52,8 +52,8 @@ func TestCryptoServices(t *testing.T) {
 	}
 	defer lis.Close()
 	s := grpc.NewServer()
-	ttnpb.RegisterNetworkCryptoServiceServer(s, &mockNetworkRPCServer{memSvc, keyVault})
-	ttnpb.RegisterApplicationCryptoServiceServer(s, &mockApplicationRPCServer{memSvc, keyVault})
+	ttnpb.RegisterNetworkCryptoServiceServer(s, &mockNetworkRPCServer{Network: memSvc, KeyVault: keyVault})
+	ttnpb.RegisterApplicationCryptoServiceServer(s, &mockApplicationRPCServer{Application: memSvc, 	KeyVault: keyVault})
 	go s.Serve(lis)
 	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
@@ -372,6 +372,8 @@ func TestCryptoServices(t *testing.T) {
 }
 
 type mockNetworkRPCServer struct {
+	ttnpb.UnimplementedNetworkCryptoServiceServer
+
 	Network Network
 	crypto.KeyVault
 }
@@ -471,6 +473,8 @@ func (s *mockNetworkRPCServer) GetNwkKey(ctx context.Context, req *ttnpb.GetRoot
 }
 
 type mockApplicationRPCServer struct {
+	ttnpb.UnimplementedApplicationCryptoServiceServer
+
 	Application Application
 	crypto.KeyVault
 }

--- a/pkg/crypto/cryptoservices/cryptoservices_test.go
+++ b/pkg/crypto/cryptoservices/cryptoservices_test.go
@@ -53,7 +53,7 @@ func TestCryptoServices(t *testing.T) {
 	defer lis.Close()
 	s := grpc.NewServer()
 	ttnpb.RegisterNetworkCryptoServiceServer(s, &mockNetworkRPCServer{Network: memSvc, KeyVault: keyVault})
-	ttnpb.RegisterApplicationCryptoServiceServer(s, &mockApplicationRPCServer{Application: memSvc, 	KeyVault: keyVault})
+	ttnpb.RegisterApplicationCryptoServiceServer(s, &mockApplicationRPCServer{Application: memSvc, KeyVault: keyVault})
 	go s.Serve(lis)
 	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {

--- a/pkg/deviceclaimingserver/grpc_end_devices.go
+++ b/pkg/deviceclaimingserver/grpc_end_devices.go
@@ -87,6 +87,8 @@ func (noopEDCS) UnauthorizeApplication(ctx context.Context, ids *ttnpb.Applicati
 
 // endDeviceClaimingServer is the front facing entity for gRPC requests.
 type endDeviceClaimingServer struct {
+	ttnpb.UnimplementedEndDeviceClaimingServerServer
+
 	DCS *DeviceClaimingServer
 }
 

--- a/pkg/deviceclaimingserver/grpc_gateways.go
+++ b/pkg/deviceclaimingserver/grpc_gateways.go
@@ -41,6 +41,8 @@ func (noopGCLS) UnauthorizeGateway(ctx context.Context, gtwIDs *ttnpb.GatewayIde
 
 // gatewayClaimingServer is the front facing entity for gRPC requests.
 type gatewayClaimingServer struct {
+	ttnpb.UnimplementedGatewayClaimingServerServer
+
 	DCS *DeviceClaimingServer
 }
 

--- a/pkg/devicerepository/devicerepository.go
+++ b/pkg/devicerepository/devicerepository.go
@@ -32,6 +32,8 @@ import (
 //
 // The Device Repository component exposes the DeviceRepository service.
 type DeviceRepository struct {
+	ttnpb.UnimplementedDeviceRepositoryServer
+
 	*component.Component
 	ctx context.Context
 

--- a/pkg/devicetemplateconverter/grpc.go
+++ b/pkg/devicetemplateconverter/grpc.go
@@ -26,6 +26,8 @@ import (
 )
 
 type endDeviceTemplateConverterServer struct {
+	ttnpb.EndDeviceTemplateConverterServer
+
 	DTC *DeviceTemplateConverter
 }
 

--- a/pkg/devicetemplateconverter/grpc.go
+++ b/pkg/devicetemplateconverter/grpc.go
@@ -26,7 +26,7 @@ import (
 )
 
 type endDeviceTemplateConverterServer struct {
-	ttnpb.EndDeviceTemplateConverterServer
+	ttnpb.UnimplementedEndDeviceTemplateConverterServer
 
 	DTC *DeviceTemplateConverter
 }

--- a/pkg/events/grpc/grpc.go
+++ b/pkg/events/grpc/grpc.go
@@ -57,6 +57,8 @@ func NewEventsServer(ctx context.Context, pubsub events.PubSub) *EventsServer {
 
 // EventsServer streams events from a PubSub over gRPC.
 type EventsServer struct {
+	ttnpb.UnimplementedEventsServer
+
 	ctx          context.Context
 	pubsub       events.PubSub
 	definedNames map[string]struct{}

--- a/pkg/gatewayconfigurationserver/server.go
+++ b/pkg/gatewayconfigurationserver/server.go
@@ -26,6 +26,8 @@ import (
 
 // Server implements the Gateway Configuration Server component.
 type Server struct {
+	ttnpb.UnimplementedGatewayConfigurationServiceServer
+
 	*component.Component
 	config *Config
 }

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -62,6 +62,9 @@ import (
 //
 // The Gateway Server exposes the Gs, GtwGs and NsGs services and MQTT and UDP frontends for gateways.
 type GatewayServer struct {
+	ttnpb.UnimplementedGsServer
+	ttnpb.UnimplementedNsGsServer
+
 	*component.Component
 	ctx context.Context
 

--- a/pkg/gatewayserver/io/grpc/grpc.go
+++ b/pkg/gatewayserver/io/grpc/grpc.go
@@ -59,6 +59,8 @@ func WithMQTTV2ConfigProvider(provider config.MQTTConfigProvider) Option {
 }
 
 type impl struct {
+	ttnpb.UnimplementedGtwGsServer
+
 	server               io.Server
 	mqttConfigProvider   config.MQTTConfigProvider
 	mqttv2ConfigProvider config.MQTTConfigProvider

--- a/pkg/gatewayserver/upstream/mock/network_server.go
+++ b/pkg/gatewayserver/upstream/mock/network_server.go
@@ -26,6 +26,8 @@ import (
 
 // NS is a mock NS for GS tests.
 type NS struct {
+	ttnpb.UnimplementedGsNsServer
+
 	upCh    chan *ttnpb.UplinkMessage
 	txAckCh chan *ttnpb.GatewayTxAcknowledgment
 }

--- a/pkg/identityserver/application_access.go
+++ b/pkg/identityserver/application_access.go
@@ -362,6 +362,8 @@ func (is *IdentityServer) listApplicationCollaborators(ctx context.Context, req 
 }
 
 type applicationAccess struct {
+	ttnpb.UnimplementedApplicationAccessServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/application_registry.go
+++ b/pkg/identityserver/application_registry.go
@@ -409,6 +409,8 @@ func (is *IdentityServer) issueDevEUI(ctx context.Context, ids *ttnpb.Applicatio
 }
 
 type applicationRegistry struct {
+	ttnpb.UnimplementedApplicationRegistryServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/client_access.go
+++ b/pkg/identityserver/client_access.go
@@ -222,6 +222,8 @@ func (is *IdentityServer) listClientCollaborators(
 }
 
 type clientAccess struct {
+	ttnpb.UnimplementedClientAccessServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/client_registry.go
+++ b/pkg/identityserver/client_registry.go
@@ -440,6 +440,8 @@ func (is *IdentityServer) purgeClient(ctx context.Context, ids *ttnpb.ClientIden
 }
 
 type clientRegistry struct {
+	ttnpb.UnimplementedClientRegistryServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/contact_info_registry.go
+++ b/pkg/identityserver/contact_info_registry.go
@@ -162,6 +162,8 @@ func (is *IdentityServer) validateContactInfo(ctx context.Context, req *ttnpb.Co
 }
 
 type contactInfoRegistry struct {
+	ttnpb.UnimplementedContactInfoRegistryServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/end_device_registry.go
+++ b/pkg/identityserver/end_device_registry.go
@@ -454,6 +454,8 @@ func validateEndDeviceAuthenticationCode(authCode ttnpb.EndDeviceAuthenticationC
 }
 
 type endDeviceRegistry struct {
+	ttnpb.UnimplementedEndDeviceRegistryServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/entity_access.go
+++ b/pkg/identityserver/entity_access.go
@@ -430,6 +430,8 @@ func restrictRights(info *ttnpb.AuthInfoResponse, rights *ttnpb.Rights) {
 }
 
 type entityAccess struct {
+	ttnpb.UnimplementedEntityAccessServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/gateway_access.go
+++ b/pkg/identityserver/gateway_access.go
@@ -356,6 +356,8 @@ func (is *IdentityServer) listGatewayCollaborators(ctx context.Context, req *ttn
 }
 
 type gatewayAccess struct {
+	ttnpb.UnimplementedGatewayAccessServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/gateway_registry.go
+++ b/pkg/identityserver/gateway_registry.go
@@ -677,6 +677,8 @@ func validateClaimAuthenticationCode(authCode *ttnpb.GatewayClaimAuthenticationC
 }
 
 type gatewayRegistry struct {
+	ttnpb.UnimplementedGatewayRegistryServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -46,6 +46,8 @@ import (
 // The Identity Server exposes the Registry and Access services for Applications,
 // OAuth clients, Gateways, Organizations and Users.
 type IdentityServer struct {
+	ttnpb.UnimplementedIsServer
+
 	*component.Component
 	ctx    context.Context
 	config *Config

--- a/pkg/identityserver/invitation_registry.go
+++ b/pkg/identityserver/invitation_registry.go
@@ -122,6 +122,8 @@ func (is *IdentityServer) deleteInvitation(ctx context.Context, in *ttnpb.Delete
 }
 
 type invitationRegistry struct {
+	ttnpb.UnimplementedUserInvitationRegistryServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/mock/application_registry.go
+++ b/pkg/identityserver/mock/application_registry.go
@@ -25,8 +25,8 @@ import (
 )
 
 type mockISApplicationRegistry struct {
-	ttnpb.ApplicationRegistryServer
-	ttnpb.ApplicationAccessServer
+	ttnpb.UnimplementedApplicationRegistryServer
+	ttnpb.UnimplementedApplicationAccessServer
 
 	applications      map[string]*ttnpb.Application
 	applicationAuths  map[string][]string

--- a/pkg/identityserver/mock/device_registry.go
+++ b/pkg/identityserver/mock/device_registry.go
@@ -26,7 +26,7 @@ import (
 var errFetchDevice = errors.DefineInternal("fetch_device", "failed to fetch device")
 
 type mockISEndDeviceRegistry struct {
-	ttnpb.EndDeviceRegistryServer
+	ttnpb.UnimplementedEndDeviceRegistryServer
 	endDevices sync.Map
 }
 

--- a/pkg/identityserver/mock/entity_access.go
+++ b/pkg/identityserver/mock/entity_access.go
@@ -22,6 +22,8 @@ import (
 )
 
 type mockEntityAccess struct {
+	ttnpb.UnimplementedEntityAccessServer
+
 	authInfoResponse *ttnpb.AuthInfoResponse
 	err              error
 }

--- a/pkg/identityserver/mock/gateway_registry.go
+++ b/pkg/identityserver/mock/gateway_registry.go
@@ -50,8 +50,8 @@ func DefaultGateway(ids *ttnpb.GatewayIdentifiers, locationPublic, updateLocatio
 }
 
 type mockISGatewayRegistry struct {
-	ttnpb.GatewayRegistryServer
-	ttnpb.GatewayAccessServer
+	ttnpb.UnimplementedGatewayRegistryServer
+	ttnpb.UnimplementedGatewayAccessServer
 	gateways      map[string]*ttnpb.Gateway
 	gatewayAuths  map[string][]string
 	gatewayRights map[string]authKeyToRights

--- a/pkg/identityserver/notification_registry.go
+++ b/pkg/identityserver/notification_registry.go
@@ -305,6 +305,8 @@ func (is *IdentityServer) updateNotificationStatus(ctx context.Context, req *ttn
 }
 
 type notificationRegistry struct {
+	ttnpb.UnimplementedNotificationServiceServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/oauth_registry.go
+++ b/pkg/identityserver/oauth_registry.go
@@ -125,6 +125,8 @@ func (is *IdentityServer) deleteOAuthAccessToken(ctx context.Context, req *ttnpb
 }
 
 type oauthRegistry struct {
+	ttnpb.UnimplementedOAuthAuthorizationRegistryServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/organization_access.go
+++ b/pkg/identityserver/organization_access.go
@@ -360,6 +360,8 @@ func (is *IdentityServer) listOrganizationCollaborators(ctx context.Context, req
 }
 
 type organizationAccess struct {
+	ttnpb.UnimplementedOrganizationAccessServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/organization_registry.go
+++ b/pkg/identityserver/organization_registry.go
@@ -340,6 +340,8 @@ func (is *IdentityServer) purgeOrganization(ctx context.Context, ids *ttnpb.Orga
 }
 
 type organizationRegistry struct {
+	ttnpb.UnimplementedOrganizationRegistryServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/registry_search.go
+++ b/pkg/identityserver/registry_search.go
@@ -24,6 +24,9 @@ import (
 )
 
 type registrySearch struct {
+	ttnpb.UnimplementedEntityRegistrySearchServer
+	ttnpb.UnimplementedEndDeviceRegistrySearchServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/user_access.go
+++ b/pkg/identityserver/user_access.go
@@ -267,6 +267,8 @@ func (is *IdentityServer) createLoginToken(ctx context.Context, req *ttnpb.Creat
 }
 
 type userAccess struct {
+	ttnpb.UnimplementedUserAccessServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/user_registry.go
+++ b/pkg/identityserver/user_registry.go
@@ -768,6 +768,8 @@ func (is *IdentityServer) purgeUser(ctx context.Context, ids *ttnpb.UserIdentifi
 }
 
 type userRegistry struct {
+	ttnpb.UnimplementedUserRegistryServer
+
 	*IdentityServer
 }
 

--- a/pkg/identityserver/user_session_registry.go
+++ b/pkg/identityserver/user_session_registry.go
@@ -67,6 +67,8 @@ func (is *IdentityServer) deleteUserSession(ctx context.Context, req *ttnpb.User
 }
 
 type userSessionRegistry struct {
+	ttnpb.UnimplementedUserSessionRegistryServer
+
 	*IdentityServer
 }
 

--- a/pkg/joinserver/grpc.go
+++ b/pkg/joinserver/grpc.go
@@ -22,6 +22,8 @@ import (
 )
 
 type jsServer struct {
+	ttnpb.UnimplementedJsServer
+
 	JS *JoinServer
 }
 

--- a/pkg/joinserver/grpc_appjs.go
+++ b/pkg/joinserver/grpc_appjs.go
@@ -21,6 +21,8 @@ import (
 )
 
 type appJsServer struct {
+	ttnpb.UnimplementedAppJsServer
+
 	JS *JoinServer
 }
 

--- a/pkg/joinserver/grpc_application_activation_settings_registry.go
+++ b/pkg/joinserver/grpc_application_activation_settings_registry.go
@@ -26,6 +26,8 @@ import (
 )
 
 type applicationActivationSettingsRegistryServer struct {
+	ttnpb.UnimplementedApplicationActivationSettingRegistryServer
+
 	JS       *JoinServer
 	kekLabel string
 }

--- a/pkg/joinserver/grpc_asjs.go
+++ b/pkg/joinserver/grpc_asjs.go
@@ -21,6 +21,8 @@ import (
 )
 
 type asJsServer struct {
+	ttnpb.UnimplementedAsJsServer
+
 	JS *JoinServer
 }
 

--- a/pkg/joinserver/grpc_deviceregistry.go
+++ b/pkg/joinserver/grpc_deviceregistry.go
@@ -56,6 +56,8 @@ var (
 )
 
 type jsEndDeviceRegistryServer struct {
+	ttnpb.UnimplementedJsEndDeviceRegistryServer
+
 	JS       *JoinServer
 	kekLabel string
 }

--- a/pkg/joinserver/grpc_nsjs.go
+++ b/pkg/joinserver/grpc_nsjs.go
@@ -21,6 +21,8 @@ import (
 )
 
 type nsJsServer struct {
+	ttnpb.UnimplementedNsJsServer
+
 	JS *JoinServer
 }
 

--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -44,6 +44,8 @@ import (
 //
 // The Join Server exposes the NsJs, AsJs, AppJs and DeviceRegistry services.
 type JoinServer struct {
+	ttnpb.UnimplementedJsServer
+
 	*component.Component
 	ctx context.Context
 

--- a/pkg/messageprocessors/devicerepository/devicerepository_test.go
+++ b/pkg/messageprocessors/devicerepository/devicerepository_test.go
@@ -87,6 +87,8 @@ func (m mockProvider) GetPayloadEncoderDecoder(ctx context.Context, formatter tt
 }
 
 type mockDR struct {
+	ttnpb.UnimplementedDeviceRepositoryServer
+
 	uplinkDecoders,
 	downlinkDecoders map[string]*ttnpb.MessagePayloadDecoder
 	downlinkEncoders map[string]*ttnpb.MessagePayloadEncoder

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -113,6 +113,11 @@ type InteropClient interface {
 //
 // The Network Server exposes the GsNs, AsNs, DeviceRegistry and ApplicationDownlinkQueue services.
 type NetworkServer struct {
+	ttnpb.UnimplementedAsNsServer
+	ttnpb.UnimplementedGsNsServer
+	ttnpb.UnimplementedNsEndDeviceRegistryServer
+	ttnpb.UnimplementedNsServer
+
 	*component.Component
 	ctx context.Context
 

--- a/pkg/packetbrokeragent/mock/gatewayserver.go
+++ b/pkg/packetbrokeragent/mock/gatewayserver.go
@@ -25,6 +25,8 @@ import (
 
 // GatewayServer is a mock Gateway Server.
 type GatewayServer struct {
+	ttnpb.UnimplementedNsGsServer
+
 	*component.Component
 	Downlink chan *ttnpb.DownlinkMessage
 }

--- a/pkg/packetbrokeragent/mock/networkserver.go
+++ b/pkg/packetbrokeragent/mock/networkserver.go
@@ -26,6 +26,8 @@ import (
 
 // NetworkServer is a mock Network Server.
 type NetworkServer struct {
+	ttnpb.UnimplementedGsNsServer
+
 	*component.Component
 	Uplink chan *ttnpb.UplinkMessage
 	TxAck  chan *ttnpb.GatewayTxAcknowledgment

--- a/pkg/qrcodegenerator/grpc_end_devices.go
+++ b/pkg/qrcodegenerator/grpc_end_devices.go
@@ -27,6 +27,8 @@ import (
 var errUnauthenticated = errors.DefineUnauthenticated("unauthenticated", "call was not authenticated")
 
 type endDeviceQRCodeGeneratorServer struct {
+	ttnpb.UnimplementedEndDeviceQRCodeGeneratorServer
+
 	QRG *QRCodeGenerator
 }
 

--- a/pkg/rpcserver/rpcserver_test.go
+++ b/pkg/rpcserver/rpcserver_test.go
@@ -143,13 +143,16 @@ type (
 )
 
 type mockServer struct {
-	ttnpb.AppAsServer
+	ttnpb.UnimplementedAppAsServer
 
 	pushCtx context.Context
 	pushReq *ttnpb.DownlinkQueueRequest
 
 	subCtx context.Context
 	subIDs *ttnpb.ApplicationIdentifiers
+
+	decCtx context.Context
+	decReq *ttnpb.DecodeDownlinkRequest
 }
 
 func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {

--- a/pkg/rpcserver/rpcserver_test.go
+++ b/pkg/rpcserver/rpcserver_test.go
@@ -150,9 +150,6 @@ type mockServer struct {
 
 	subCtx context.Context
 	subIDs *ttnpb.ApplicationIdentifiers
-
-	decCtx context.Context
-	decReq *ttnpb.DecodeDownlinkRequest
 }
 
 func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {


### PR DESCRIPTION
#### Summary
This PR adds `ttnpb.Unimplemented<Server>` to RPC Servers

References #2798

#### Changes
<!-- What are the changes made in this pull request? -->
- Adds `ttnpb.Unimplemented<ServerName>` to every RPC Server used in a `ttnpb.Register<ServerName>Server()`


#### Testing
- Existing Unit Tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
