### PR TITLE
Fix csv import first column skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - When searching for end-devices, specifying `last_seen_at` as the field in which the devices will be sorted by no longer returns an error.
+- Importing devices via CSV no longer skips the first header column when BOM bytes are present.
 
 ### Security
 

--- a/pkg/devicetemplates/ttscsv.go
+++ b/pkg/devicetemplates/ttscsv.go
@@ -367,6 +367,18 @@ func (t *ttsCSV) Convert(ctx context.Context, r io.Reader, ch chan<- *ttnpb.EndD
 	comma := ';'
 	const maxHeaderLength = 1024
 	buf := bufio.NewReaderSize(r, maxHeaderLength)
+
+	// eliminate BOM if its present
+	ru, _, err := buf.ReadRune()
+	if err != nil {
+		return err
+	}
+	if ru != '\uFEFF' {
+		if err := buf.UnreadRune(); err != nil {
+			return err
+		}
+	}
+
 	if head, _ := buf.Peek(maxHeaderLength); len(head) > 0 {
 		if c, ok := determineComma(head); ok {
 			comma = c


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsIndustries/lorawan-stack-support/issues/892

Basically there were some cases where the CSV import would not consider the value of the ID column in the csv file, this in fact was not a problem with the ID column but the first column present in the header of any file that contained the BOM (Byte Order Mark) bytes.


#### Changes
<!-- What are the changes made in this pull request? -->

- Trim bytes of BOM bytes if present
- ...


#### Testing

<!-- How did you verify that this change works? -->

Manual testing, used the CSV file provided in the issue and also tested the import with a json file.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This is a bug fix, the only thing that could be affected by this change would be the JSON import but that was tested.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
