### PR TITLE
Validate other admin existence on user delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Deletion of the last admin user or removal of its admin status via an update operation now returns an error.
+
 ### Deprecated
 
 ### Removed

--- a/config/messages.json
+++ b/config/messages.json
@@ -5408,6 +5408,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/identityserver/store:last_admin": {
+    "translations": {
+      "en": "user `{user_id}` is the last admin"
+    },
+    "description": {
+      "package": "pkg/identityserver/store",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/identityserver/store:login_token_already_used": {
     "translations": {
       "en": "login token already used"

--- a/pkg/identityserver/store/errors.go
+++ b/pkg/identityserver/store/errors.go
@@ -63,6 +63,9 @@ var (
 	ErrUserSessionNotFound = errors.DefineNotFound(
 		"user_session_not_found", "user session with id `{session_id}` not found", "user_id",
 	)
+	ErrLastAdmin = errors.DefineFailedPrecondition(
+		"last_admin", "user `{user_id}` is the last admin",
+	)
 
 	ErrAPIKeyNotFound = errors.DefineNotFound(
 		"api_key_not_found", "api key with id `{api_key_id}` not found", "entity_type", "entity_id",

--- a/pkg/identityserver/user_registry.go
+++ b/pkg/identityserver/user_registry.go
@@ -469,6 +469,12 @@ func (is *IdentityServer) updateUser(ctx context.Context, req *ttnpb.UpdateUserR
 	}
 
 	err = is.store.Transact(ctx, func(ctx context.Context, st store.Store) (err error) {
+		if ttnpb.HasAnyField(req.FieldMask.GetPaths(), "admin") {
+			if err := isLastAdmin(ctx, st, req.User.Ids); err != nil {
+				// Is updating the last admin to no longer be an admin.
+				return err
+			}
+		}
 		updatingContactInfo := ttnpb.HasAnyField(req.FieldMask.GetPaths(), "contact_info")
 		var contactInfo []*ttnpb.ContactInfo
 		updatingPrimaryEmailAddress := ttnpb.HasAnyField(req.FieldMask.GetPaths(), "primary_email_address")

--- a/pkg/identityserver/user_registry.go
+++ b/pkg/identityserver/user_registry.go
@@ -692,9 +692,14 @@ func (is *IdentityServer) deleteUser(ctx context.Context, ids *ttnpb.UserIdentif
 	if err := rights.RequireUser(ctx, ids, ttnpb.Right_RIGHT_USER_DELETE); err != nil {
 		return nil, err
 	}
+
 	err := is.store.Transact(ctx, func(ctx context.Context, st store.Store) error {
+		err := isLastAdmin(ctx, st, ids)
+		if err != nil {
+			return err
+		}
 		// Delete the the user's sessions to enforce logouts.
-		err := st.DeleteAllUserSessions(ctx, ids)
+		err = st.DeleteAllUserSessions(ctx, ids)
 		if err != nil {
 			return err
 		}

--- a/pkg/identityserver/user_registry_test.go
+++ b/pkg/identityserver/user_registry_test.go
@@ -316,5 +316,18 @@ func TestUsersCRUD(t *testing.T) {
 
 		_, err = reg.Purge(ctx, usr1.GetIds(), adminUsrCreds)
 		a.So(err, should.BeNil)
+
+		// Admin restrictions, cannot remove the only admin in tenant store.
+		_, err = reg.Delete(ctx, adminUsr.GetIds(), adminUsrCreds)
+		a.So(errors.IsFailedPrecondition(err), should.BeTrue)
+
+		_, err = reg.Update(ctx, &ttnpb.UpdateUserRequest{
+			User: &ttnpb.User{
+				Ids:   adminUsr.GetIds(),
+				Admin: false,
+			},
+			FieldMask: ttnpb.FieldMask("admin"),
+		}, adminUsrCreds)
+		a.So(errors.IsFailedPrecondition(err), should.BeTrue)
 	}, withPrivateTestDatabase(p))
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/894#issuecomment-1357596803

Add validation to check if an user that is going to be deleted is the last admin of a tenant.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add invalid deletion error to store pkg.
- Add admin validation at the user deletion
- Add tests (TODO)


#### Testing

<!-- How did you verify that this change works? -->

Manual testing

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
