### PR TITLE
Add more proto unimplemented to RPC servers

### DIFF
--- a/pkg/deviceclaimingserver/grpc_gateways.go
+++ b/pkg/deviceclaimingserver/grpc_gateways.go
@@ -22,7 +22,9 @@ import (
 )
 
 // noopGCLS is a no-op GCLS.
-type noopGCLS struct{}
+type noopGCLS struct {
+	ttnpb.UnimplementedGatewayClaimingServerServer
+}
 
 // Claim implements GatewayClaimingServer.
 func (noopGCLS) Claim(ctx context.Context, req *ttnpb.ClaimGatewayRequest) (ids *ttnpb.GatewayIdentifiers, retErr error) {

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -338,6 +338,8 @@ func MakeInteropClientHandleJoinRequestChFunc(reqCh chan<- InteropClientHandleJo
 var _ ttnpb.NsJsServer = &MockNsJsServer{}
 
 type MockNsJsServer struct {
+	ttnpb.UnimplementedNsJsServer
+
 	HandleJoinFunc  func(context.Context, *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error)
 	GetNwkSKeysFunc func(context.Context, *ttnpb.SessionKeyRequest) (*ttnpb.NwkSKeysResponse, error)
 }
@@ -409,6 +411,8 @@ func (m MockNsJsClient) GetNwkSKeys(ctx context.Context, req *ttnpb.SessionKeyRe
 var _ ttnpb.NsGsServer = &MockNsGsServer{}
 
 type MockNsGsServer struct {
+	ttnpb.UnimplementedNsGsServer
+
 	ScheduleDownlinkFunc func(context.Context, *ttnpb.DownlinkMessage) (*ttnpb.ScheduleDownlinkResponse, error)
 }
 
@@ -447,6 +451,8 @@ func MakeNsGsScheduleDownlinkChFunc(reqCh chan<- NsGsScheduleDownlinkRequest) fu
 var _ ttnpb.NsAsServer = &MockNsAsServer{}
 
 type MockNsAsServer struct {
+	ttnpb.UnimplementedNsAsServer
+
 	HandleUplinkFunc func(context.Context, *ttnpb.NsAsHandleUplinkRequest) error
 }
 

--- a/pkg/packetbrokeragent/grpc_disabled.go
+++ b/pkg/packetbrokeragent/grpc_disabled.go
@@ -22,7 +22,11 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
-type disabledServer struct{}
+type disabledServer struct {
+	ttnpb.UnimplementedPbaServer
+	ttnpb.UnimplementedGsPbaServer
+	ttnpb.UnimplementedNsPbaServer
+}
 
 var errNotEnabled = errors.DefineFailedPrecondition("not_enabled", "Packet Broker is not enabled")
 

--- a/pkg/packetbrokeragent/grpc_gspba.go
+++ b/pkg/packetbrokeragent/grpc_gspba.go
@@ -50,6 +50,8 @@ type frequencyPlansStore interface {
 type GetFrequencyPlansStore func(ctx context.Context) (frequencyPlansStore, error)
 
 type gsPbaServer struct {
+	ttnpb.UnimplementedGsPbaServer
+
 	netID               types.NetID
 	clusterID           string
 	config              ForwarderConfig

--- a/pkg/packetbrokeragent/grpc_nspba.go
+++ b/pkg/packetbrokeragent/grpc_nspba.go
@@ -26,6 +26,8 @@ import (
 )
 
 type nsPbaServer struct {
+	ttnpb.UnimplementedNsPbaServer
+
 	contextDecoupler contextDecoupler
 	downstreamCh     chan *downlinkMessage
 	frequencyPlans   GetFrequencyPlansStore

--- a/pkg/packetbrokeragent/grpc_pba.go
+++ b/pkg/packetbrokeragent/grpc_pba.go
@@ -35,6 +35,8 @@ import (
 const listPageSize = 100
 
 type pbaServer struct {
+	ttnpb.UnimplementedPbaServer
+
 	*Agent
 	iamConn,
 	cpConn *grpc.ClientConn

--- a/pkg/packetbrokeragent/mock/pbcontrolplane.go
+++ b/pkg/packetbrokeragent/mock/pbcontrolplane.go
@@ -26,6 +26,8 @@ import (
 
 // PBControlPlane is a mock Packet Broker Control Plane.
 type PBControlPlane struct {
+	routingpb.UnimplementedPolicyManagerServer
+
 	*grpc.Server
 	ListDefaultPoliciesHandler     func(ctx context.Context, req *routingpb.ListDefaultPoliciesRequest) (*routingpb.ListDefaultPoliciesResponse, error)
 	GetDefaultPolicyHandler        func(ctx context.Context, req *routingpb.GetDefaultPolicyRequest) (*routingpb.GetPolicyResponse, error)

--- a/pkg/packetbrokeragent/mock/pbiam.go
+++ b/pkg/packetbrokeragent/mock/pbiam.go
@@ -57,13 +57,16 @@ func NewPBIAM(tb testing.TB) *PBIAM {
 			}),
 		),
 	}
-	iampb.RegisterNetworkRegistryServer(iam.Server, &pbIAMRegistry{iam})
-	iampb.RegisterTenantRegistryServer(iam.Server, &pbIAMRegistry{iam})
-	iampbv2.RegisterCatalogServer(iam.Server, &pbIAMCatalog{iam})
+	iampb.RegisterNetworkRegistryServer(iam.Server, &pbIAMRegistry{PBIAM: iam})
+	iampb.RegisterTenantRegistryServer(iam.Server, &pbIAMRegistry{PBIAM: iam})
+	iampbv2.RegisterCatalogServer(iam.Server, &pbIAMCatalog{PBIAM: iam})
 	return iam
 }
 
 type pbIAMRegistry struct {
+	iampb.UnimplementedNetworkRegistryServer
+	iampb.UnimplementedTenantRegistryServer
+
 	*PBIAM
 }
 
@@ -138,6 +141,8 @@ func (s *pbIAMRegistry) DeleteTenant(ctx context.Context, req *iampb.TenantReque
 }
 
 type pbIAMCatalog struct {
+	iampbv2.UnimplementedCatalogServer
+
 	*PBIAM
 }
 

--- a/pkg/packetbrokeragent/mock/pbmapper.go
+++ b/pkg/packetbrokeragent/mock/pbmapper.go
@@ -40,11 +40,13 @@ func NewPBMapper(tb testing.TB) *PBMapper {
 			}),
 		),
 	}
-	mappingpb.RegisterMapperServer(mp.Server, &pbMapper{mp})
+	mappingpb.RegisterMapperServer(mp.Server, &pbMapper{PBMapper: mp})
 	return mp
 }
 
 type pbMapper struct {
+	mappingpb.UnimplementedMapperServer
+
 	*PBMapper
 }
 

--- a/pkg/util/rpctest/server.go
+++ b/pkg/util/rpctest/server.go
@@ -25,7 +25,9 @@ import (
 )
 
 // The FooBarExampleServer is an example/test server
-type FooBarExampleServer struct{}
+type FooBarExampleServer struct {
+	UnimplementedFooBarServer
+}
 
 // Unary RPC example
 func (s *FooBarExampleServer) Unary(ctx context.Context, foo *Foo) (*Bar, error) {

--- a/pkg/util/test/application_services.go
+++ b/pkg/util/test/application_services.go
@@ -23,6 +23,8 @@ import (
 
 // MockApplicationAccessServer is a mock ttnpb.ApplicationAccessServer used for testing.
 type MockApplicationAccessServer struct {
+	ttnpb.UnimplementedApplicationAccessServer
+
 	CreateAPIKeyFunc      func(context.Context, *ttnpb.CreateApplicationAPIKeyRequest) (*ttnpb.APIKey, error)
 	GetAPIKeyFunc         func(context.Context, *ttnpb.GetApplicationAPIKeyRequest) (*ttnpb.APIKey, error)
 	ListAPIKeysFunc       func(context.Context, *ttnpb.ListApplicationAPIKeysRequest) (*ttnpb.APIKeys, error)


### PR DESCRIPTION
#### Summary
This PR follows-up #5978 PR with the missing `ttnpb.Unimplemented<ServerName>`

#### Changes
- Added more `Unimplemented<ServerName>` to RPC servers


#### Testing
- Existing UT

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
