### PR TITLE
Refactor device templates

### DIFF
--- a/cmd/ttn-lw-cli/commands/applications.go
+++ b/cmd/ttn-lw-cli/commands/applications.go
@@ -165,7 +165,7 @@ var (
 		RunE: asBulk(func(cmd *cobra.Command, args []string) (err error) {
 			var application ttnpb.Application
 			if inputDecoder != nil {
-				_, err := inputDecoder.Decode(&application)
+				err := inputDecoder.Decode(&application)
 				if err != nil {
 					return err
 				}

--- a/cmd/ttn-lw-cli/commands/bulk.go
+++ b/cmd/ttn-lw-cli/commands/bulk.go
@@ -18,6 +18,7 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 )
 
 // asBulk enables some commands to do bulk operations.
@@ -31,7 +32,7 @@ func asBulk(runE func(cmd *cobra.Command, args []string) error) func(cmd *cobra.
 		}
 		for {
 			err = runE(cmd, args)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return nil
 			}
 			if err != nil {

--- a/cmd/ttn-lw-cli/commands/clients.go
+++ b/cmd/ttn-lw-cli/commands/clients.go
@@ -174,7 +174,7 @@ var (
 				ttnpb.GrantType_GRANT_AUTHORIZATION_CODE,
 			}
 			if inputDecoder != nil {
-				_, err := inputDecoder.Decode(&client)
+				err := inputDecoder.Decode(&client)
 				if err != nil {
 					return err
 				}

--- a/cmd/ttn-lw-cli/commands/gateways.go
+++ b/cmd/ttn-lw-cli/commands/gateways.go
@@ -256,7 +256,7 @@ var (
 			}
 			var gateway ttnpb.Gateway
 			if inputDecoder != nil {
-				_, err := inputDecoder.Decode(&gateway)
+				err := inputDecoder.Decode(&gateway)
 				if err != nil {
 					return err
 				}

--- a/cmd/ttn-lw-cli/commands/lorawan.go
+++ b/cmd/ttn-lw-cli/commands/lorawan.go
@@ -317,7 +317,7 @@ var (
 					return nil
 				}
 				var input []byte
-				if _, err := inputDecoder.Decode(&input); err != nil {
+				if err := inputDecoder.Decode(&input); err != nil {
 					return err
 				}
 				var frame ttnpb.Message

--- a/cmd/ttn-lw-cli/commands/organizations.go
+++ b/cmd/ttn-lw-cli/commands/organizations.go
@@ -170,7 +170,7 @@ var (
 			}
 			var organization ttnpb.Organization
 			if inputDecoder != nil {
-				_, err := inputDecoder.Decode(&organization)
+				err := inputDecoder.Decode(&organization)
 				if err != nil {
 					return err
 				}

--- a/cmd/ttn-lw-cli/commands/users.go
+++ b/cmd/ttn-lw-cli/commands/users.go
@@ -191,7 +191,7 @@ var (
 			var user ttnpb.User
 			user.State = ttnpb.State_STATE_APPROVED // This may not be honored by the server.
 			if inputDecoder != nil {
-				_, err := inputDecoder.Decode(&user)
+				err := inputDecoder.Decode(&user)
 				if err != nil {
 					return err
 				}

--- a/config/messages.json
+++ b/config/messages.json
@@ -8837,6 +8837,15 @@
       "file": "data_rate.go"
     }
   },
+  "error:pkg/util/io:json_token": {
+    "translations": {
+      "en": "invalid JSON token"
+    },
+    "description": {
+      "package": "pkg/util/io",
+      "file": "io.go"
+    }
+  },
   "error:pkg/validate:email": {
     "translations": {
       "en": "`{email}` is not a valid email."

--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	github.com/jarcoal/httpmock v1.1.0
 	github.com/jaytaylor/html2text v0.0.0-20211105163654-bc68cce691ba
 	github.com/jinzhu/gorm v1.9.16
+	github.com/json-iterator/go v1.1.12
 	github.com/jtacoma/uritemplates v1.0.0
 	github.com/kr/pretty v0.3.0
 	github.com/lib/pq v1.10.4
@@ -214,9 +215,8 @@ require (
 	github.com/jacobsa/reqtrace v0.0.0-20150505043853-245c9e0234cb // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
-	github.com/klauspost/compress v1.14.4 // indirect
+	github.com/klauspost/compress v1.15.11 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mattn/go-ieproxy v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -518,8 +518,8 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.8.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.14.4 h1:eijASRJcobkVtSt81Olfh7JX43osYLwy5krOJo6YEu4=
-github.com/klauspost/compress v1.14.4/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.11 h1:Lcadnb3RKGin4FYM/orgq0qde+nc15E5Cbqg4B9Sx9c=
+github.com/klauspost/compress v1.15.11/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/kljensen/snowball v0.6.0/go.mod h1:27N7E8fVU5H68RlUmnWwZCfxgt4POBJfENGMvNRhldw=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/pkg/devicetemplateconverter/util_test.go
+++ b/pkg/devicetemplateconverter/util_test.go
@@ -35,16 +35,16 @@ func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.Cluste
 
 type mockConverter struct {
 	ttnpb.EndDeviceTemplateFormat
-	ConvertFunc func(context.Context, io.Reader, chan<- *ttnpb.EndDeviceTemplate) error
+	ConvertFunc func(context.Context, io.Reader, func(*ttnpb.EndDeviceTemplate) error) error
 }
 
 func (c *mockConverter) Format() *ttnpb.EndDeviceTemplateFormat {
 	return &c.EndDeviceTemplateFormat
 }
 
-func (c *mockConverter) Convert(ctx context.Context, r io.Reader, ch chan<- *ttnpb.EndDeviceTemplate) error {
+func (c *mockConverter) Convert(ctx context.Context, r io.Reader, f func(*ttnpb.EndDeviceTemplate) error) error {
 	if c.ConvertFunc == nil {
 		panic("Convert should not be called")
 	}
-	return c.ConvertFunc(ctx, r, ch)
+	return c.ConvertFunc(ctx, r, f)
 }

--- a/pkg/devicetemplates/converters.go
+++ b/pkg/devicetemplates/converters.go
@@ -24,7 +24,7 @@ import (
 // Converter converts a binary file in end device templates.
 type Converter interface {
 	Format() *ttnpb.EndDeviceTemplateFormat
-	Convert(context.Context, io.Reader, chan<- *ttnpb.EndDeviceTemplate) error
+	Convert(context.Context, io.Reader, func(*ttnpb.EndDeviceTemplate) error) error
 }
 
 var converters = map[string]Converter{}

--- a/pkg/devicetemplates/converters_test.go
+++ b/pkg/devicetemplates/converters_test.go
@@ -48,6 +48,6 @@ func (c *mockConverter) Format() *ttnpb.EndDeviceTemplateFormat {
 	return &c.EndDeviceTemplateFormat
 }
 
-func (c *mockConverter) Convert(context.Context, io.Reader, chan<- *ttnpb.EndDeviceTemplate) error {
+func (*mockConverter) Convert(context.Context, io.Reader, func(*ttnpb.EndDeviceTemplate) error) error {
 	return nil
 }

--- a/pkg/devicetemplates/ttscsv.go
+++ b/pkg/devicetemplates/ttscsv.go
@@ -355,9 +355,9 @@ func determineComma(head []byte) (rune, bool) {
 }
 
 // Convert implements the devicetemplates.Converter interface.
-func (t *ttsCSV) Convert(ctx context.Context, r io.Reader, ch chan<- *ttnpb.EndDeviceTemplate) error { //nolint:gocyclo
-	defer close(ch)
-
+func (t *ttsCSV) Convert( //nolint:gocyclo
+	ctx context.Context, r io.Reader, f func(*ttnpb.EndDeviceTemplate) error,
+) error {
 	r, err := charset.NewReader(r, "text/csv")
 	if err != nil {
 		return err
@@ -461,10 +461,8 @@ func (t *ttsCSV) Convert(ctx context.Context, r io.Reader, ch chan<- *ttnpb.EndD
 			tmpl = profileTmpl
 		}
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case ch <- tmpl:
+		if err := f(tmpl); err != nil {
+			return err
 		}
 		line++
 	}

--- a/pkg/ttnpb/end_device.go
+++ b/pkg/ttnpb/end_device.go
@@ -1562,3 +1562,6 @@ func (d *EndDevice) UpdateTimestamps(src *EndDevice) {
 		d.UpdatedAt = src.UpdatedAt
 	}
 }
+
+// EndDeviceFieldPathsNestedWithoutWrappers is the set of EndDevice nested paths without the wrapper paths.
+var EndDeviceFieldPathsNestedWithoutWrappers = FieldsWithoutWrappers(EndDeviceFieldPathsNested)

--- a/pkg/ttnpb/fieldmask_utils.go
+++ b/pkg/ttnpb/fieldmask_utils.go
@@ -331,3 +331,28 @@ func IncludeFields(paths []string, includePaths ...string) []string {
 	}
 	return included
 }
+
+// FieldsWithoutWrappers returns the paths without the wrapper value paths.
+// A wrapper type is a type which contains a singular field called `value`.
+func FieldsWithoutWrappers(paths []string) []string {
+	if len(paths) == 0 {
+		return paths
+	}
+	leaves := make(map[string]int)
+	for _, path := range paths {
+		prefix := path
+		for i := strings.LastIndex(prefix, "."); i != -1; i = strings.LastIndex(prefix, ".") {
+			prefix = path[:i]
+			leaves[prefix]++
+		}
+	}
+	result := make([]string, 0, len(paths))
+	for _, path := range paths {
+		father := strings.TrimSuffix(path, ".value")
+		if path != father && leaves[father] == 1 {
+			continue
+		}
+		result = append(result, path)
+	}
+	return result
+}

--- a/pkg/ttnpb/fieldmask_utils_test.go
+++ b/pkg/ttnpb/fieldmask_utils_test.go
@@ -232,3 +232,16 @@ func TestIncludeFields(t *testing.T) {
 	a.So(IncludeFields(paths, "a", "b", "c"), should.Resemble, paths)
 	a.So(IncludeFields(paths, "c.e.g"), should.Resemble, []string{})
 }
+
+func TestFieldsWithoutWrappers(t *testing.T) {
+	t.Parallel()
+
+	a := assertions.New(t)
+	paths := []string{
+		"a",
+		"a.b.value",
+		"a.c.value",
+		"a.c.d",
+	}
+	a.So(FieldsWithoutWrappers(paths), should.Resemble, []string{"a", "a.c.value", "a.c.d"})
+}

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -525,7 +525,7 @@ github.com/kisielk/sqlstruct v0.0.0-20150923205031-648daed35d49/go.mod h1:yyMNCy
 github.com/kisom/goutils v1.1.0/go.mod h1:+UBTfd78habUYWFbNWTJNG+jNG/i/lGURakr4A/yNRw=
 github.com/klauspost/compress v1.8.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.14.4 h1:eijASRJcobkVtSt81Olfh7JX43osYLwy5krOJo6YEu4=
+github.com/klauspost/compress v1.15.11 h1:Lcadnb3RKGin4FYM/orgq0qde+nc15E5Cbqg4B9Sx9c=
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/kljensen/snowball v0.6.0/go.mod h1:27N7E8fVU5H68RlUmnWwZCfxgt4POBJfENGMvNRhldw=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/pull/3510

This PR backports the above changes.

#### Changes
<!-- What are the changes made in this pull request? -->

- Decouple field mask generation of template contents from the actual decoding of the template.
  - The previous mechanism was flawed because it could not handle `oneof` fields correctly.
  - We now compute the field mask of an `EndDevice` using the non zero fields (which correctly generate `oneof` paths).
- Use callbacks instead of channels while parsing end device templates. This simplifies error handling for the caller and the called. 
- Fix the JSON parser to allow both a stream of JSON objects, and an array of JSON objects.
  - This was always meant to be supported, but the gogoproto migration has shown that actually we were not propagating errors correctly on gRPC streams towards the frontend. While digging this, I found that providing an array while importing devices always returned an error, and I've fixed the error handling as such.


#### Testing

<!-- How did you verify that this change works? -->

Covered by the original PR.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Covered by the original PR.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
