### PR TITLE
Backport proto comparison fixes

### DIFF
--- a/pkg/applicationserver/grpc_deviceregistry_test.go
+++ b/pkg/applicationserver/grpc_deviceregistry_test.go
@@ -182,7 +182,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			},
 			GetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(ids, should.Resemble, ttnpb.EndDeviceIdentifiers{
+				a.So(ids, should.Resemble, &ttnpb.EndDeviceIdentifiers{
 					ApplicationIds: &ttnpb.ApplicationIdentifiers{
 						ApplicationId: registeredApplicationID,
 					},
@@ -247,7 +247,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			},
 			GetFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(ids, should.Resemble, ttnpb.EndDeviceIdentifiers{
+				a.So(ids, should.Resemble, &ttnpb.EndDeviceIdentifiers{
 					ApplicationIds: &ttnpb.ApplicationIdentifiers{
 						ApplicationId: registeredApplicationID,
 					},
@@ -432,7 +432,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			},
 			SetFunc: func(ctx context.Context, deviceIds *ttnpb.EndDeviceIdentifiers, gets []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(deviceIds, should.Resemble, ttnpb.EndDeviceIdentifiers{
+				a.So(deviceIds, should.Resemble, &ttnpb.EndDeviceIdentifiers{
 					ApplicationIds: &ttnpb.ApplicationIdentifiers{
 						ApplicationId: registeredApplicationID,
 					},

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -113,6 +113,8 @@ func TestNetErrors(t *testing.T) {
 	t.Parallel()
 	a := assertions.New(t)
 
+	errDummy := fmt.Errorf("dummy")
+
 	for _, tc := range []struct {
 		Name     string
 		Error    error
@@ -205,7 +207,7 @@ func TestNetErrors(t *testing.T) {
 				Addr:   &net.IPAddr{IP: net.IP{1, 1, 1, 1}},
 				Source: &net.IPAddr{IP: net.IP{2, 2, 2, 2}},
 				Net:    "0.0.0.0",
-				Err:    fmt.Errorf("dummy"),
+				Err:    errDummy,
 			},
 			Validate: func(_ error, e *errors.Error, a *assertions.Assertion) {
 				a.So(e.FullName(), should.Equal, "pkg/errors:net_operation")
@@ -217,7 +219,7 @@ func TestNetErrors(t *testing.T) {
 					"net":     "0.0.0.0",
 					"op":      "read",
 				})
-				a.So(e.Cause(), should.Resemble, fmt.Errorf("dummy"))
+				a.So(e.Cause(), should.Resemble, errDummy)
 			},
 		},
 	} {

--- a/pkg/identityserver/storetest/membership_store.go
+++ b/pkg/identityserver/storetest/membership_store.go
@@ -100,7 +100,7 @@ func (st *StoreTest) TestMembershipStoreCRUD(t *T) {
 				if a.So(err, should.BeNil) && a.So(members, should.NotBeNil) && a.So(members, should.HaveLength, 1) {
 					for _, v := range members {
 						memberIDs, rights := v.Ids, v.Rights
-						a.So(memberIDs, should.Resemble, usr1.GetEntityIdentifiers())
+						a.So(memberIDs.GetEntityIdentifiers(), should.Resemble, usr1.GetEntityIdentifiers())
 						a.So(rights, should.Resemble, someRights[ids.EntityType()])
 					}
 				}

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -133,7 +133,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{
 					ApplicationId: registeredApplicationID,
 				})
 				a.So(devID, should.Equal, unregisteredDeviceID)
@@ -173,7 +173,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{
 					ApplicationId: "bar-application",
 				})
 				a.So(devID, should.Equal, "bar-device")
@@ -215,7 +215,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{
 					ApplicationId: registeredApplicationID,
 				})
 				a.So(devID, should.Equal, registeredDeviceID)
@@ -279,7 +279,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{
 					ApplicationId: registeredApplicationID,
 				})
 				a.So(devID, should.Equal, registeredDeviceID)
@@ -340,7 +340,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{
 					ApplicationId: registeredApplicationID,
 				})
 				a.So(devID, should.Equal, registeredDeviceID)
@@ -598,7 +598,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{
 					ApplicationId: registeredApplicationID,
 				})
 				a.So(devID, should.Equal, "new-device")
@@ -660,7 +660,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{
 					ApplicationId: registeredApplicationID,
 				})
 				a.So(devID, should.Equal, registeredDeviceID)
@@ -746,7 +746,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{
 					ApplicationId: registeredApplicationID,
 				})
 				a.So(devID, should.Equal, registeredDeviceID)
@@ -936,7 +936,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{
 					ApplicationId: registeredApplicationID,
 				})
 				a.So(devID, should.Equal, unregisteredDeviceID)
@@ -967,7 +967,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			DeviceRequest: ttnpb.Clone(registeredDevice.Ids),
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{
 					ApplicationId: registeredApplicationID,
 				})
 				a.So(devID, should.Equal, registeredDeviceID)

--- a/pkg/networkserver/grpc_asns_test.go
+++ b/pkg/networkserver/grpc_asns_test.go
@@ -70,7 +70,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -120,7 +120,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -189,7 +189,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -270,7 +270,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -367,7 +367,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 			Time: time.Unix(0, 42),
 			AddFunc: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, startAt time.Time, replace bool) error {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(ids, should.Resemble, ttnpb.EndDeviceIdentifiers{
+				a.So(ids, should.Resemble, &ttnpb.EndDeviceIdentifiers{
 					DeviceId:       "test-dev-id",
 					ApplicationIds: &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"},
 				})
@@ -377,7 +377,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -459,7 +459,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"mac_state",
@@ -532,7 +532,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"mac_state",
@@ -612,7 +612,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"mac_state",
@@ -791,7 +791,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -842,7 +842,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -911,7 +911,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -992,7 +992,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -1084,7 +1084,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 			Name: "Invalid request/push/Class C/FCnt too low",
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -1156,7 +1156,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 			Name: "Invalid request/push/Class C/FCnt lower than NFCntDown",
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -1223,7 +1223,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 			Name: "Valid request/push/Class C/No session",
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -1358,7 +1358,7 @@ func TestDownlinkQueueList(t *testing.T) {
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"pending_session.queued_application_downlinks",
@@ -1385,7 +1385,7 @@ func TestDownlinkQueueList(t *testing.T) {
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"pending_session.queued_application_downlinks",
@@ -1426,7 +1426,7 @@ func TestDownlinkQueueList(t *testing.T) {
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"pending_session.queued_application_downlinks",
@@ -1469,7 +1469,7 @@ func TestDownlinkQueueList(t *testing.T) {
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"pending_session.queued_application_downlinks",

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -97,7 +97,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -144,7 +144,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -210,7 +210,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"pending_session.keys.f_nwk_s_int_key",
@@ -272,7 +272,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			},
 			GetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"pending_session.keys.f_nwk_s_int_key.encrypted_key",
@@ -1262,7 +1262,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.BeNil)
 
@@ -1296,7 +1296,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
+				a.So(appID, should.Resemble, &ttnpb.ApplicationIdentifiers{ApplicationId: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.BeNil)
 

--- a/pkg/packetbrokeragent/authenticator_internal_test.go
+++ b/pkg/packetbrokeragent/authenticator_internal_test.go
@@ -46,7 +46,7 @@ func TestOAuth2(t *testing.T) {
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
-	a.So(tenantID, should.Resemble, ttnpb.PacketBrokerNetworkIdentifier{
+	a.So(tenantID, should.Resemble, &ttnpb.PacketBrokerNetworkIdentifier{
 		NetId:    0x000013,
 		TenantId: "tti",
 	})

--- a/pkg/ttnpb/udp/translation_test.go
+++ b/pkg/ttnpb/udp/translation_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	pbtypes "github.com/gogo/protobuf/types"
-	"github.com/kr/pretty"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/gpstime"
@@ -260,6 +259,7 @@ func TestToGatewayUpRoundtrip(t *testing.T) {
 		{
 			Name: "TxAcknowledgment",
 			Data: &udp.Data{
+				RxPacket: []*udp.RxPacket{},
 				TxPacketAck: &udp.TxPacketAck{
 					Error: udp.TxErrNone,
 				},
@@ -285,7 +285,7 @@ func TestToGatewayUpRoundtrip(t *testing.T) {
 			PacketType:      tc.PacketType,
 		}
 		actual.Data.RxPacket, actual.Data.Stat, actual.Data.TxPacketAck = udp.FromGatewayUp(up)
-		a.So(pretty.Diff(actual, expected), should.BeEmpty)
+		a.So(actual, should.Resemble, expected)
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/pull/3445/

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix type mismatch in IS entity type tests.
- Ensure that tests do not copy proto messages.
- Fix error comparison in `pkg/errors`.
- Use resemblance (`should.Resemble`) in UDP protocol tests.

#### Testing

<!-- How did you verify that this change works? -->

UT.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This is mainly testing.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Only needs CI.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
