### PR TITLE
Support TLS client certificates for Backend Interfaces interoperability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Deprecated
 
+- Configuring certificate authorities per LoRaWAN Backend Interfaces SenderID (`interop.sender-client-ca`) is now deprecated and support will be removed in a future version of The Things Stack.
+
 ### Removed
 
 - The device version identifiers no longer have the `serial_number`, `vendor_id` and `vendor_profile_id` fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - List of end-devices can now be sorted by `last_seen_at` field. Unseen devices will be shown last.
 - End devices now contain `lora_alliance_profile_ids` field.
+- Add `source` config option for TLS certificates in LoRaWAN Backend Interfaces interop client configuration. This value can be `file` (existing behavior) or `key-vault`.
 
 ### Changed
 

--- a/cmd/ttn-lw-stack/commands/root.go
+++ b/cmd/ttn-lw-stack/commands/root.go
@@ -41,7 +41,10 @@ var (
 	logger log.Stack
 	name   = "ttn-lw-stack"
 	mgr    = conf.InitializeWithDefaults(name, "ttn_lw", DefaultConfig,
-		conf.WithDeprecatedFlag("interop.sender-client-cas", "use interop.sender-client-ca sub-fields instead"),
+		conf.WithDeprecatedFlag(
+			"interop.sender-client-cas",
+			"TLS client authentication with LoRaWAN Backend Interfaces is deprecated",
+		),
 	)
 	config = new(Config)
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -3385,7 +3385,16 @@
   },
   "error:pkg/crypto/cryptoutil:certificate_not_found": {
     "translations": {
-      "en": "certificate with ID `{id}` not found"
+      "en": "certificate with label `{label}` not found"
+    },
+    "description": {
+      "package": "pkg/crypto/cryptoutil",
+      "file": "cryptoutil.go"
+    }
+  },
+  "error:pkg/crypto/cryptoutil:client_certificate_not_found": {
+    "translations": {
+      "en": "client certificate not found"
     },
     "description": {
       "package": "pkg/crypto/cryptoutil",
@@ -3401,18 +3410,9 @@
       "file": "cryptoutil.go"
     }
   },
-  "error:pkg/crypto/cryptoutil:kek_not_found": {
-    "translations": {
-      "en": "KEK with label `{label}` not found"
-    },
-    "description": {
-      "package": "pkg/crypto/cryptoutil",
-      "file": "cryptoutil.go"
-    }
-  },
   "error:pkg/crypto/cryptoutil:key_not_found": {
     "translations": {
-      "en": "key with ID `{id}` not found"
+      "en": "key with label `{label}` not found"
     },
     "description": {
       "package": "pkg/crypto/cryptoutil",

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -409,7 +409,7 @@ func (as *ApplicationServer) publishUp(ctx context.Context, up *ttnpb.Applicatio
 // Server, and if the end device's skip_payload_crypto_override is true or if the link's skip_payload_crypto is true.
 func (as *ApplicationServer) skipPayloadCrypto(ctx context.Context, link *ttnpb.ApplicationLink, dev *ttnpb.EndDevice, session *ttnpb.Session) bool {
 	if appSKey := session.GetKeys().GetAppSKey(); appSKey != nil {
-		if _, err := cryptoutil.UnwrapAES128Key(ctx, appSKey, as.KeyVault); err == nil {
+		if _, err := cryptoutil.UnwrapAES128Key(ctx, appSKey, as.KeyService()); err == nil {
 			return false
 		}
 	}

--- a/pkg/applicationserver/grpc_deviceregistry.go
+++ b/pkg/applicationserver/grpc_deviceregistry.go
@@ -64,7 +64,7 @@ type asEndDeviceRegistryServer struct {
 
 func (r asEndDeviceRegistryServer) retrieveSessionKeys(ctx context.Context, dev *ttnpb.EndDevice, paths []string) error {
 	unwrapKeys := func(ctx context.Context, session *ttnpb.Session, prefix string, paths ...string) error {
-		sk, err := cryptoutil.UnwrapSelectedSessionKeys(ctx, r.AS.KeyVault, session.Keys, prefix, paths...)
+		sk, err := cryptoutil.UnwrapSelectedSessionKeys(ctx, r.AS.KeyService(), session.Keys, prefix, paths...)
 		if err != nil {
 			return err
 		}
@@ -212,7 +212,7 @@ func (r asEndDeviceRegistryServer) Set(ctx context.Context, req *ttnpb.SetEndDev
 	sets := append(req.FieldMask.GetPaths()[:0:0], req.FieldMask.GetPaths()...)
 	if ttnpb.HasAnyField(req.FieldMask.GetPaths(), "session.keys.app_s_key.key") {
 		appSKey, err := cryptoutil.WrapAES128Key(
-			ctx, *types.MustAES128Key(req.EndDevice.Session.Keys.AppSKey.Key), r.kekLabel, r.AS.KeyVault,
+			ctx, *types.MustAES128Key(req.EndDevice.Session.Keys.AppSKey.Key), r.kekLabel, r.AS.KeyService(),
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/applicationserver/payload.go
+++ b/pkg/applicationserver/payload.go
@@ -101,7 +101,7 @@ func (as *ApplicationServer) encryptDownlink(ctx context.Context, dev *ttnpb.End
 	if session.GetKeys().GetAppSKey() == nil {
 		return errNoAppSKey.New()
 	}
-	appSKey, err := cryptoutil.UnwrapAES128Key(ctx, session.Keys.AppSKey, as.KeyVault)
+	appSKey, err := cryptoutil.UnwrapAES128Key(ctx, session.Keys.AppSKey, as.KeyService())
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func (as *ApplicationServer) decryptUplink(ctx context.Context, dev *ttnpb.EndDe
 	if dev.GetSession().GetKeys().GetAppSKey() == nil {
 		return errNoAppSKey.New()
 	}
-	appSKey, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.Keys.AppSKey, as.KeyVault)
+	appSKey, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.Keys.AppSKey, as.KeyService())
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func (as *ApplicationServer) decryptDownlink(ctx context.Context, dev *ttnpb.End
 	if session.GetKeys().GetAppSKey() == nil {
 		return errNoAppSKey.New()
 	}
-	appSKey, err := cryptoutil.UnwrapAES128Key(ctx, session.Keys.AppSKey, as.KeyVault)
+	appSKey, err := cryptoutil.UnwrapAES128Key(ctx, session.Keys.AppSKey, as.KeyService())
 	if err != nil {
 		return err
 	}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -85,7 +85,9 @@ type Component struct {
 	fillers []fillcontext.Filler
 
 	frequencyPlans *frequencyplans.Store
-	KeyVault       crypto.KeyVault
+
+	componentKEKLabeler crypto.ComponentKEKLabeler
+	keyService          crypto.KeyService
 
 	rightsFetcher rights.Fetcher
 
@@ -161,7 +163,11 @@ func New(logger log.Stack, config *Config, opts ...Option) (c *Component, err er
 		return nil, err
 	}
 
-	c.KeyVault, err = config.KeyVault.KeyVault(ctx, c)
+	c.componentKEKLabeler, err = config.KeyVault.ComponentKEKLabeler()
+	if err != nil {
+		return nil, err
+	}
+	c.keyService, err = config.KeyVault.KeyService(ctx, c)
 	if err != nil {
 		return nil, err
 	}
@@ -264,6 +270,16 @@ func (c *Component) FromRequestContext(ctx context.Context) context.Context {
 		valueCtx:  ctx,
 		cancelCtx: c.ctx,
 	}
+}
+
+// ComponentKEKLabeler returns the component's ComponentKEKLabeler
+func (c *Component) ComponentKEKLabeler() crypto.ComponentKEKLabeler {
+	return c.componentKEKLabeler
+}
+
+// KeyService returns the component's KeyService.
+func (c *Component) KeyService() crypto.KeyService {
+	return c.keyService
 }
 
 // FrequencyPlansStore returns the component's frequencyPlans Store

--- a/pkg/component/tls.go
+++ b/pkg/component/tls.go
@@ -35,7 +35,7 @@ func (c *Component) getTLSConfig(ctx context.Context) tlsconfig.Config {
 		}
 	}
 	if conf.Source == "key-vault" {
-		conf.KeyVault.KeyVault = c.KeyVault
+		conf.KeyVault.CertificateProvider = c.keyService
 	}
 	return conf
 }

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -476,8 +476,8 @@ type InteropServer struct {
 	ListenTLS        string `name:"listen-tls" description:"TLS address for the interop server for LoRaWAN Backend Interfaces to listen on"` //nolint:lll
 	PublicTLSAddress string `name:"public-tls-address" description:"Public address of the interop server for LoRaWAN Backend Interfaces"`    //nolint:lll
 
-	SenderClientCA           SenderClientCA    `name:"sender-client-ca"`
-	SenderClientCADeprecated map[string]string `name:"sender-client-cas" description:"Path to PEM encoded file with client CAs of sender IDs to trust; deprecated - use sender-client-ca instead"` //nolint:lll
+	SenderClientCA           SenderClientCA    `name:"sender-client-ca" description:"Client CAs for sender IDs to trust (DEPRECATED)"`                               //nolint:lll
+	SenderClientCADeprecated map[string]string `name:"sender-client-cas" description:"Path to PEM encoded file with client CAs of sender IDs to trust (DEPRECATED)"` //nolint:lll
 
 	PacketBroker PacketBrokerInteropAuth `name:"packet-broker"`
 }

--- a/pkg/config/tlsconfig/config.go
+++ b/pkg/config/tlsconfig/config.go
@@ -178,7 +178,7 @@ type ServerAuth struct {
 	Key          string         `json:"key" yaml:"key" name:"key" description:"Location of TLS private key"`
 	ACME         ACME           `name:"acme"`
 	KeyVault     ServerKeyVault `name:"key-vault"`
-	CipherSuites []string       `name:"cipher-suites" description:"DEPRECATED: List of IANA names of TLS cipher suites to use"` //nolint:lll
+	CipherSuites []string       `name:"cipher-suites" description:"List of IANA names of TLS cipher suites to use (DEPRECATED)"` //nolint:lll
 }
 
 var (

--- a/pkg/crypto/cryptoservices/grpc.go
+++ b/pkg/crypto/cryptoservices/grpc.go
@@ -27,16 +27,16 @@ import (
 
 type networkRPCClient struct {
 	Client ttnpb.NetworkCryptoServiceClient
-	crypto.KeyVault
+	crypto.KeyService
 	callOpts []grpc.CallOption
 }
 
 // NewNetworkRPCClient returns a network service which uses a gRPC service on the given connection.
-func NewNetworkRPCClient(cc *grpc.ClientConn, keyVault crypto.KeyVault, callOpts ...grpc.CallOption) Network {
+func NewNetworkRPCClient(cc *grpc.ClientConn, keyVault crypto.KeyService, callOpts ...grpc.CallOption) Network {
 	return &networkRPCClient{
-		Client:   ttnpb.NewNetworkCryptoServiceClient(cc),
-		KeyVault: keyVault,
-		callOpts: callOpts,
+		Client:     ttnpb.NewNetworkCryptoServiceClient(cc),
+		KeyService: keyVault,
+		callOpts:   callOpts,
 	}
 }
 
@@ -116,15 +116,15 @@ func (s *networkRPCClient) DeriveNwkSKeys(ctx context.Context, dev *ttnpb.EndDev
 		return NwkSKeys{}, err
 	}
 	var res NwkSKeys
-	res.FNwkSIntKey, err = cryptoutil.UnwrapAES128Key(ctx, keys.FNwkSIntKey, s.KeyVault)
+	res.FNwkSIntKey, err = cryptoutil.UnwrapAES128Key(ctx, keys.FNwkSIntKey, s.KeyService)
 	if err != nil {
 		return NwkSKeys{}, err
 	}
-	res.SNwkSIntKey, err = cryptoutil.UnwrapAES128Key(ctx, keys.SNwkSIntKey, s.KeyVault)
+	res.SNwkSIntKey, err = cryptoutil.UnwrapAES128Key(ctx, keys.SNwkSIntKey, s.KeyService)
 	if err != nil {
 		return NwkSKeys{}, err
 	}
-	res.NwkSEncKey, err = cryptoutil.UnwrapAES128Key(ctx, keys.NwkSEncKey, s.KeyVault)
+	res.NwkSEncKey, err = cryptoutil.UnwrapAES128Key(ctx, keys.NwkSEncKey, s.KeyService)
 	if err != nil {
 		return NwkSKeys{}, err
 	}
@@ -143,7 +143,7 @@ func (s *networkRPCClient) GetNwkKey(ctx context.Context, dev *ttnpb.EndDevice) 
 		}
 		return nil, err
 	}
-	plain, err := cryptoutil.UnwrapAES128Key(ctx, ke, s.KeyVault)
+	plain, err := cryptoutil.UnwrapAES128Key(ctx, ke, s.KeyService)
 	if err != nil {
 		return nil, err
 	}
@@ -152,16 +152,16 @@ func (s *networkRPCClient) GetNwkKey(ctx context.Context, dev *ttnpb.EndDevice) 
 
 type applicationRPCClient struct {
 	Client ttnpb.ApplicationCryptoServiceClient
-	crypto.KeyVault
+	crypto.KeyService
 	callOpts []grpc.CallOption
 }
 
 // NewApplicationRPCClient returns an application service which uses a gRPC service on the given connection.
-func NewApplicationRPCClient(cc *grpc.ClientConn, keyVault crypto.KeyVault, callOpts ...grpc.CallOption) Application {
+func NewApplicationRPCClient(cc *grpc.ClientConn, keyVault crypto.KeyService, callOpts ...grpc.CallOption) Application {
 	return &applicationRPCClient{
-		Client:   ttnpb.NewApplicationCryptoServiceClient(cc),
-		KeyVault: keyVault,
-		callOpts: callOpts,
+		Client:     ttnpb.NewApplicationCryptoServiceClient(cc),
+		KeyService: keyVault,
+		callOpts:   callOpts,
 	}
 }
 
@@ -178,7 +178,7 @@ func (s *applicationRPCClient) DeriveAppSKey(ctx context.Context, dev *ttnpb.End
 	if err != nil {
 		return types.AES128Key{}, err
 	}
-	return cryptoutil.UnwrapAES128Key(ctx, res.AppSKey, s.KeyVault)
+	return cryptoutil.UnwrapAES128Key(ctx, res.AppSKey, s.KeyService)
 }
 
 func (s *applicationRPCClient) GetAppKey(ctx context.Context, dev *ttnpb.EndDevice) (*types.AES128Key, error) {
@@ -193,7 +193,7 @@ func (s *applicationRPCClient) GetAppKey(ctx context.Context, dev *ttnpb.EndDevi
 		}
 		return nil, err
 	}
-	plain, err := cryptoutil.UnwrapAES128Key(ctx, ke, s.KeyVault)
+	plain, err := cryptoutil.UnwrapAES128Key(ctx, ke, s.KeyService)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crypto/cryptoutil/kek_labelers.go
+++ b/pkg/crypto/cryptoutil/kek_labelers.go
@@ -34,8 +34,8 @@ type ComponentPrefixKEKLabeler struct {
 // hostFromAddress returns the cluster host from the given address.
 func hostFromAddress(ctx context.Context, addr string) string {
 	host := addr
-	if url, err := url.Parse(addr); err == nil && url.Host != "" {
-		host = url.Host
+	if u, err := url.Parse(addr); err == nil && u.Host != "" {
+		host = u.Host
 	}
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
@@ -58,7 +58,8 @@ func (c ComponentPrefixKEKLabeler) join(parts ...string) string {
 	return strings.Join(parts, sep)
 }
 
-// NsKEKLabel returns a KEK label in the form `ns:netID:host` from the given NetID and address, where `:` is the default separator. Empty parts are omitted.
+// NsKEKLabel returns a KEK label in the form `ns:netID:host` from the given NetID and address,
+// where `:` is the default separator. Empty parts are omitted.
 func (c ComponentPrefixKEKLabeler) NsKEKLabel(ctx context.Context, netID *types.NetID, addr string) string {
 	parts := make([]string, 0, 3)
 	parts = append(parts, "ns")
@@ -71,7 +72,8 @@ func (c ComponentPrefixKEKLabeler) NsKEKLabel(ctx context.Context, netID *types.
 	return c.join(parts...)
 }
 
-// AsKEKLabel returns a KEK label in the form `as:host` from the given address, where `:` is the default separator. Empty parts are omitted.
+// AsKEKLabel returns a KEK label in the form `as:host` from the given address,
+// where `:` is the default separator. Empty parts are omitted.
 func (c ComponentPrefixKEKLabeler) AsKEKLabel(ctx context.Context, addr string) string {
 	parts := make([]string, 0, 2)
 	parts = append(parts, "as")

--- a/pkg/crypto/cryptoutil/kek_labelers_test.go
+++ b/pkg/crypto/cryptoutil/kek_labelers_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestComponentPrefixKEKLabeler(t *testing.T) {
+	t.Parallel()
 	for i, tc := range []struct {
 		Separator     string
 		ReplaceOldNew []string
@@ -107,7 +108,9 @@ func TestComponentPrefixKEKLabeler(t *testing.T) {
 			Expected: "ns_000042_localhost",
 		},
 	} {
+		tc := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
 			a := assertions.New(t)
 			labeler := ComponentPrefixKEKLabeler{
 				Separator:     tc.Separator,

--- a/pkg/crypto/cryptoutil/keyservice_cache.go
+++ b/pkg/crypto/cryptoutil/keyservice_cache.go
@@ -1,0 +1,68 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/bluele/gcache"
+	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
+)
+
+type cacheKeyServiceEntry struct {
+	value any
+	err   error
+}
+
+type cacheKeyService struct {
+	crypto.KeyService
+	cache gcache.Cache
+}
+
+// NewCacheKeyService returns a new crypto.KeyService that caches the results of Unwrap.
+func NewCacheKeyService(inner crypto.KeyService, ttl time.Duration, size int) crypto.KeyService {
+	builder := gcache.New(size).ARC()
+	if ttl != 0 {
+		builder = builder.Expiration(ttl)
+	}
+	return &cacheKeyService{
+		KeyService: inner,
+		cache:      builder.Build(),
+	}
+}
+
+func (c *cacheKeyService) getOrLoad(
+	ctx context.Context, cache crypto.CacheKey, key string, loaderFunc func() (interface{}, error),
+) (interface{}, error) {
+	cacheKey := fmt.Sprintf("%s:%s", cache, key)
+	if val, err := c.cache.Get(cacheKey); err == nil {
+		crypto.RegisterCacheHit(ctx, cache)
+		entry := val.(*cacheKeyServiceEntry)
+		return entry.value, entry.err
+	}
+	crypto.RegisterCacheMiss(ctx, cache)
+	val, err := loaderFunc()
+	c.cache.Set(cacheKey, &cacheKeyServiceEntry{val, err}) //nolint:errcheck
+	return val, err
+}
+
+func (c *cacheKeyService) Unwrap(ctx context.Context, ciphertext []byte, kekLabel string) ([]byte, error) {
+	res, err := c.getOrLoad(ctx, crypto.CacheUnwrap, kekLabel, func() (interface{}, error) {
+		return c.KeyService.Unwrap(ctx, ciphertext, kekLabel)
+	})
+	return res.([]byte), err
+}

--- a/pkg/crypto/cryptoutil/keyservice_cache_test.go
+++ b/pkg/crypto/cryptoutil/keyservice_cache_test.go
@@ -1,0 +1,127 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutil_test
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	. "go.thethings.network/lorawan-stack/v3/pkg/crypto/cryptoutil"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+type mockKeyService struct {
+	params struct {
+		ctx        context.Context
+		ciphertext []byte
+		kekLabel   string
+	}
+	results struct {
+		key []byte
+		err error
+	}
+	calls struct {
+		count int
+	}
+}
+
+func (*mockKeyService) Wrap(context.Context, []byte, string) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockKeyService) Unwrap(ctx context.Context, ciphertext []byte, label string) ([]byte, error) {
+	m.params.ctx, m.params.ciphertext, m.params.kekLabel = ctx, ciphertext, label
+	m.calls.count++
+	return m.results.key, m.results.err
+}
+
+func (*mockKeyService) Encrypt(context.Context, []byte, string) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*mockKeyService) Decrypt(context.Context, []byte, string) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*mockKeyService) ServerCertificate(context.Context, string) (tls.Certificate, error) {
+	return tls.Certificate{}, errors.New("not implemented")
+}
+
+func (*mockKeyService) ClientCertificate(context.Context) (tls.Certificate, error) {
+	return tls.Certificate{}, errors.New("not implemented")
+}
+
+func (*mockKeyService) HMACHash(context.Context, []byte, string) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestCacheUsed(t *testing.T) {
+	t.Parallel()
+	a := assertions.New(t)
+	m := &mockKeyService{}
+
+	ctx := test.Context()
+	ck := NewCacheKeyService(m, test.Delay, 1)
+
+	// Cache is empty, expect a miss
+	m.results.key = []byte{0x01, 0x02, 0x03}
+	m.results.err = nil
+
+	key, err := ck.Unwrap(ctx, []byte{0x02, 0x03, 0x04}, "foo")
+	a.So(key, should.Resemble, m.results.key)
+	a.So(err, should.Equal, m.results.err)
+	a.So(m.params.ctx, should.HaveParentContextOrEqual, ctx)
+	a.So(m.params.ciphertext, should.Resemble, []byte{0x02, 0x03, 0x04})
+	a.So(m.params.kekLabel, should.Equal, "foo")
+	a.So(m.calls.count, should.Equal, 1)
+
+	// Expect to be served from cache
+	key, err = ck.Unwrap(ctx, []byte{0x02, 0x03, 0x04}, "foo")
+	a.So(key, should.Resemble, m.results.key)
+	a.So(err, should.Equal, m.results.err)
+	a.So(m.calls.count, should.Equal, 1)
+
+	// Expect the old element to be evicted, and a cache miss to occur
+	m.results.key = []byte{0x05, 0x06, 0x07}
+	m.results.err = nil
+	m.calls.count = 0
+
+	key, err = ck.Unwrap(ctx, []byte{0x03, 0x04, 0x05}, "bar")
+	a.So(key, should.Resemble, m.results.key)
+	a.So(err, should.Equal, m.results.err)
+	a.So(m.params.ctx, should.HaveParentContextOrEqual, ctx)
+	a.So(m.params.ciphertext, should.Resemble, []byte{0x03, 0x04, 0x05})
+	a.So(m.params.kekLabel, should.Equal, "bar")
+	a.So(m.calls.count, should.Equal, 1)
+
+	// Expect the cache miss
+	m.results.key = []byte{0x01, 0x02, 0x03}
+	m.results.err = nil
+	m.calls.count = 0
+
+	key, err = ck.Unwrap(ctx, []byte{0x02, 0x03, 0x04}, "foo")
+	a.So(key, should.Resemble, m.results.key)
+	a.So(err, should.Equal, m.results.err)
+	a.So(m.params.ctx, should.HaveParentContextOrEqual, ctx)
+	a.So(m.params.ciphertext, should.Resemble, []byte{0x02, 0x03, 0x04})
+	a.So(m.params.kekLabel, should.Equal, "foo")
+	a.So(m.calls.count, should.Equal, 1)
+
+	// Delay based evictions are left out since they may lead to flakyness.
+}

--- a/pkg/crypto/cryptoutil/keyvault_cache.go
+++ b/pkg/crypto/cryptoutil/keyvault_cache.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@ package cryptoutil
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"time"
 
@@ -23,41 +25,158 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
 )
 
-type unwrapEntry struct {
-	value []byte
+type cacheKeyCacheEntry struct {
+	value any
 	err   error
 }
 
-type cachedVault struct {
-	crypto.KeyVault
-	unwrapCache gcache.Cache
+// CacheKeyVaultClock provides a time source.
+type CacheKeyVaultClock interface {
+	Now() time.Time
 }
 
-func NewCacheKeyVault(main crypto.KeyVault, ttl time.Duration, size int) crypto.KeyVault {
-	builder := gcache.New(size).ARC()
+// CacheKeyVaultClockFunc implements CacheKeyVaultClock.
+type CacheKeyVaultClockFunc func() time.Time
+
+// Now implements CacheKeyVaultClock.
+func (f CacheKeyVaultClockFunc) Now() time.Time {
+	return f()
+}
+
+type cacheKeyVault struct {
+	inner crypto.KeyVault
+	cache gcache.Cache
+	clock CacheKeyVaultClock
+}
+
+type cacheKeyVaultOptions struct {
+	ttl   time.Duration
+	size  int
+	clock CacheKeyVaultClock
+}
+
+// CacheKeyVaultOption configures CacheKeyVault.
+type CacheKeyVaultOption interface {
+	apply(*cacheKeyVaultOptions)
+}
+
+type cacheKeyVaultOptionFunc func(*cacheKeyVaultOptions)
+
+func (f cacheKeyVaultOptionFunc) apply(opts *cacheKeyVaultOptions) {
+	f(opts)
+}
+
+// WithCacheKeyVaultSize configures the size of the cache.
+func WithCacheKeyVaultSize(size int) CacheKeyVaultOption {
+	return cacheKeyVaultOptionFunc(func(opts *cacheKeyVaultOptions) {
+		opts.size = size
+	})
+}
+
+// WithCacheKeyVaultTTL configures the time-to-live of the cache. If 0, no expiry is used.
+func WithCacheKeyVaultTTL(ttl time.Duration) CacheKeyVaultOption {
+	return cacheKeyVaultOptionFunc(func(opts *cacheKeyVaultOptions) {
+		opts.ttl = ttl
+	})
+}
+
+// WithCacheKeyVaultClock configures a time source.
+// This is useful for testing.
+func WithCacheKeyVaultClock(clock CacheKeyVaultClock) CacheKeyVaultOption {
+	return cacheKeyVaultOptionFunc(func(opts *cacheKeyVaultOptions) {
+		opts.clock = clock
+	})
+}
+
+// NewCacheKeyVault returns a new crypto.KeyVault that caches the keys in memory.
+// Certificates are cached for the duration of their validity minus one hour, maximed by the given time-to-live.
+func NewCacheKeyVault(inner crypto.KeyVault, opts ...CacheKeyVaultOption) crypto.KeyVault {
+	options := &cacheKeyVaultOptions{
+		size:  1000,
+		clock: CacheKeyVaultClockFunc(time.Now),
+	}
+	for _, opt := range opts {
+		opt.apply(options)
+	}
+	builder := gcache.New(options.size).ARC()
+	if options.ttl != 0 {
+		builder = builder.Expiration(options.ttl)
+	}
+	if options.clock != nil {
+		builder = builder.Clock(options.clock)
+	}
+	return &cacheKeyVault{
+		inner: inner,
+		cache: builder.Build(),
+		clock: options.clock,
+	}
+}
+
+func (c *cacheKeyVault) getOrLoad(
+	ctx context.Context, cache crypto.CacheKey, label string, loaderFn func() (any, time.Duration, error),
+) (any, error) {
+	cacheKey := fmt.Sprintf("%s:%s", cache, label)
+	val, err := c.cache.Get(cacheKey)
+	if err == nil {
+		crypto.RegisterCacheHit(ctx, cache)
+		entry := val.(*cacheKeyCacheEntry)
+		return entry.value, entry.err
+	}
+	crypto.RegisterCacheMiss(ctx, cache)
+	val, ttl, err := loaderFn()
 	if ttl != 0 {
-		builder = builder.Expiration(ttl)
+		c.cache.SetWithExpire(cacheKey, &cacheKeyCacheEntry{val, err}, ttl) //nolint:errcheck
+	} else {
+		c.cache.Set(cacheKey, &cacheKeyCacheEntry{val, err}) //nolint:errcheck
 	}
-	return &cachedVault{
-		KeyVault:    main,
-		unwrapCache: builder.Build(),
-	}
+	return val, err
 }
 
-func unwrapCacheKey(ciphertext []byte, kekLabel string) string {
-	return fmt.Sprintf("%v:%v", kekLabel, ciphertext)
+// Key implements crypto.KeyVault.
+func (c *cacheKeyVault) Key(ctx context.Context, label string) ([]byte, error) {
+	val, err := c.getOrLoad(ctx, crypto.CacheEncryptionKey, label, func() (any, time.Duration, error) {
+		val, err := c.inner.Key(ctx, label)
+		return val, 0, err
+	})
+	return val.([]byte), err
 }
 
-func (c *cachedVault) Unwrap(ctx context.Context, ciphertext []byte, kekLabel string) ([]byte, error) {
-	id := unwrapCacheKey(ciphertext, kekLabel)
-	if val, err := c.unwrapCache.Get(id); err == nil {
-		crypto.RegisterCacheHit(ctx, "unwrap")
-		v := val.(*unwrapEntry)
-		return v.value, v.err
+func (c *cacheKeyVault) cacheCertificateTTL(crt tls.Certificate) (time.Duration, bool) {
+	if len(crt.Certificate) > 0 {
+		cert, err := x509.ParseCertificate(crt.Certificate[0])
+		if err == nil {
+			return cert.NotAfter.Sub(c.clock.Now()) - time.Hour, true
+		}
 	}
-	v := &unwrapEntry{}
-	c.unwrapCache.Set(id, v)
-	crypto.RegisterCacheMiss(ctx, "unwrap")
-	v.value, v.err = c.KeyVault.Unwrap(ctx, ciphertext, kekLabel)
-	return v.value, v.err
+	return 0, false
+}
+
+// Certificate implements crypto.KeyVault.
+func (c *cacheKeyVault) ServerCertificate(ctx context.Context, label string) (tls.Certificate, error) {
+	val, err := c.getOrLoad(ctx, crypto.CacheServerCertificate, label, func() (any, time.Duration, error) {
+		val, err := c.inner.ServerCertificate(ctx, label)
+		ttl := time.Duration(0)
+		if err == nil {
+			if certTTL, ok := c.cacheCertificateTTL(val); ok {
+				ttl = certTTL
+			}
+		}
+		return val, ttl, err
+	})
+	return val.(tls.Certificate), err
+}
+
+// ClientCertificate implements crypto.KeyVault.
+func (c *cacheKeyVault) ClientCertificate(ctx context.Context) (tls.Certificate, error) {
+	val, err := c.getOrLoad(ctx, crypto.CacheClientCertificate, "", func() (any, time.Duration, error) {
+		val, err := c.inner.ClientCertificate(ctx)
+		ttl := time.Duration(0)
+		if err == nil {
+			if certTTL, ok := c.cacheCertificateTTL(val); ok {
+				ttl = certTTL
+			}
+		}
+		return val, ttl, err
+	})
+	return val.(tls.Certificate), err
 }

--- a/pkg/crypto/cryptoutil/keyvault_empty.go
+++ b/pkg/crypto/cryptoutil/keyvault_empty.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,33 +21,22 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
 )
 
-type emptyKeyVault struct {
-	ComponentPrefixKEKLabeler
+type emptyKeyVault struct{}
+
+// Key implements crypto.KeyVault.
+func (emptyKeyVault) Key(_ context.Context, label string) ([]byte, error) {
+	return nil, errKeyNotFound.WithAttributes("label", label)
+}
+
+// ServerCertificate implements crypto.KeyVault.
+func (emptyKeyVault) ServerCertificate(_ context.Context, label string) (tls.Certificate, error) {
+	return tls.Certificate{}, errCertificateNotFound.WithAttributes("label", label)
+}
+
+// ClientCertificate implements crypto.KeyVault.
+func (emptyKeyVault) ClientCertificate(_ context.Context) (tls.Certificate, error) {
+	return tls.Certificate{}, errClientCertificateNotFound.New()
 }
 
 // EmptyKeyVault is an empty key vault.
 var EmptyKeyVault crypto.KeyVault = emptyKeyVault{}
-
-func (emptyKeyVault) Wrap(ctx context.Context, plaintext []byte, kekLabel string) ([]byte, error) {
-	return nil, errKEKNotFound.WithAttributes("label", kekLabel)
-}
-
-func (emptyKeyVault) Unwrap(ctx context.Context, ciphertext []byte, kekLabel string) ([]byte, error) {
-	return nil, errKEKNotFound.WithAttributes("label", kekLabel)
-}
-
-func (emptyKeyVault) Encrypt(ctx context.Context, plaintext []byte, id string) ([]byte, error) {
-	return nil, errKeyNotFound.WithAttributes("id", id)
-}
-
-func (emptyKeyVault) Decrypt(ctx context.Context, ciphertext []byte, id string) ([]byte, error) {
-	return nil, errKeyNotFound.WithAttributes("id", id)
-}
-
-func (emptyKeyVault) ExportCertificate(ctx context.Context, id string) (*tls.Certificate, error) {
-	return nil, errCertificateNotFound.WithAttributes("id", id)
-}
-
-func (emptyKeyVault) HMACHash(_ context.Context, _ []byte, id string) ([]byte, error) {
-	return nil, errKeyNotFound.WithAttributes("id", id)
-}

--- a/pkg/crypto/cryptoutil/keyvault_empty.go
+++ b/pkg/crypto/cryptoutil/keyvault_empty.go
@@ -17,7 +17,6 @@ package cryptoutil
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
 )
@@ -43,10 +42,6 @@ func (emptyKeyVault) Encrypt(ctx context.Context, plaintext []byte, id string) (
 
 func (emptyKeyVault) Decrypt(ctx context.Context, ciphertext []byte, id string) ([]byte, error) {
 	return nil, errKeyNotFound.WithAttributes("id", id)
-}
-
-func (emptyKeyVault) GetCertificate(ctx context.Context, id string) (*x509.Certificate, error) {
-	return nil, errCertificateNotFound.WithAttributes("id", id)
 }
 
 func (emptyKeyVault) ExportCertificate(ctx context.Context, id string) (*tls.Certificate, error) {

--- a/pkg/crypto/cryptoutil/keyvault_empty_test.go
+++ b/pkg/crypto/cryptoutil/keyvault_empty_test.go
@@ -40,9 +40,6 @@ func TestEmptyKeyVault(t *testing.T) {
 	_, err = cryptoutil.EmptyKeyVault.Decrypt(test.Context(), []byte{0x1, 0x2}, "test")
 	a.So(errors.IsNotFound(err), should.BeTrue)
 
-	_, err = cryptoutil.EmptyKeyVault.GetCertificate(test.Context(), "test")
-	a.So(errors.IsNotFound(err), should.BeTrue)
-
 	_, err = cryptoutil.EmptyKeyVault.ExportCertificate(test.Context(), "test")
 	a.So(errors.IsNotFound(err), should.BeTrue)
 

--- a/pkg/crypto/cryptoutil/keyvault_empty_test.go
+++ b/pkg/crypto/cryptoutil/keyvault_empty_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,23 +26,15 @@ import (
 )
 
 func TestEmptyKeyVault(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
-	_, err := cryptoutil.EmptyKeyVault.Wrap(test.Context(), []byte{0x1, 0x2}, "test")
+	_, err := cryptoutil.EmptyKeyVault.Key(test.Context(), "test")
 	a.So(errors.IsNotFound(err), should.BeTrue)
 
-	_, err = cryptoutil.EmptyKeyVault.Unwrap(test.Context(), []byte{0x1, 0x2}, "test")
+	_, err = cryptoutil.EmptyKeyVault.ServerCertificate(test.Context(), "test")
 	a.So(errors.IsNotFound(err), should.BeTrue)
 
-	_, err = cryptoutil.EmptyKeyVault.Encrypt(test.Context(), []byte{0x1, 0x2}, "test")
-	a.So(errors.IsNotFound(err), should.BeTrue)
-
-	_, err = cryptoutil.EmptyKeyVault.Decrypt(test.Context(), []byte{0x1, 0x2}, "test")
-	a.So(errors.IsNotFound(err), should.BeTrue)
-
-	_, err = cryptoutil.EmptyKeyVault.ExportCertificate(test.Context(), "test")
-	a.So(errors.IsNotFound(err), should.BeTrue)
-
-	_, err = cryptoutil.EmptyKeyVault.HMACHash(test.Context(), []byte{0x01, 0x02}, "test")
+	_, err = cryptoutil.EmptyKeyVault.ClientCertificate(test.Context())
 	a.So(errors.IsNotFound(err), should.BeTrue)
 }

--- a/pkg/crypto/cryptoutil/keyvault_mem.go
+++ b/pkg/crypto/cryptoutil/keyvault_mem.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/pem"
 	"strings"
 
@@ -96,19 +95,6 @@ func (v MemKeyVault) HMACHash(_ context.Context, payload []byte, id string) ([]b
 		return nil, err
 	}
 	return crypto.HMACHash(key, payload)
-}
-
-// GetCertificate implements KeyVault.
-func (v MemKeyVault) GetCertificate(ctx context.Context, id string) (*x509.Certificate, error) {
-	raw, ok := v.m[id]
-	if !ok {
-		return nil, errCertificateNotFound.WithAttributes("id", id)
-	}
-	block, _ := pem.Decode(raw)
-	if block == nil || block.Type != "CERTIFICATE" {
-		return nil, errCertificateNotFound.WithAttributes("id", id)
-	}
-	return x509.ParseCertificate(block.Bytes)
 }
 
 // ExportCertificate implements KeyVault.

--- a/pkg/crypto/cryptoutil/keyvault_mem.go
+++ b/pkg/crypto/cryptoutil/keyvault_mem.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,86 +22,25 @@ import (
 	"strings"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
-	"go.thethings.network/lorawan-stack/v3/pkg/types"
 )
 
-// MemKeyVault is a KeyVault that uses secrets from memory.
-// This implementation does not provide any security as secrets are stored in the clear.
-type MemKeyVault struct {
-	ComponentPrefixKEKLabeler
+type memKeyVault struct {
 	m map[string][]byte
 }
 
-// NewMemKeyVault returns a MemKeyVault.
-// Certificates keys can be appended as PEM block.
-func NewMemKeyVault(m map[string][]byte) *MemKeyVault {
-	return &MemKeyVault{
-		m: m,
+// Key implements crypto.KeyVault.
+func (kv *memKeyVault) Key(_ context.Context, label string) ([]byte, error) {
+	key, ok := kv.m[label]
+	if !ok {
+		return nil, errKeyNotFound.WithAttributes("label", label)
 	}
+	return key, nil
 }
 
-// Wrap implements KeyVault.
-func (v MemKeyVault) Wrap(ctx context.Context, plaintext []byte, kekLabel string) ([]byte, error) {
-	kek, ok := v.m[kekLabel]
+func (kv *memKeyVault) certificate(label string) (tls.Certificate, error) {
+	raw, ok := kv.m[label]
 	if !ok {
-		return nil, errKEKNotFound.WithAttributes("label", kekLabel)
-	}
-	return crypto.WrapKey(plaintext, kek)
-}
-
-// Unwrap implements KeyVault.
-func (v MemKeyVault) Unwrap(ctx context.Context, ciphertext []byte, kekLabel string) ([]byte, error) {
-	kek, ok := v.m[kekLabel]
-	if !ok {
-		return nil, errKEKNotFound.WithAttributes("label", kekLabel)
-	}
-	return crypto.UnwrapKey(ciphertext, kek)
-}
-
-// Encrypt implements KeyVault.
-func (v MemKeyVault) Encrypt(ctx context.Context, plaintext []byte, id string) ([]byte, error) {
-	rawKey, ok := v.m[id]
-	if !ok {
-		return nil, errKeyNotFound.WithAttributes("id", id)
-	}
-	var key types.AES128Key
-	if err := key.UnmarshalBinary(rawKey); err != nil {
-		return nil, err
-	}
-	return crypto.Encrypt(key, plaintext)
-}
-
-// Decrypt implements KeyVault.
-func (v MemKeyVault) Decrypt(ctx context.Context, ciphertext []byte, id string) ([]byte, error) {
-	rawKey, ok := v.m[id]
-	if !ok {
-		return nil, errKeyNotFound.WithAttributes("id", id)
-	}
-	var key types.AES128Key
-	if err := key.UnmarshalBinary(rawKey); err != nil {
-		return nil, err
-	}
-	return crypto.Decrypt(key, ciphertext)
-}
-
-// HMACHash implements KeyVault.
-func (v MemKeyVault) HMACHash(_ context.Context, payload []byte, id string) ([]byte, error) {
-	rawKey, ok := v.m[id]
-	if !ok {
-		return nil, errKeyNotFound.WithAttributes("id", id)
-	}
-	var key types.AES128Key
-	if err := key.UnmarshalBinary(rawKey); err != nil {
-		return nil, err
-	}
-	return crypto.HMACHash(key, payload)
-}
-
-// ExportCertificate implements KeyVault.
-func (v MemKeyVault) ExportCertificate(ctx context.Context, id string) (*tls.Certificate, error) {
-	raw, ok := v.m[id]
-	if !ok {
-		return nil, errCertificateNotFound.WithAttributes("id", id)
+		return tls.Certificate{}, errCertificateNotFound.WithAttributes("label", label)
 	}
 	certPEMBlock, keyPEMBlock := &bytes.Buffer{}, &bytes.Buffer{}
 	for {
@@ -111,18 +50,33 @@ func (v MemKeyVault) ExportCertificate(ctx context.Context, id string) (*tls.Cer
 		}
 		if block.Type == "CERTIFICATE" {
 			if err := pem.Encode(certPEMBlock, block); err != nil {
-				return nil, err
+				return tls.Certificate{}, err
 			}
 		} else if block.Type == "PRIVATE KEY" || strings.HasSuffix(block.Type, " PRIVATE KEY") {
 			if err := pem.Encode(keyPEMBlock, block); err != nil {
-				return nil, err
+				return tls.Certificate{}, err
 			}
 		}
 		raw = rest
 	}
-	res, err := tls.X509KeyPair(certPEMBlock.Bytes(), keyPEMBlock.Bytes())
-	if err != nil {
-		return nil, err
+	return tls.X509KeyPair(certPEMBlock.Bytes(), keyPEMBlock.Bytes())
+}
+
+// ServerCertificate implements crypto.KeyVault.
+func (kv *memKeyVault) ServerCertificate(_ context.Context, label string) (tls.Certificate, error) {
+	return kv.certificate(label)
+}
+
+// ClientCertificate implements crypto.KeyVault.
+func (kv *memKeyVault) ClientCertificate(context.Context) (tls.Certificate, error) {
+	return kv.certificate("client")
+}
+
+// NewMemKeyVault returns a crypto.KeyVault that stores keys in memory.
+// Certificates must be PEM encoded. The client certificate must be labeled "client".
+// The given map must not be modified after calling this function.
+func NewMemKeyVault(m map[string][]byte) crypto.KeyVault {
+	return &memKeyVault{
+		m: m,
 	}
-	return &res, nil
 }

--- a/pkg/crypto/cryptoutil/keyvault_mem_test.go
+++ b/pkg/crypto/cryptoutil/keyvault_mem_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,11 +16,13 @@ package cryptoutil_test
 
 import (
 	"crypto/ecdsa"
+	"crypto/rsa"
 	"crypto/subtle"
 	"encoding/hex"
 	"testing"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto/cryptoutil"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
@@ -28,6 +30,7 @@ import (
 )
 
 func TestMemKeyVault(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
 	plaintext, _ := hex.DecodeString("00112233445566778899AABBCCDDEEFF")
@@ -37,8 +40,9 @@ func TestMemKeyVault(t *testing.T) {
 	genericPlainText := []byte("thisisabigsecret")
 	key, _ := hex.DecodeString("00112233445566778899AABBCCDDEEFF")
 
-	v := cryptoutil.NewMemKeyVault(map[string][]byte{
+	kv := cryptoutil.NewMemKeyVault(map[string][]byte{
 		"kek1": kek,
+		"key1": key,
 		"cert1": []byte(`-----BEGIN CERTIFICATE-----
 MIIBfDCCASKgAwIBAgIBBDAKBggqhkjOPQQDAjAkMRAwDgYDVQQKEwdBY21lIENv
 MRAwDgYDVQQDEwdSb290IENBMCAXDTE5MDgwNzExMzYxOFoYDzIxMTkwNzE0MTEz
@@ -55,56 +59,140 @@ AwEHoUQDQgAEjf3zZPXlc/sseTt7YzF0o61feXvk98JFyy+s/j0gzMzUjEka7+Wz
 TPERi9uMQjERns1qXG/9DJLe/Qxi0r84hA==
 -----END EC PRIVATE KEY-----
 `),
-		"key1": key,
+		"client": []byte(`-----BEGIN CERTIFICATE-----
+MIIEbzCCAtegAwIBAgIRANiI/y0X2PqYWt0LYz7EcvkwDQYJKoZIhvcNAQELBQAw
+gZsxHjAcBgNVBAoTFW1rY2VydCBkZXZlbG9wbWVudCBDQTE4MDYGA1UECwwvam9o
+YW5ASm9oYW5zLU1hY0Jvb2stUHJvLmxvY2FsIChKb2hhbiBTdG9ra2luZykxPzA9
+BgNVBAMMNm1rY2VydCBqb2hhbkBKb2hhbnMtTWFjQm9vay1Qcm8ubG9jYWwgKEpv
+aGFuIFN0b2traW5nKTAeFw0yMjEyMTQxMzE0MzBaFw0yNTAzMTQxMzE0MzBaMGMx
+JzAlBgNVBAoTHm1rY2VydCBkZXZlbG9wbWVudCBjZXJ0aWZpY2F0ZTE4MDYGA1UE
+Cwwvam9oYW5ASm9oYW5zLU1hY0Jvb2stUHJvLmxvY2FsIChKb2hhbiBTdG9ra2lu
+ZykwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC8CUD5bBqUZKPU0a5m
+X8HKN+WMiBqHnAOC2b3DG66LpE67G1iQSskpnyaC3HfjR4sbN7fvujq67KM9CCSp
+N+HrJsolW9lob3E7NPqrC9fp1o8k6e13JeQH3HNogkcEd2xBcmOm/pOp1zXUQfMo
+2sqsaESmy7++cAyMITBK627dZVh3nTpNGtPuQSQuzO57EVxM9eJnYKJK6+Qyt+qg
+kxod+uHsCHT6avV7oITD5m8hYueEwGTk5X5yvuOtyQgjhMGgS4wypyRahIXuUymd
+bNA0656ze4+XwBYISuJtCMONveYgjVfSAzF0qWe9WwwYjNvl65aI1V77ar5U6kMl
+yPCBAgMBAAGjZTBjMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcD
+AgYIKwYBBQUHAwEwHwYDVR0jBBgwFoAUhzWfRIDn/IZkQruKVvTVZtIAVIQwEQYD
+VR0RBAowCIIGMDAwMDEzMA0GCSqGSIb3DQEBCwUAA4IBgQA/aqDqz5gpYN5G9foP
+mouFDJlNm4sWaDxMtCweaOaI5K7golON7vXU1OYs8/mZijeiWwWI5Lvp6iI2oFVW
+mPf4DdyCUXzDQUHlBP5UvbEPDosRR2+hwLUDmGTmCd2SJ00Gqi6tIJvSdDReYyMx
+fNu9SweSiN31adVO4yLxvkDbsvRNySlmJtsN0zZOlf5EO1AjBgFjShCV6VXzRZVB
+/E+hhZLYVQHftdXsZwoZsWrrz7NIzI3LQWXIhdM85A6JxCj5/X7QCKfC5w5bDsFE
+WsGApwMYMPIU03Pi74xImho/oHVhJl5P6VKWiry/odczSnUeR8JGPKLI74xowz5x
+SFgCNkcRoEBSvFc/RtcarHln0bTWdpHn+M17mz0bGm18hmqJk869xXVTGdBV0IMt
+VFD2heIHIPCuQeK72HiYBuPf4zUDzdJBM0bws9jg4tG7C4UQ/G9nKijCTTSBZ3mh
+PfSiNlBbUVD+Kr9jdJ6olE+ptRkrkwHs3fS3GczUap6iJoQ=
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIFBzCCA2+gAwIBAgIQYgrUieWsg08BHkDDcf5LxjANBgkqhkiG9w0BAQsFADCB
+mzEeMBwGA1UEChMVbWtjZXJ0IGRldmVsb3BtZW50IENBMTgwNgYDVQQLDC9qb2hh
+bkBKb2hhbnMtTWFjQm9vay1Qcm8ubG9jYWwgKEpvaGFuIFN0b2traW5nKTE/MD0G
+A1UEAww2bWtjZXJ0IGpvaGFuQEpvaGFucy1NYWNCb29rLVByby5sb2NhbCAoSm9o
+YW4gU3Rva2tpbmcpMB4XDTIyMTIxNDEyNDUwNVoXDTMyMTIxNDEyNDUwNVowgZsx
+HjAcBgNVBAoTFW1rY2VydCBkZXZlbG9wbWVudCBDQTE4MDYGA1UECwwvam9oYW5A
+Sm9oYW5zLU1hY0Jvb2stUHJvLmxvY2FsIChKb2hhbiBTdG9ra2luZykxPzA9BgNV
+BAMMNm1rY2VydCBqb2hhbkBKb2hhbnMtTWFjQm9vay1Qcm8ubG9jYWwgKEpvaGFu
+IFN0b2traW5nKTCCAaIwDQYJKoZIhvcNAQEBBQADggGPADCCAYoCggGBAK1yiSEd
+Oa+aDu/YOFvDfE0uYv9jpncI9Cy3gN4D1M0+w1gk4i7LavxJOJF/OEv2pY5dnQoX
+ucYQEtZvxeUY3TSSE6ak4DNSvryOytn7wvvRpvnnbwRNKu8UkrdJT1gotobY8JUt
+q4exzzaqPhD4rOVWbDfoTkO4++qpecMgtkLJ7lPTmYZOlht4Zan4xEYfleBJvEAh
+g2UU5UbYI8q3DcREP3sl/V5S82NmrCgFwJY+2T2hRZkt2HXG4e7wKvc6TTMFnOyy
+SAIqZfv2WVBo+haLOJkXWhzU3bExyhbsrWTDZEeloZK74w/tSv9dz6QGn6RlVb1O
+6TuG8fl29tXrx1TIF22fgwK29D5e2xlHyCioQyxXOdt2kvrlLSKq48d+rMB6PiBD
+TccISOCTkAxzITACSncBzu1Y3u8F8hdDtGYgtXhcvTn5pbzvEvOsg5tgqrVwzj4y
+ZbE40+ZNf0pz1//OtZhrbapoS/kwwMFy+rSfly6LInrqvQQQqEgtjrEJ3wIDAQAB
+o0UwQzAOBgNVHQ8BAf8EBAMCAgQwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4E
+FgQUhzWfRIDn/IZkQruKVvTVZtIAVIQwDQYJKoZIhvcNAQELBQADggGBACRJqdQ3
+OIE51KUrtVe07OrUpBirfRM7puIvrB/+MEN2fFOUblQ+B7UKyzHOeH/UmPnSaR1W
+AkdwT0fx3r9rf9tVadUpNlwEk/pDT7aQQCw7KAdVUoEPFcyBD0xVvNpNaWozeub1
+g2JIUnLd2XTvygbLRAUQ/+I9WBquMDyTYtgDgp5ShzsWwnYGuQjQyJb7UV/Qddf2
+ohFwxsIea8C/QEkMgkJDTVLn6JNKFlriYPLi0TXE0KQbN5f187j9caeoFKahyxZA
+Br5UbQI6ACWzdTn32lSQTs0RGTnOWq2hFPLYB045XsdfTcUFk3l3ivnlZ103HSDq
++EDPC6I/Hhjwsn8WGcQmnlcSGL7RSRNckhg4ruCjNSI0TuJ2wI3tTpGwPHEBUgHh
+sMxzjZqT4RBSF7I+9Ki/yufqWNsrovKufhOrj5FnJdqMOs1Pm0fcRb7LCeuuWc0p
+pveJZu/2DmCUNMGVQKew7mrNnUTtFgvDja3/BS+OxZ/p7pqmvpXsvkAvzA==
+-----END CERTIFICATE-----
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC8CUD5bBqUZKPU
+0a5mX8HKN+WMiBqHnAOC2b3DG66LpE67G1iQSskpnyaC3HfjR4sbN7fvujq67KM9
+CCSpN+HrJsolW9lob3E7NPqrC9fp1o8k6e13JeQH3HNogkcEd2xBcmOm/pOp1zXU
+QfMo2sqsaESmy7++cAyMITBK627dZVh3nTpNGtPuQSQuzO57EVxM9eJnYKJK6+Qy
+t+qgkxod+uHsCHT6avV7oITD5m8hYueEwGTk5X5yvuOtyQgjhMGgS4wypyRahIXu
+UymdbNA0656ze4+XwBYISuJtCMONveYgjVfSAzF0qWe9WwwYjNvl65aI1V77ar5U
+6kMlyPCBAgMBAAECggEAa7vtkzqh+/WxfGTqxFMG6EKgbaUpdhsoU9dHhzscBXwN
+c9yWII4ItaUu3nlM41aBWAXTiDGuJp0gZf59asrO0Pk3hrIaXWDEgoS3PjsZ6St6
+dk7lNIfsH6jqIq3J3MBDsTfF6s8fcYcRm1xx4i2BQ8i11M8WPBlcxwjY74P20Ded
+ZgQb0B3KVTdrZvNHH/uL4S/fa/E5MHCFw4p1pT2hhHLzumxK+mwXnkKXEiiPBNtG
+4QRwixsGhJkE+aDMc14H3q1EltTBSpq3twD1sfl+uDnIo83aEp6An4/AJt+1eouF
+3Jsdl6oaZLVIEvxqMBzP9Fjqif/HfIc8VypVFoB8AQKBgQDu5rwbBth2AHSRxROv
+ahYNzAydnxOc6ma4H7ax7LAZk0qKCmxahuXAuXGSouYaJr1kRmBw+2CwU8u84lHa
+nnr92qk2fa/+P6lDADIHK2dATIqEXViuMzzZCugQYFUwrDlnvxH1HQ4qY/jOYZ6M
+b9HDNrasahBEDHPu0uiNVeUaoQKBgQDJfosAXHemxRCPq3Lw7R2dU1KSVe91w2Sv
+JSwtzZn3EkN54r3LQFUGU8L1A7i3jeF9g8VGRFkO5GUudBq1QNf5GH8H1zHuQ9hE
+KoX6YnuWIJ9UWEKR+eZB+R9Tn6jAZsALRNV7G+9EJZMpVXzogzuxSQJnDKOsp3Rc
+SPU5pDDp4QKBgGq82nR01Ye7YlmypL3t9xaJAWX3Kgsky2oeeUD7kB6NKXONfqXf
+uY0nDbBHaelrP5kqvHIeTi/Z8KBeudWkky0SYiH/e/9rsBNIZhG/+azHxeen0TRb
+nicW8WJHuCg7+pX4z2wlZCvaaNLE2NLELwM6UdmstcHBkpa00sQ7CVahAoGBAKa/
+BRMwcohdjt4GWWGOKLLYkH2vhjJjl7/luFDTU/YGdDa68KvyOiq5SJ5xDP1B+fhg
+AvKqfzT2x9EQnkWfOtvWbNG1QYnXNXL76dISjAnqR1CKldSuBOJV4pnWh9VpcsYg
+mbZ+oJw5qDZNm8fjSpPlQoq7B/xKu93fNqkT+rKhAoGAHFBfgS7WAi6Snz0LreMb
+JRirtVNS4U9qx4x9yvLXrwbqHg4wlOLNbu5DAXxVCy2tLjTT1faIG1idIYLYGSw2
+6XIkwt9xoA7LJ5IIebRuAKNpINxu2IlscVLly/nXnpnNnEwvwWadQBc5dRC3mEPp
+BQApUt5UZZkvwrTGD5Ez4KM=
+-----END PRIVATE KEY-----
+`),
 	})
+	ks := crypto.NewKeyService(kv)
 
 	// Existing KEK.
 	{
-		actual, err := v.Wrap(test.Context(), plaintext, "kek1")
+		actual, err := ks.Wrap(test.Context(), plaintext, "kek1")
 		a.So(err, should.BeNil)
 		a.So(actual, should.Resemble, ciphertext)
 	}
 	{
-		actual, err := v.Unwrap(test.Context(), ciphertext, "kek1")
+		actual, err := ks.Unwrap(test.Context(), ciphertext, "kek1")
 		a.So(err, should.BeNil)
 		a.So(actual, should.Resemble, plaintext)
 	}
 
 	// Non-existing KEK.
 	{
-		_, err := v.Wrap(test.Context(), plaintext, "kek2")
+		_, err := ks.Wrap(test.Context(), plaintext, "kek2")
 		a.So(errors.IsNotFound(err), should.BeTrue)
 	}
 	{
-		_, err := v.Unwrap(test.Context(), ciphertext, "kek2")
+		_, err := ks.Unwrap(test.Context(), ciphertext, "kek2")
 		a.So(errors.IsNotFound(err), should.BeTrue)
 	}
 
 	// Existing Key.
 	{
-		encrypted, err := v.Encrypt(test.Context(), genericPlainText, "key1")
+		encrypted, err := ks.Encrypt(test.Context(), genericPlainText, "key1")
 		a.So(err, should.BeNil)
 
 		expectedCiphertextLen := len(genericPlainText) + 12 + 16
 		a.So(len(encrypted), should.Equal, expectedCiphertextLen)
 
-		actual, err := v.Decrypt(test.Context(), encrypted, "key1")
+		actual, err := ks.Decrypt(test.Context(), encrypted, "key1")
 		a.So(err, should.BeNil)
 		a.So(actual, should.Resemble, genericPlainText)
 	}
 
 	// Non-existing Key.
 	{
-		_, err := v.Encrypt(test.Context(), genericPlainText, "key2")
+		_, err := ks.Encrypt(test.Context(), genericPlainText, "key2")
 		a.So(errors.IsNotFound(err), should.BeTrue)
 
-		_, err = v.Decrypt(test.Context(), []uint8{}, "key2")
+		_, err = ks.Decrypt(test.Context(), []uint8{}, "key2")
 		a.So(errors.IsNotFound(err), should.BeTrue)
 	}
 
 	// Export existing certificate.
 	{
-		cert, err := v.ExportCertificate(test.Context(), "cert1")
+		cert, err := ks.ServerCertificate(test.Context(), "cert1")
 		a.So(err, should.BeNil)
 		if a.So(len(cert.Certificate), should.Equal, 1) {
 			a.So(len(cert.Certificate[0]), should.Equal, 384)
@@ -114,34 +202,44 @@ TPERi9uMQjERns1qXG/9DJLe/Qxi0r84hA==
 
 	// Export non-existing certificate.
 	{
-		_, err := v.ExportCertificate(test.Context(), "cert2")
+		_, err := ks.ServerCertificate(test.Context(), "cert2")
 		a.So(errors.IsNotFound(err), should.BeTrue)
+	}
+
+	// Export existing client certificate.
+	{
+		cert, err := ks.ClientCertificate(test.Context())
+		a.So(err, should.BeNil)
+		a.So(len(cert.Certificate), should.Equal, 2)
+		a.So(cert.PrivateKey, should.HaveSameTypeAs, &rsa.PrivateKey{})
 	}
 
 	// Hashing with valid key
 	{
-		hash1, err := v.HMACHash(test.Context(), []byte{0x01, 0x02}, "key1")
+		hash1, err := ks.HMACHash(test.Context(), []byte{0x01, 0x02}, "key1")
 		a.So(err, should.BeNil)
 		a.So(hash1, should.NotBeNil)
-		hash2, err := v.HMACHash(test.Context(), []byte{0x01, 0x02}, "key1")
+
+		hash2, err := ks.HMACHash(test.Context(), []byte{0x01, 0x02}, "key1")
 		a.So(err, should.BeNil)
 		a.So(hash2, should.NotBeNil)
 		a.So(subtle.ConstantTimeCompare(hash1, hash2), should.Equal, 1)
 	}
 
-	// Hashing with invalild key
+	// Hashing with invalid key
 	{
-		hash, err := v.HMACHash(test.Context(), []byte{0x01, 0x02}, "key2")
+		hash, err := ks.HMACHash(test.Context(), []byte{0x01, 0x02}, "key2")
 		a.So(errors.IsNotFound(err), should.BeTrue)
 		a.So(hash, should.BeNil)
 	}
 
 	// Hashing with corrupted value key
 	{
-		hash1, err := v.HMACHash(test.Context(), []byte{0x01, 0x02}, "key1")
+		hash1, err := ks.HMACHash(test.Context(), []byte{0x01, 0x02}, "key1")
 		a.So(err, should.BeNil)
 		a.So(hash1, should.NotBeNil)
-		hash2, err := v.HMACHash(test.Context(), []byte{0x01, 0x02, 0x03}, "key1")
+
+		hash2, err := ks.HMACHash(test.Context(), []byte{0x01, 0x02, 0x03}, "key1")
 		a.So(err, should.BeNil)
 		a.So(hash2, should.NotBeNil)
 		a.So(subtle.ConstantTimeCompare(hash1, hash2), should.BeZeroValue)

--- a/pkg/crypto/cryptoutil/keyvault_mem_test.go
+++ b/pkg/crypto/cryptoutil/keyvault_mem_test.go
@@ -102,19 +102,6 @@ TPERi9uMQjERns1qXG/9DJLe/Qxi0r84hA==
 		a.So(errors.IsNotFound(err), should.BeTrue)
 	}
 
-	// Get existing certificate.
-	{
-		cert, err := v.GetCertificate(test.Context(), "cert1")
-		a.So(err, should.BeNil)
-		a.So(cert.Subject.CommonName, should.Equal, "client_auth_test_cert")
-	}
-
-	// Get non-existing certificate.
-	{
-		_, err := v.GetCertificate(test.Context(), "cert2")
-		a.So(errors.IsNotFound(err), should.BeTrue)
-	}
-
 	// Export existing certificate.
 	{
 		cert, err := v.ExportCertificate(test.Context(), "cert1")

--- a/pkg/crypto/keyservice.go
+++ b/pkg/crypto/keyservice.go
@@ -1,0 +1,121 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypto
+
+import (
+	"context"
+	"crypto/tls"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
+)
+
+// KeyService provides common cryptographic operations.
+type KeyService interface {
+	// Wrap implements the RFC 3394 AES Key Wrap algorithm. Only keys of 16, 24 or 32 bytes are accepted.
+	// Keys are referenced using the KEK labels.
+	Wrap(ctx context.Context, plaintext []byte, kekLabel string) ([]byte, error)
+	// Unwrap implements the RFC 3394 AES Key Unwrap algorithm. Only keys of 16, 24 or 32 bytes are accepted.
+	// Keys are referenced using the KEK labels.
+	Unwrap(ctx context.Context, ciphertext []byte, kekLabel string) ([]byte, error)
+
+	// Encrypt encrypts messages of variable length using AES 128 GCM.
+	// The encryption key is referenced using the label.
+	Encrypt(ctx context.Context, plaintext []byte, label string) ([]byte, error)
+	// Decrypt decrypts messages of variable length using AES 128 GCM.
+	// The encryption key is referenced using the label.
+	Decrypt(ctx context.Context, ciphertext []byte, label string) ([]byte, error)
+
+	// ServerCertificate returns the X.509 certificate and private key of the given label.
+	ServerCertificate(ctx context.Context, label string) (tls.Certificate, error)
+
+	// ClientCertificate returns the X.509 client certificate and private key.
+	ClientCertificate(ctx context.Context) (tls.Certificate, error)
+
+	// HMACHash calculates the Keyed-Hash Message Authentication Code (HMAC, RFC 2104) hash of the data.
+	// The AES key used for hashing is referenced using the label.
+	HMACHash(ctx context.Context, payload []byte, label string) ([]byte, error)
+}
+
+type keyService struct {
+	vault KeyVault
+}
+
+// NewKeyService returns a new KeyService.
+func NewKeyService(vault KeyVault) KeyService {
+	return &keyService{
+		vault: vault,
+	}
+}
+
+func (ks *keyService) aes128Key(ctx context.Context, label string) (types.AES128Key, error) {
+	key, err := ks.vault.Key(ctx, label)
+	if err != nil {
+		return types.AES128Key{}, err
+	}
+	var res types.AES128Key
+	if err := res.Unmarshal(key); err != nil {
+		return types.AES128Key{}, err
+	}
+	return res, nil
+}
+
+// Decrypt decrypts messages of variable length using AES 128 GCM.
+func (ks *keyService) Decrypt(ctx context.Context, ciphertext []byte, label string) ([]byte, error) {
+	key, err := ks.aes128Key(ctx, label)
+	if err != nil {
+		return nil, err
+	}
+	return Decrypt(key, ciphertext)
+}
+
+func (ks *keyService) Encrypt(ctx context.Context, plaintext []byte, label string) ([]byte, error) {
+	key, err := ks.aes128Key(ctx, label)
+	if err != nil {
+		return nil, err
+	}
+	return Encrypt(key, plaintext)
+}
+
+func (ks *keyService) ServerCertificate(ctx context.Context, label string) (tls.Certificate, error) {
+	return ks.vault.ServerCertificate(ctx, label)
+}
+
+func (ks *keyService) ClientCertificate(ctx context.Context) (tls.Certificate, error) {
+	return ks.vault.ClientCertificate(ctx)
+}
+
+func (ks *keyService) HMACHash(ctx context.Context, payload []byte, label string) ([]byte, error) {
+	key, err := ks.aes128Key(ctx, label)
+	if err != nil {
+		return nil, err
+	}
+	return HMACHash(key, payload)
+}
+
+func (ks *keyService) Unwrap(ctx context.Context, ciphertext []byte, label string) ([]byte, error) {
+	key, err := ks.vault.Key(ctx, label)
+	if err != nil {
+		return nil, err
+	}
+	return UnwrapKey(ciphertext, key)
+}
+
+func (ks *keyService) Wrap(ctx context.Context, plaintext []byte, label string) ([]byte, error) {
+	key, err := ks.vault.Key(ctx, label)
+	if err != nil {
+		return nil, err
+	}
+	return WrapKey(plaintext, key)
+}

--- a/pkg/crypto/keyservice.go
+++ b/pkg/crypto/keyservice.go
@@ -71,7 +71,6 @@ func (ks *keyService) aes128Key(ctx context.Context, label string) (types.AES128
 	return res, nil
 }
 
-// Decrypt decrypts messages of variable length using AES 128 GCM.
 func (ks *keyService) Decrypt(ctx context.Context, ciphertext []byte, label string) ([]byte, error) {
 	key, err := ks.aes128Key(ctx, label)
 	if err != nil {

--- a/pkg/crypto/keyvault.go
+++ b/pkg/crypto/keyvault.go
@@ -17,7 +17,6 @@ package crypto
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 )
 
 // KeyVault provides wrapping and unwrapping keys using KEK labels.
@@ -38,8 +37,6 @@ type KeyVault interface {
 	// The encryption key is referenced using the ID.
 	Decrypt(ctx context.Context, ciphertext []byte, id string) ([]byte, error)
 
-	// GetCertificate gets the X.509 certificate of the given identifier.
-	GetCertificate(ctx context.Context, id string) (*x509.Certificate, error)
 	// ExportCertificate exports the X.509 certificate and private key of the given identifier.
 	ExportCertificate(ctx context.Context, id string) (*tls.Certificate, error)
 

--- a/pkg/crypto/keyvault.go
+++ b/pkg/crypto/keyvault.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,28 +19,9 @@ import (
 	"crypto/tls"
 )
 
-// KeyVault provides wrapping and unwrapping keys using KEK labels.
+// KeyVault provides access to private keys.
 type KeyVault interface {
-	ComponentKEKLabeler
-
-	// Wrap implements the RFC 3394 AES Key Wrap algorithm. Only keys of 16, 24 or 32 bytes are accepted.
-	// Keys are referenced using the KEK labels.
-	Wrap(ctx context.Context, plaintext []byte, kekLabel string) ([]byte, error)
-	// UnwrapKey implements the RFC 3394 AES Key Unwrap algorithm. Only keys of 16, 24 or 32 bytes are accepted.
-	// Keys are referenced using the KEK labels.
-	Unwrap(ctx context.Context, ciphertext []byte, kekLabel string) ([]byte, error)
-
-	// Encrypt encrypts messages of variable length using AES 128 GCM.
-	// The encryption key is referenced using the ID.
-	Encrypt(ctx context.Context, plaintext []byte, id string) ([]byte, error)
-	// Decrypt decrypts messages of variable length using AES 128 GCM.
-	// The encryption key is referenced using the ID.
-	Decrypt(ctx context.Context, ciphertext []byte, id string) ([]byte, error)
-
-	// ExportCertificate exports the X.509 certificate and private key of the given identifier.
-	ExportCertificate(ctx context.Context, id string) (*tls.Certificate, error)
-
-	// HMACHash calculates the Keyed-Hash Message Authentication Code (HMAC, RFC 2104) hash of the data.
-	// The AES key used for hashing is referenced using the ID.
-	HMACHash(ctx context.Context, payload []byte, id string) ([]byte, error)
+	Key(ctx context.Context, label string) ([]byte, error)
+	ServerCertificate(ctx context.Context, label string) (tls.Certificate, error)
+	ClientCertificate(ctx context.Context) (tls.Certificate, error)
 }

--- a/pkg/crypto/observability.go
+++ b/pkg/crypto/observability.go
@@ -63,12 +63,23 @@ func init() {
 	metrics.MustRegister(cMetrics)
 }
 
+// CacheKey is a cache key.
+type CacheKey string
+
+// Cache keys.
+const (
+	CacheEncryptionKey     CacheKey = "key"
+	CacheServerCertificate CacheKey = "server_certificate"
+	CacheClientCertificate CacheKey = "client_certificate"
+	CacheUnwrap            CacheKey = "unwrap"
+)
+
 // RegisterCacheHit registers a cache hit for the provided cache.
-func RegisterCacheHit(ctx context.Context, cache string) {
-	cMetrics.cacheHit.WithLabelValues(ctx, cache).Inc()
+func RegisterCacheHit(ctx context.Context, cache CacheKey) {
+	cMetrics.cacheHit.WithLabelValues(ctx, string(cache)).Inc()
 }
 
 // RegisterCacheMiss registers a cache miss for the provided cache.
-func RegisterCacheMiss(ctx context.Context, cache string) {
-	cMetrics.cacheMiss.WithLabelValues(ctx, cache).Inc()
+func RegisterCacheMiss(ctx context.Context, cache CacheKey) {
+	cMetrics.cacheMiss.WithLabelValues(ctx, string(cache)).Inc()
 }

--- a/pkg/identityserver/end_device_registry.go
+++ b/pkg/identityserver/end_device_registry.go
@@ -167,7 +167,7 @@ func (is *IdentityServer) createEndDevice(ctx context.Context, req *ttnpb.Create
 			return nil, err
 		}
 		if is.config.EndDevices.EncryptionKeyID != "" {
-			encrypted, err := is.KeyVault.Encrypt(
+			encrypted, err := is.KeyService().Encrypt(
 				ctx,
 				[]byte(req.EndDevice.ClaimAuthenticationCode.Value),
 				is.config.EndDevices.EncryptionKeyID,
@@ -249,7 +249,7 @@ func (is *IdentityServer) getEndDevice(ctx context.Context, req *ttnpb.GetEndDev
 			if err != nil {
 				return nil, err
 			}
-			value, err := is.KeyVault.Decrypt(ctx, v, s[0])
+			value, err := is.KeyService().Decrypt(ctx, v, s[0])
 			if err != nil {
 				return nil, err
 			}
@@ -375,7 +375,7 @@ func (is *IdentityServer) updateEndDevice(ctx context.Context, req *ttnpb.Update
 		if req.EndDevice.ClaimAuthenticationCode.Value != "" {
 			if is.config.EndDevices.EncryptionKeyID != "" {
 				ptCACSecret = req.EndDevice.ClaimAuthenticationCode.Value
-				encrypted, err := is.KeyVault.Encrypt(
+				encrypted, err := is.KeyService().Encrypt(
 					ctx,
 					[]byte(req.EndDevice.ClaimAuthenticationCode.Value),
 					is.config.EndDevices.EncryptionKeyID,

--- a/pkg/identityserver/gateway_registry.go
+++ b/pkg/identityserver/gateway_registry.go
@@ -110,7 +110,7 @@ func (is *IdentityServer) createGateway(ctx context.Context, req *ttnpb.CreateGa
 	if reqGtw.LbsLnsSecret != nil {
 		value := reqGtw.LbsLnsSecret.Value
 		if is.config.Gateways.EncryptionKeyID != "" {
-			value, err = is.KeyVault.Encrypt(ctx, reqGtw.LbsLnsSecret.Value, is.config.Gateways.EncryptionKeyID)
+			value, err = is.KeyService().Encrypt(ctx, reqGtw.LbsLnsSecret.Value, is.config.Gateways.EncryptionKeyID)
 			if err != nil {
 				return nil, err
 			}
@@ -124,7 +124,7 @@ func (is *IdentityServer) createGateway(ctx context.Context, req *ttnpb.CreateGa
 	if reqGtw.TargetCupsKey != nil {
 		value := reqGtw.TargetCupsKey.Value
 		if is.config.Gateways.EncryptionKeyID != "" {
-			value, err = is.KeyVault.Encrypt(ctx, reqGtw.TargetCupsKey.Value, is.config.Gateways.EncryptionKeyID)
+			value, err = is.KeyService().Encrypt(ctx, reqGtw.TargetCupsKey.Value, is.config.Gateways.EncryptionKeyID)
 			if err != nil {
 				return nil, err
 			}
@@ -141,7 +141,7 @@ func (is *IdentityServer) createGateway(ctx context.Context, req *ttnpb.CreateGa
 		}
 		value := reqGtw.ClaimAuthenticationCode.Secret.Value
 		if is.config.Gateways.EncryptionKeyID != "" {
-			value, err = is.KeyVault.Encrypt(ctx, value, is.config.Gateways.EncryptionKeyID)
+			value, err = is.KeyService().Encrypt(ctx, value, is.config.Gateways.EncryptionKeyID)
 			if err != nil {
 				return nil, err
 			}
@@ -245,7 +245,7 @@ func (is *IdentityServer) getGateway(ctx context.Context, req *ttnpb.GetGatewayR
 	if gtw.LbsLnsSecret != nil {
 		value := gtw.LbsLnsSecret.Value
 		if gtw.LbsLnsSecret.KeyId != "" {
-			value, err = is.KeyVault.Decrypt(ctx, gtw.LbsLnsSecret.Value, gtw.LbsLnsSecret.KeyId)
+			value, err = is.KeyService().Decrypt(ctx, gtw.LbsLnsSecret.Value, gtw.LbsLnsSecret.KeyId)
 			if err != nil {
 				return nil, err
 			}
@@ -259,7 +259,7 @@ func (is *IdentityServer) getGateway(ctx context.Context, req *ttnpb.GetGatewayR
 	if gtw.ClaimAuthenticationCode != nil && gtw.ClaimAuthenticationCode.Secret != nil {
 		value := gtw.ClaimAuthenticationCode.Secret.Value
 		if gtw.ClaimAuthenticationCode.Secret.KeyId != "" {
-			value, err = is.KeyVault.Decrypt(ctx, gtw.ClaimAuthenticationCode.Secret.Value, gtw.ClaimAuthenticationCode.Secret.KeyId)
+			value, err = is.KeyService().Decrypt(ctx, gtw.ClaimAuthenticationCode.Secret.Value, gtw.ClaimAuthenticationCode.Secret.KeyId)
 			if err != nil {
 				return nil, err
 			}
@@ -278,7 +278,7 @@ func (is *IdentityServer) getGateway(ctx context.Context, req *ttnpb.GetGatewayR
 	if gtw.TargetCupsKey != nil {
 		value := gtw.TargetCupsKey.Value
 		if gtw.TargetCupsKey.KeyId != "" {
-			value, err = is.KeyVault.Decrypt(ctx, gtw.TargetCupsKey.Value, gtw.TargetCupsKey.KeyId)
+			value, err = is.KeyService().Decrypt(ctx, gtw.TargetCupsKey.Value, gtw.TargetCupsKey.KeyId)
 			if err != nil {
 				return nil, err
 			}
@@ -407,7 +407,7 @@ func (is *IdentityServer) listGateways(ctx context.Context, req *ttnpb.ListGatew
 			} else if gtws.Gateways[i].LbsLnsSecret != nil {
 				value := gtws.Gateways[i].LbsLnsSecret.Value
 				if gtws.Gateways[i].LbsLnsSecret.KeyId != "" {
-					value, err = is.KeyVault.Decrypt(ctx, gtws.Gateways[i].LbsLnsSecret.Value, gtws.Gateways[i].LbsLnsSecret.KeyId)
+					value, err = is.KeyService().Decrypt(ctx, gtws.Gateways[i].LbsLnsSecret.Value, gtws.Gateways[i].LbsLnsSecret.KeyId)
 					if err != nil {
 						return nil, err
 					}
@@ -426,7 +426,7 @@ func (is *IdentityServer) listGateways(ctx context.Context, req *ttnpb.ListGatew
 			} else if gtws.Gateways[i].TargetCupsKey != nil {
 				value := gtws.Gateways[i].TargetCupsKey.Value
 				if gtws.Gateways[i].TargetCupsKey.KeyId != "" {
-					value, err = is.KeyVault.Decrypt(ctx, gtws.Gateways[i].TargetCupsKey.Value, gtws.Gateways[i].TargetCupsKey.KeyId)
+					value, err = is.KeyService().Decrypt(ctx, gtws.Gateways[i].TargetCupsKey.Value, gtws.Gateways[i].TargetCupsKey.KeyId)
 					if err != nil {
 						return nil, err
 					}
@@ -445,7 +445,7 @@ func (is *IdentityServer) listGateways(ctx context.Context, req *ttnpb.ListGatew
 			} else if gtws.Gateways[i].ClaimAuthenticationCode != nil && gtws.Gateways[i].ClaimAuthenticationCode.Secret != nil {
 				value := gtws.Gateways[i].ClaimAuthenticationCode.Secret.Value
 				if keyID := gtws.Gateways[i].ClaimAuthenticationCode.Secret.KeyId; keyID != "" {
-					value, err = is.KeyVault.Decrypt(ctx, value, keyID)
+					value, err = is.KeyService().Decrypt(ctx, value, keyID)
 					if err != nil {
 						return nil, err
 					}
@@ -502,7 +502,7 @@ func (is *IdentityServer) updateGateway(ctx context.Context, req *ttnpb.UpdateGa
 			value := reqGtw.LbsLnsSecret.Value
 			ptLBSLNSSecret = reqGtw.LbsLnsSecret.Value
 			if is.config.Gateways.EncryptionKeyID != "" {
-				value, err = is.KeyVault.Encrypt(ctx, reqGtw.LbsLnsSecret.Value, is.config.Gateways.EncryptionKeyID)
+				value, err = is.KeyService().Encrypt(ctx, reqGtw.LbsLnsSecret.Value, is.config.Gateways.EncryptionKeyID)
 				if err != nil {
 					return nil, err
 				}
@@ -522,7 +522,7 @@ func (is *IdentityServer) updateGateway(ctx context.Context, req *ttnpb.UpdateGa
 			value := reqGtw.TargetCupsKey.Value
 			ptTargetCUPSKeySecret = reqGtw.TargetCupsKey.Value
 			if is.config.Gateways.EncryptionKeyID != "" {
-				value, err = is.KeyVault.Encrypt(ctx, reqGtw.TargetCupsKey.Value, is.config.Gateways.EncryptionKeyID)
+				value, err = is.KeyService().Encrypt(ctx, reqGtw.TargetCupsKey.Value, is.config.Gateways.EncryptionKeyID)
 				if err != nil {
 					return nil, err
 				}
@@ -545,7 +545,7 @@ func (is *IdentityServer) updateGateway(ctx context.Context, req *ttnpb.UpdateGa
 			value := reqGtw.ClaimAuthenticationCode.Secret.Value
 			ptCACSecret = reqGtw.ClaimAuthenticationCode.Secret.Value
 			if is.config.Gateways.EncryptionKeyID != "" {
-				value, err = is.KeyVault.Encrypt(ctx, value, is.config.Gateways.EncryptionKeyID)
+				value, err = is.KeyService().Encrypt(ctx, value, is.config.Gateways.EncryptionKeyID)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/interop/client_test.go
+++ b/pkg/interop/client_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	componenttest "go.thethings.network/lorawan-stack/v3/pkg/component/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	. "go.thethings.network/lorawan-stack/v3/pkg/interop"
@@ -246,10 +248,14 @@ func TestGetAppSKey(t *testing.T) { //nolint:paralleltest
 			srv := tc.NewServer(a)
 			defer srv.Close()
 
+			c := componenttest.NewComponent(t, &component.Config{})
+			componenttest.StartComponent(t, c)
+			defer c.Close()
+
 			cl, err := NewClient(ctx, config.InteropClient{
 				ConfigSource: "directory",
 				Directory:    "testdata/client",
-			}, test.HTTPClientProvider, SelectorApplicationServer)
+			}, c, SelectorApplicationServer)
 			if !a.So(err, should.BeNil) {
 				t.Fatalf("Failed to create new client: %s", err)
 			}
@@ -655,10 +661,14 @@ func TestHandleJoinRequest(t *testing.T) { //nolint:paralleltest
 			srv := tc.NewServer(a)
 			defer srv.Close()
 
+			c := componenttest.NewComponent(t, &component.Config{})
+			componenttest.StartComponent(t, c)
+			defer c.Close()
+
 			cl, err := NewClient(ctx, config.InteropClient{
 				ConfigSource: "directory",
 				Directory:    "testdata/client",
-			}, test.HTTPClientProvider, SelectorNetworkServer)
+			}, c, SelectorNetworkServer)
 			if !a.So(err, should.BeNil) {
 				t.Fatalf("Failed to create new client: %s", err)
 			}
@@ -830,10 +840,14 @@ func TestJoinServerRace(t *testing.T) { //nolint:paralleltest
 				defer srv.Close() //nolint:revive
 			}
 
+			c := componenttest.NewComponent(t, &component.Config{})
+			componenttest.StartComponent(t, c)
+			defer c.Close()
+
 			cl, err := NewClient(ctx, config.InteropClient{
 				ConfigSource: "directory",
 				Directory:    "testdata/client",
-			}, test.HTTPClientProvider, SelectorNetworkServer)
+			}, c, SelectorNetworkServer)
 			if !a.So(err, should.BeNil) {
 				t.Fatalf("Failed to create new client: %s", err)
 			}

--- a/pkg/interop/config.go
+++ b/pkg/interop/config.go
@@ -81,6 +81,7 @@ const (
 	SenderClientCAsConfigurationName = "config.yml"
 )
 
+// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6026)
 func fetchSenderClientCAs( //nolint:gocyclo
 	ctx context.Context, conf config.InteropServer, httpClientProvider httpclient.Provider,
 ) (map[string][]*x509.Certificate, error) {

--- a/pkg/interop/config.go
+++ b/pkg/interop/config.go
@@ -23,6 +23,7 @@ import (
 
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
+	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/fetch"
 	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
@@ -31,6 +32,7 @@ import (
 
 type tlsConfig struct {
 	RootCA      string `yaml:"root-ca"`
+	Source      string `yaml:"source"`
 	Certificate string `yaml:"certificate"`
 	Key         string `yaml:"key"`
 }
@@ -53,22 +55,33 @@ func (r fetcherFileReader) ReadFile(name string) ([]byte, error) {
 	return b, nil
 }
 
-func (conf tlsConfig) TLSConfig(fetcher fetch.Interface) (*tls.Config, error) {
+func (conf tlsConfig) TLSConfig(fetcher fetch.Interface, ks crypto.KeyService) (*tls.Config, error) {
 	res := &tls.Config{
 		MinVersion: tls.VersionTLS12,
 	}
-	if err := (&tlsconfig.Client{
+	clientConfig := &tlsconfig.Client{
 		FileReader: fetcherFileReader{fetcher: fetcher},
 		RootCA:     conf.RootCA,
-	}).ApplyTo(res); err != nil {
+	}
+	if err := clientConfig.ApplyTo(res); err != nil {
 		return nil, err
 	}
-	if err := (&tlsconfig.ClientAuth{
-		Source:      "file",
+	source := conf.Source
+	// TODO: Require explicit source for client certificate
+	// (https://github.com/TheThingsNetwork/lorawan-stack/issues/1450)
+	if source == "" && (conf.Certificate != "" || conf.Key != "") {
+		source = "file"
+	}
+	clientAuthConfig := &tlsconfig.ClientAuth{
+		Source:      source,
 		FileReader:  fetcherFileReader{fetcher: fetcher},
 		Certificate: conf.Certificate,
 		Key:         conf.Key,
-	}).ApplyTo(res); err != nil {
+		KeyVault: tlsconfig.ClientKeyVault{
+			CertificateProvider: ks,
+		},
+	}
+	if err := clientAuthConfig.ApplyTo(res); err != nil {
 		return nil, err
 	}
 	return res, nil

--- a/pkg/interop/server.go
+++ b/pkg/interop/server.go
@@ -71,6 +71,7 @@ type Server struct {
 
 	router *mux.Router
 
+	// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6026)
 	senderClientCAs    map[string][]*x509.Certificate
 	senderClientCAPool *x509.CertPool
 
@@ -92,6 +93,7 @@ func NewServer(c Component, contextFillers []fillcontext.Filler, conf config.Int
 	ctx := log.NewContextWithField(c.Context(), "namespace", "interop")
 	logger := log.FromContext(ctx)
 
+	// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6026)
 	senderClientCAs, err := fetchSenderClientCAs(ctx, conf, c)
 	if err != nil {
 		return nil, err
@@ -119,7 +121,8 @@ func NewServer(c Component, contextFillers []fillcontext.Filler, conf config.Int
 	}
 
 	s := &Server{
-		config:             conf,
+		config: conf,
+		// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6026)
 		senderClientCAs:    senderClientCAs,
 		senderClientCAPool: senderClientCAPool,
 		tokenVerifiers:     tokenVerifiers,
@@ -163,6 +166,7 @@ func (s *Server) RegisterJS(js JoinServer) {
 }
 
 // ClientCAPool returns a certificate pool of all configured client CAs.
+// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6026)
 func (s *Server) ClientCAPool() *x509.CertPool {
 	return s.senderClientCAPool
 }
@@ -172,6 +176,7 @@ func (s *Server) ClientCAPool() *x509.CertPool {
 // and Join Servers respectively.
 func (s *Server) SenderClientCAs(_ context.Context, senderID string) ([]*x509.Certificate, error) {
 	// TODO: Lookup partner CA by SenderID with DNS (https://github.com/TheThingsNetwork/lorawan-stack/issues/718).
+	// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6026)
 	return s.senderClientCAs[senderID], nil
 }
 

--- a/pkg/joinserver/grpc_application_activation_settings_registry.go
+++ b/pkg/joinserver/grpc_application_activation_settings_registry.go
@@ -46,7 +46,7 @@ func (srv applicationActivationSettingsRegistryServer) Get(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	kek, err := cryptoutil.UnwrapKeyEnvelope(ctx, sets.Kek, srv.JS.KeyVault)
+	kek, err := cryptoutil.UnwrapKeyEnvelope(ctx, sets.Kek, srv.JS.KeyService())
 	if err != nil {
 		return nil, errUnwrapKey.WithCause(err)
 	}
@@ -84,7 +84,7 @@ func (srv applicationActivationSettingsRegistryServer) Set(ctx context.Context, 
 
 	sets := req.FieldMask.GetPaths()
 	if ttnpb.HasAnyField(sets, "kek.key") && len(reqKEK.GetKey()) > 0 {
-		kek, err := cryptoutil.WrapAES128Key(ctx, *types.MustAES128Key(reqKEK.Key), srv.kekLabel, srv.JS.KeyVault)
+		kek, err := cryptoutil.WrapAES128Key(ctx, *types.MustAES128Key(reqKEK.Key), srv.kekLabel, srv.JS.KeyService())
 		if err != nil {
 			return nil, errWrapKey.WithCause(err)
 		}

--- a/pkg/joinserver/grpc_deviceregistry.go
+++ b/pkg/joinserver/grpc_deviceregistry.go
@@ -144,7 +144,7 @@ func (srv jsEndDeviceRegistryServer) Get(ctx context.Context, req *ttnpb.GetEndD
 					Key: rootKeysEnc.NwkKey.Key,
 				}
 			case len(rootKeysEnc.GetNwkKey().GetEncryptedKey()) > 0:
-				nwkKey, err := cryptoutil.UnwrapAES128Key(ctx, rootKeysEnc.NwkKey, srv.JS.KeyVault)
+				nwkKey, err := cryptoutil.UnwrapAES128Key(ctx, rootKeysEnc.NwkKey, srv.JS.KeyService())
 				if err != nil {
 					return nil, err
 				}
@@ -152,7 +152,7 @@ func (srv jsEndDeviceRegistryServer) Get(ctx context.Context, req *ttnpb.GetEndD
 					Key: nwkKey.Bytes(),
 				}
 			case cc != nil && dev.ProvisionerId != "":
-				nwkKey, err := cryptoservices.NewNetworkRPCClient(cc, srv.JS.KeyVault, srv.JS.WithClusterAuth()).GetNwkKey(ctx, dev)
+				nwkKey, err := cryptoservices.NewNetworkRPCClient(cc, srv.JS.KeyService(), srv.JS.WithClusterAuth()).GetNwkKey(ctx, dev)
 				if err != nil {
 					return nil, err
 				}
@@ -171,7 +171,7 @@ func (srv jsEndDeviceRegistryServer) Get(ctx context.Context, req *ttnpb.GetEndD
 					Key: rootKeysEnc.GetAppKey().GetKey(),
 				}
 			case len(rootKeysEnc.GetAppKey().GetEncryptedKey()) > 0:
-				appKey, err := cryptoutil.UnwrapAES128Key(ctx, rootKeysEnc.AppKey, srv.JS.KeyVault)
+				appKey, err := cryptoutil.UnwrapAES128Key(ctx, rootKeysEnc.AppKey, srv.JS.KeyService())
 				if err != nil {
 					return nil, err
 				}
@@ -179,7 +179,7 @@ func (srv jsEndDeviceRegistryServer) Get(ctx context.Context, req *ttnpb.GetEndD
 					Key: appKey.Bytes(),
 				}
 			case cc != nil && dev.ProvisionerId != "":
-				appKey, err := cryptoservices.NewApplicationRPCClient(cc, srv.JS.KeyVault, srv.JS.WithClusterAuth()).GetAppKey(ctx, dev)
+				appKey, err := cryptoservices.NewApplicationRPCClient(cc, srv.JS.KeyService(), srv.JS.WithClusterAuth()).GetAppKey(ctx, dev)
 				if err != nil {
 					return nil, err
 				}
@@ -242,7 +242,7 @@ func (srv jsEndDeviceRegistryServer) Set(ctx context.Context, req *ttnpb.SetEndD
 	sets := append(req.FieldMask.GetPaths()[:0:0], req.FieldMask.GetPaths()...)
 	if ttnpb.HasAnyField(req.FieldMask.GetPaths(), "root_keys.app_key.key") {
 		appKey, err := cryptoutil.WrapAES128Key(
-			ctx, *types.MustAES128Key(req.EndDevice.RootKeys.AppKey.Key), srv.kekLabel, srv.JS.KeyVault,
+			ctx, *types.MustAES128Key(req.EndDevice.RootKeys.AppKey.Key), srv.kekLabel, srv.JS.KeyService(),
 		)
 		if err != nil {
 			return nil, err
@@ -261,7 +261,7 @@ func (srv jsEndDeviceRegistryServer) Set(ctx context.Context, req *ttnpb.SetEndD
 	if ttnpb.HasAnyField(req.FieldMask.GetPaths(), "root_keys.nwk_key.key") {
 		if !types.MustAES128Key(req.EndDevice.GetRootKeys().GetNwkKey().GetKey()).OrZero().IsZero() {
 			nwkKey, err := cryptoutil.WrapAES128Key(
-				ctx, *types.MustAES128Key(req.EndDevice.RootKeys.NwkKey.Key), srv.kekLabel, srv.JS.KeyVault,
+				ctx, *types.MustAES128Key(req.EndDevice.RootKeys.NwkKey.Key), srv.kekLabel, srv.JS.KeyService(),
 			)
 			if err != nil {
 				return nil, err

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -509,7 +509,7 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 		if dev.GetSession().GetKeys().GetNwkSEncKey() == nil {
 			return nil, genState, errUnknownNwkSEncKey.New()
 		}
-		key, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.Keys.NwkSEncKey, ns.KeyVault)
+		key, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.Keys.NwkSEncKey, ns.KeyService())
 		if err != nil {
 			logger.WithField("kek_label", dev.Session.Keys.NwkSEncKey.KekLabel).WithError(err).Warn("Failed to unwrap NwkSEncKey")
 			return nil, genState, err
@@ -580,7 +580,7 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 	if dev.Session.GetKeys().GetSNwkSIntKey() == nil {
 		return nil, genState, errUnknownSNwkSIntKey.New()
 	}
-	key, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.Keys.SNwkSIntKey, ns.KeyVault)
+	key, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.Keys.SNwkSIntKey, ns.KeyService())
 	if err != nil {
 		logger.WithField("kek_label", dev.Session.Keys.SNwkSIntKey.KekLabel).WithError(err).Warn("Failed to unwrap SNwkSIntKey")
 		return nil, genState, err

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -217,7 +217,7 @@ func addDeviceGetPaths(paths ...string) []string {
 	return gets
 }
 
-func unwrapSelectedSessionKeys(ctx context.Context, kv crypto.KeyVault, dev *ttnpb.EndDevice, paths ...string) error {
+func unwrapSelectedSessionKeys(ctx context.Context, kv crypto.KeyService, dev *ttnpb.EndDevice, paths ...string) error {
 	if dev.PendingSession != nil && ttnpb.HasAnyField(paths,
 		"pending_session.keys.f_nwk_s_int_key.key",
 		"pending_session.keys.nwk_s_enc_key.key",
@@ -268,7 +268,7 @@ func (ns *NetworkServer) Get(ctx context.Context, req *ttnpb.GetEndDeviceRequest
 		logRegistryRPCError(ctx, err, "Failed to get device from registry")
 		return nil, err
 	}
-	if err := unwrapSelectedSessionKeys(ctx, ns.KeyVault, dev, req.FieldMask.GetPaths()...); err != nil {
+	if err := unwrapSelectedSessionKeys(ctx, ns.KeyService(), dev, req.FieldMask.GetPaths()...); err != nil {
 		log.FromContext(ctx).WithError(err).Error("Failed to unwrap selected keys")
 		return nil, err
 	}
@@ -1990,7 +1990,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		}
 		if st.HasSetField("session.keys.f_nwk_s_int_key.key") {
 			k := st.Device.Session.Keys.FNwkSIntKey.Key
-			fNwkSIntKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyVault)
+			fNwkSIntKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyService())
 			if err != nil {
 				return nil, err
 			}
@@ -2006,7 +2006,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 			})
 		}
 		if k := st.Device.Session.Keys.GetNwkSEncKey().GetKey(); k != nil && st.HasSetField("session.keys.nwk_s_enc_key.key") {
-			nwkSEncKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyVault)
+			nwkSEncKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyService())
 			if err != nil {
 				return nil, err
 			}
@@ -2022,7 +2022,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 			})
 		}
 		if k := st.Device.Session.Keys.GetSNwkSIntKey().GetKey(); k != nil && st.HasSetField("session.keys.s_nwk_s_int_key.key") {
-			sNwkSIntKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyVault)
+			sNwkSIntKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyService())
 			if err != nil {
 				return nil, err
 			}
@@ -2055,7 +2055,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		}
 		if st.HasSetField("pending_session.keys.f_nwk_s_int_key.key") {
 			k := st.Device.PendingSession.Keys.FNwkSIntKey.Key
-			fNwkSIntKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyVault)
+			fNwkSIntKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyService())
 			if err != nil {
 				return nil, err
 			}
@@ -2072,7 +2072,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		}
 		if st.HasSetField("pending_session.keys.nwk_s_enc_key.key") {
 			k := st.Device.PendingSession.Keys.NwkSEncKey.Key
-			nwkSEncKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyVault)
+			nwkSEncKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyService())
 			if err != nil {
 				return nil, err
 			}
@@ -2089,7 +2089,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		}
 		if st.HasSetField("pending_session.keys.s_nwk_s_int_key.key") {
 			k := st.Device.PendingSession.Keys.SNwkSIntKey.Key
-			sNwkSIntKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyVault)
+			sNwkSIntKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyService())
 			if err != nil {
 				return nil, err
 			}
@@ -2123,7 +2123,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		}
 		if st.HasSetField("pending_mac_state.queued_join_accept.keys.f_nwk_s_int_key.key") {
 			k := st.Device.PendingMacState.QueuedJoinAccept.Keys.FNwkSIntKey.Key
-			fNwkSIntKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyVault)
+			fNwkSIntKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyService())
 			if err != nil {
 				return nil, err
 			}
@@ -2140,7 +2140,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		}
 		if st.HasSetField("pending_mac_state.queued_join_accept.keys.nwk_s_enc_key.key") {
 			k := st.Device.PendingMacState.QueuedJoinAccept.Keys.NwkSEncKey.Key
-			nwkSEncKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyVault)
+			nwkSEncKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyService())
 			if err != nil {
 				return nil, err
 			}
@@ -2157,7 +2157,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		}
 		if st.HasSetField("pending_mac_state.queued_join_accept.keys.s_nwk_s_int_key.key") {
 			k := st.Device.PendingMacState.QueuedJoinAccept.Keys.SNwkSIntKey.Key
-			sNwkSIntKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyVault)
+			sNwkSIntKey, err := cryptoutil.WrapAES128Key(ctx, types.MustAES128Key(k).OrZero(), ns.deviceKEKLabel, ns.KeyService())
 			if err != nil {
 				return nil, err
 			}
@@ -2848,7 +2848,7 @@ func (ns *NetworkServer) ResetFactoryDefaults(ctx context.Context, req *ttnpb.Re
 		logRegistryRPCError(ctx, err, "Failed to reset device state in registry")
 		return nil, err
 	}
-	if err := unwrapSelectedSessionKeys(ctx, ns.KeyVault, dev, req.FieldMask.GetPaths()...); err != nil {
+	if err := unwrapSelectedSessionKeys(ctx, ns.KeyService(), dev, req.FieldMask.GetPaths()...); err != nil {
 		log.FromContext(ctx).WithError(err).Error("Failed to unwrap selected keys")
 		return nil, err
 	}

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -263,7 +263,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 		dev.PendingMacState != nil &&
 		devAddr.Equal(types.MustDevAddr(dev.PendingSession.DevAddr).OrZero()) &&
 		macspec.UseLegacyMIC(cmacFMatchResult.LoRaWANVersion) == macspec.UseLegacyMIC(dev.PendingMacState.LorawanVersion) {
-		fNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, dev.PendingSession.Keys.FNwkSIntKey, ns.KeyVault)
+		fNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, dev.PendingSession.Keys.FNwkSIntKey, ns.KeyService())
 		if err != nil {
 			log.FromContext(ctx).WithError(err).WithField("kek_label", dev.PendingSession.Keys.FNwkSIntKey.KekLabel).Warn("Failed to unwrap FNwkSIntKey")
 			return nil, false, nil
@@ -304,7 +304,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 		macspec.UseLegacyMIC(cmacFMatchResult.LoRaWANVersion) == macspec.UseLegacyMIC(dev.MacState.LorawanVersion) &&
 		(cmacFMatchResult.FullFCnt == FullFCnt(uint16(pld.FHdr.FCnt), dev.Session.LastFCntUp, mac.DeviceSupports32BitFCnt(dev, ns.defaultMACSettings)) ||
 			cmacFMatchResult.FullFCnt == pld.FHdr.FCnt) {
-		fNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.Keys.FNwkSIntKey, ns.KeyVault)
+		fNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.Keys.FNwkSIntKey, ns.KeyService())
 		if err != nil {
 			log.FromContext(ctx).WithError(err).WithField("kek_label", dev.Session.Keys.FNwkSIntKey.KekLabel).Warn("Failed to unwrap FNwkSIntKey")
 			return nil, false, nil
@@ -435,7 +435,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 			log.FromContext(ctx).Warn("Device missing NwkSEncKey in registry")
 			return nil, false, nil
 		}
-		key, err := cryptoutil.UnwrapAES128Key(ctx, session.Keys.NwkSEncKey, ns.KeyVault)
+		key, err := cryptoutil.UnwrapAES128Key(ctx, session.Keys.NwkSEncKey, ns.KeyService())
 		if err != nil {
 			log.FromContext(ctx).WithField("kek_label", session.Keys.NwkSEncKey.KekLabel).WithError(err).Warn("Failed to unwrap NwkSEncKey")
 			return nil, false, nil
@@ -653,7 +653,7 @@ macLoop:
 
 	// NOTE: Legacy MIC check is already performed.
 	if !macspec.UseLegacyMIC(dev.MacState.LorawanVersion) {
-		sNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.Keys.SNwkSIntKey, ns.KeyVault)
+		sNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.Keys.SNwkSIntKey, ns.KeyService())
 		if err != nil {
 			logger.WithField("kek_label", dev.Session.Keys.SNwkSIntKey.GetKekLabel()).WithError(err).Warn("Failed to unwrap SNwkSIntKey")
 			return nil, false, nil
@@ -903,7 +903,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 				"pending_session", match.IsPending,
 			))
 
-			fNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, match.FNwkSIntKey, ns.KeyVault)
+			fNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, match.FNwkSIntKey, ns.KeyService())
 			if err != nil {
 				log.FromContext(ctx).WithError(err).WithField("kek_label", match.FNwkSIntKey.KekLabel).Warn("Failed to unwrap FNwkSIntKey")
 				return false, nil
@@ -1309,11 +1309,11 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 		keyEnvelopes = keyEnvelopes[:1]
 	}
 	for _, keyEnvelope := range keyEnvelopes {
-		unwrappedKey, err := cryptoutil.UnwrapAES128Key(ctx, keyEnvelope, ns.KeyVault)
+		unwrappedKey, err := cryptoutil.UnwrapAES128Key(ctx, keyEnvelope, ns.KeyService())
 		if err != nil {
 			return err
 		}
-		wrappedEnvelope, err := cryptoutil.WrapAES128Key(ctx, unwrappedKey, ns.deviceKEKLabel, ns.KeyVault)
+		wrappedEnvelope, err := cryptoutil.WrapAES128Key(ctx, unwrappedKey, ns.deviceKEKLabel, ns.KeyService())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Groundwork for #5982 
Includes https://github.com/TheThingsIndustries/lorawan-stack/pull/3538

#### Changes
<!-- What are the changes made in this pull request? -->

From the included PR:

>- Split key vault in two logical components: the actual vault for retrieving secrets and the logic that uses the vault. [...]
>- Clarify certificate logic to align better with TLS configuration
>- Implement reusable `KeyVault` and `KeyService` cache wrappers so that we don't have to implement that in the implementations themselves [...]. Certificate caching usses the certificate validity time for TTL
>- Extract KEK labeling to their own files so that they can be removed with nicer diffs once we change the way this works. [...]
>- General code improvements

Additionally, this includes interop client configuration to use the key vault for TLS, in which case the client certificate will be used.

#### Testing

<!-- How did you verify that this change works? -->

Local integration testing and unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Everything except 72b35c0d0b0c6b3ef7a4f83158fe3ec598a563b8 is already reviewed and approved. You can recheck everything of course, but only this commit is really necessary.

Documentation follows.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
