### PR TITLE
Do not copy proto messages 

### DIFF
--- a/pkg/identityserver/end_device_registry.go
+++ b/pkg/identityserver/end_device_registry.go
@@ -163,7 +163,7 @@ func (is *IdentityServer) createEndDevice(ctx context.Context, req *ttnpb.Create
 	// Create the CAC only if the value is set.
 	if req.EndDevice.GetClaimAuthenticationCode().GetValue() != "" {
 		ptCACSecret = req.EndDevice.ClaimAuthenticationCode.Value
-		if err = validateEndDeviceAuthenticationCode(*req.EndDevice.ClaimAuthenticationCode); err != nil {
+		if err = validateEndDeviceAuthenticationCode(req.EndDevice.ClaimAuthenticationCode); err != nil {
 			return nil, err
 		}
 		if is.config.EndDevices.EncryptionKeyID != "" {
@@ -369,7 +369,7 @@ func (is *IdentityServer) updateEndDevice(ctx context.Context, req *ttnpb.Update
 		req.FieldMask.GetPaths(),
 		"claim_authentication_code",
 	) && req.EndDevice.ClaimAuthenticationCode != nil {
-		if err = validateEndDeviceAuthenticationCode(*req.EndDevice.ClaimAuthenticationCode); err != nil {
+		if err = validateEndDeviceAuthenticationCode(req.EndDevice.ClaimAuthenticationCode); err != nil {
 			return nil, err
 		}
 		if req.EndDevice.ClaimAuthenticationCode.Value != "" {
@@ -444,7 +444,7 @@ func (is *IdentityServer) deleteEndDevice(ctx context.Context, ids *ttnpb.EndDev
 	return ttnpb.Empty, nil
 }
 
-func validateEndDeviceAuthenticationCode(authCode ttnpb.EndDeviceAuthenticationCode) error {
+func validateEndDeviceAuthenticationCode(authCode *ttnpb.EndDeviceAuthenticationCode) error {
 	if validFrom, validTo := ttnpb.StdTime(authCode.ValidFrom), ttnpb.StdTime(authCode.ValidTo); validFrom != nil &&
 		validTo != nil {
 		if validTo.Before(*validFrom) || authCode.Value == "" {

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -1045,7 +1045,7 @@ func loggerWithTxRequestFields(logger log.Interface, req *ttnpb.TxRequest, rx1, 
 	}
 	if req.AbsoluteTime != nil {
 		pairs = append(pairs,
-			"absolute_time", *req.AbsoluteTime,
+			"absolute_time", req.AbsoluteTime.AsTime(),
 		)
 	}
 	return logger.WithFields(log.Fields(pairs...))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes some proto message copy-by-value usages throughout our code base. These are not valid anymore with proto v2.

The check to run is `go vet -copylocks ./...`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Avoid copying protos by value.


#### Testing

<!-- How did you verify that this change works? -->

UT.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
