### PR TITLE
Redis last invalidation keys migration

### DIFF
--- a/cmd/ttn-lw-stack/commands/ns_db.go
+++ b/cmd/ttn-lw-stack/commands/ns_db.go
@@ -18,14 +18,11 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/go-redis/redis/v8"
 	"github.com/spf13/cobra"
-	"github.com/vmihailenco/msgpack/v5"
 	"go.thethings.network/lorawan-stack/v3/pkg/cleanup"
 	nsredis "go.thethings.network/lorawan-stack/v3/pkg/networkserver/redis"
 	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
-	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
 )
 
@@ -92,11 +89,12 @@ var (
 				panic("Only Redis is supported by this command")
 			}
 
-			logger.Info("Connecting to Redis database...")
-			cl := NewNetworkServerDeviceRegistryRedis(config)
+			logger.Info("Checking Network Server db version...")
+			devicesClient := NewNetworkServerDeviceRegistryRedis(config)
+			defer devicesClient.Close()
 
 			if force, _ := cmd.Flags().GetBool("force"); !force {
-				schemaVersion, err := getSchemaVersion(cl)
+				schemaVersion, err := getSchemaVersion(devicesClient)
 				if err != nil {
 					return err
 				}
@@ -104,365 +102,49 @@ var (
 					logger.Info("Database schema version is already in latest version")
 					return nil
 				}
+				if schemaVersion < nsredis.UnsupportedMigrationVersionBreakpoint {
+					logger.Warnf(
+						"You are currently running version %d of the Network Server database. This version cannot be auto-migrated to latest. Use v3.23.0 of The Things Stack to migrate to a supported one before migrating to latest.", //nolint:lll
+						schemaVersion,
+					)
+					return nil
+				}
 			}
 
-			var migrated uint64
-			defer func() { logger.Debugf("%d keys migrated", migrated) }()
+			logger.Info("Connecting to Redis database...")
+			uplinkClient := NewNetworkServerApplicationUplinkQueueRedis(config)
+			defer uplinkClient.Close()
 
-			type KeyEnvelope3_11Snapshot struct {
-				Key          []byte `msgpack:"key"`
-				KEKLabel     string `msgpack:"kek_label"`
-				EncryptedKey []byte `msgpack:"encrypted_key"`
-			}
+			var removed uint64
+			defer func() { logger.Debugf("%d keys removed", removed) }()
 
-			const (
-				idRegexpStr      = `([a-z0-9](?:[-]?[a-z0-9]){2,}){1,36}?`
-				uidRegexpStr     = idRegexpStr + `\.` + idRegexpStr
-				euiRegexpStr     = "[[:xdigit:]]{16}"
-				devAddrRegexpStr = "[[:xdigit:]]{8}"
-			)
+			uidLastInvalidationKey := regexp.MustCompile(uplinkClient.Key("uid", ".*", "last-invalidation$"))
 
-			uidRegexp := regexp.MustCompile(cl.Key("uid", uidRegexpStr+"$"))
-			uidRegexp3_10_Fields := regexp.MustCompile(cl.Key("uid", uidRegexpStr, "fields$"))
-
-			euiRegexp := regexp.MustCompile(cl.Key("eui", euiRegexpStr, euiRegexpStr+"$"))
-
-			addrRegexpLegacy := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr+"$"))
-			addrRegexp3_10_16Bit := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "16bit$"))
-			addrRegexp3_10_32Bit := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "32bit$"))
-			addrRegexp3_10_Pending := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "pending$"))
-			addrRegexp3_11_Current := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "current$"))
-			addrRegexp3_11_CurrentFields := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "current", "fields$"))
-			addrRegexp3_11_PendingFields := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "pending", "fields$"))
-			err := ttnredis.RangeRedisKeys(ctx, cl, cl.Key("*"), ttnredis.DefaultRangeCount, func(k string) (bool, error) {
-				logger := logger.WithField("key", k)
-				switch {
-				case uidRegexp3_10_Fields.MatchString(k):
-					if err := cl.Del(ctx, k).Err(); err != nil {
+			pipeliner := uplinkClient.Pipeline()
+			err := ttnredis.RangeRedisKeys(ctx, uplinkClient, uplinkClient.Key("*"), ttnredis.DefaultRangeCount,
+				func(k string) (bool, error) {
+					logger := logger.WithField("key", k)
+					if !uidLastInvalidationKey.MatchString(k) {
+						return true, nil
+					}
+					if err := pipeliner.Del(ctx, k).Err(); err != nil {
 						logger.WithError(err).Error("Failed to delete key")
 						return true, nil
 					}
-
-				case addrRegexpLegacy.MatchString(k):
-					var devAddr types.DevAddr
-					if err := devAddr.UnmarshalText([]byte(k[len(k)-8:])); err != nil {
-						logger.WithError(err).Error("Failed to parse DevAddr from legacy DevAddr key")
-						return true, nil
-					}
-					currentKey := nsredis.CurrentAddrKey(k)
-					currentFieldKey := nsredis.FieldKey(currentKey)
-					pendingKey := nsredis.PendingAddrKey(k)
-					pendingFieldKey := nsredis.FieldKey(pendingKey)
-					pendingScore := float64(time.Now().UnixNano())
-					if err := ttnredis.RangeRedisSet(ctx, cl, k, "*", ttnredis.DefaultRangeCount, func(uid string) (bool, error) {
-						logger := logger.WithField("uid", uid)
-						uk := nsredis.UIDKey(cl, uid)
-						if err := cl.Watch(ctx, func(tx *redis.Tx) error {
-							dev := &ttnpb.EndDevice{}
-							if err := ttnredis.GetProto(ctx, tx, uk).ScanProto(dev); err != nil {
-								logger.WithError(err).Error("Failed to get device proto")
-								return err
-							}
-							p := tx.TxPipeline()
-							defer p.Close()
-							if dev.Session != nil && types.MustDevAddr(dev.Session.DevAddr).OrZero().Equal(devAddr) {
-								if dev.MacState == nil {
-									logger.Error("Device is missing MAC state, skip migrating current session")
-								} else {
-									b, err := nsredis.MarshalDeviceCurrentSession(dev)
-									if err != nil {
-										return err
-									}
-									p.ZAdd(ctx, currentKey, &redis.Z{
-										Score:  float64(dev.Session.LastFCntUp & 0xffff),
-										Member: uid,
-									})
-									p.HSet(ctx, currentFieldKey, uid, b)
-								}
-							}
-							if dev.PendingSession != nil && types.MustDevAddr(dev.PendingSession.DevAddr).OrZero().Equal(devAddr) {
-								if dev.PendingMacState == nil {
-									logger.Error("Device is missing MAC state, skip migrating pending session")
-								} else {
-									b, err := nsredis.MarshalDevicePendingSession(dev)
-									if err != nil {
-										return err
-									}
-									p.ZAdd(ctx, pendingKey, &redis.Z{
-										Score:  pendingScore,
-										Member: uid,
-									})
-									p.HSet(ctx, pendingFieldKey, uid, b)
-								}
-							}
-							p.SRem(ctx, k, uid)
-							_, err := p.Exec(ctx)
-							if err != nil {
-								logger.WithError(err).Error("Pipeline failed")
-								return err
-							}
-							return nil
-						}, k, uk); err != nil {
-							logger.WithError(err).Error("Transaction failed")
-						}
-						return true, nil
-					}); err != nil {
-						logger.WithError(err).Error("Failed to scan legacy DevAddr key")
-						return true, nil
-					}
-
-				case addrRegexp3_10_16Bit.MatchString(k), addrRegexp3_10_32Bit.MatchString(k):
-					currentKey := nsredis.CurrentAddrKey(k[:len(k)-6])
-					fieldKey := nsredis.FieldKey(currentKey)
-					if err := ttnredis.RangeRedisZSet(ctx, cl, k, "*", ttnredis.DefaultRangeCount, func(uid string, v float64) (bool, error) {
-						logger := logger.WithField("uid", uid)
-						uk := nsredis.UIDKey(cl, uid)
-						if err := cl.Watch(ctx, func(tx *redis.Tx) error {
-							dev := &ttnpb.EndDevice{}
-							if err := ttnredis.GetProto(ctx, tx, uk).ScanProto(dev); err != nil {
-								logger.WithError(err).Error("Failed to get device proto")
-								return err
-							}
-							if dev.Session == nil || dev.MacState == nil {
-								logger.Error("Device is missing session or MAC state, skip")
-								return nil
-							}
-							b, err := nsredis.MarshalDeviceCurrentSession(dev)
-							if err != nil {
-								return err
-							}
-							_, err = tx.TxPipelined(ctx, func(p redis.Pipeliner) error {
-								p.ZAdd(ctx, currentKey, &redis.Z{
-									Score:  float64(uint32(v) & 0xffff),
-									Member: uid,
-								})
-								p.HSet(ctx, fieldKey, uid, b)
-								p.ZRem(ctx, k, uid)
-								return nil
-							})
-							if err != nil {
-								logger.WithError(err).Error("Pipeline failed")
-								return err
-							}
-							return nil
-						}, k, uk); err != nil {
-							logger.WithError(err).Error("Transaction failed")
-						}
-						return true, nil
-					}); err != nil {
-						logger.WithError(err).Error("Failed to scan 3.10 current DevAddr key")
-						return true, nil
-					}
-
-				case addrRegexp3_10_Pending.MatchString(k):
-					typ, err := cl.Type(ctx, k).Result()
-					if err != nil {
-						logger.WithError(err).Error("Failed to determine type of value stored under key")
-						return true, nil
-					}
-					if typ == "zset" {
-						return true, nil
-					}
-					fieldKey := nsredis.FieldKey(k)
-					tmpKey := cl.Key(k, "migrate")
-					score := float64(time.Now().UnixNano())
-					if err := cl.Watch(ctx, func(tx *redis.Tx) error {
-						p := tx.TxPipeline()
-						defer p.Close()
-						if err := ttnredis.RangeRedisSet(ctx, tx, k, "*", ttnredis.DefaultRangeCount, func(uid string) (bool, error) {
-							logger := logger.WithField("uid", uid)
-							uk := nsredis.UIDKey(cl, uid)
-							if err := tx.Watch(ctx, uk).Err(); err != nil {
-								logger.WithField("key", uk).WithError(err).Error("Failed to watch UID key")
-								return false, err
-							}
-							dev := &ttnpb.EndDevice{}
-							if err := ttnredis.GetProto(ctx, tx, uk).ScanProto(dev); err != nil {
-								logger.WithError(err).Error("Failed to get device proto")
-								return false, err
-							}
-							if dev.PendingSession == nil || dev.PendingMacState == nil {
-								logger.Error("Device is missing pending session or MAC state, skip")
-								return true, nil
-							}
-							b, err := nsredis.MarshalDevicePendingSession(dev)
-							if err != nil {
-								return false, err
-							}
-							p.ZAdd(ctx, tmpKey, &redis.Z{
-								Score:  score,
-								Member: uid,
-							})
-							p.HSet(ctx, fieldKey, uid, b)
-							p.SRem(ctx, k, uid)
-							return true, nil
-						}); err != nil {
-							logger.WithError(err).Error("Failed to scan 3.10 pending DevAddr key")
-							return err
-						}
-						p.RenameNX(ctx, tmpKey, k)
-						_, err := p.Exec(ctx)
-						if err != nil {
-							logger.WithError(err).Error("Pipeline failed")
-							return err
-						}
-						return nil
-					}, k, tmpKey); err != nil {
-						logger.WithError(err).Error("Transaction failed")
-						return true, nil
-					}
-
-				case addrRegexp3_11_CurrentFields.MatchString(k):
-					var migratedSubkeys uint64
-					if err := ttnredis.RangeRedisHMap(ctx, cl, k, "*", 1, func(uid string, s string) (bool, error) {
-						logger := logger.WithField("uid", uid)
-						if err := cl.Watch(ctx, func(tx *redis.Tx) error {
-							if err := msgpack.Unmarshal([]byte(s), &nsredis.UplinkMatchSession{}); err == nil {
-								return nil
-							}
-							type BoolValue struct {
-								Value bool `msgpack:"value"`
-							}
-							stored := &struct {
-								FNwkSIntKey       KeyEnvelope3_11Snapshot
-								ResetsFCnt        *BoolValue
-								Supports32BitFCnt *BoolValue
-								LoRaWANVersion    ttnpb.MACVersion
-								LastFCnt          uint32
-							}{}
-							if err := msgpack.Unmarshal([]byte(s), stored); err != nil {
-								logger.WithError(err).Error("Failed to unmarshal legacy current session fields")
-								return err
-							}
-							var key *types.AES128Key
-							if len(stored.FNwkSIntKey.Key) > 0 {
-								key = &types.AES128Key{}
-								copy(key[:], stored.FNwkSIntKey.Key)
-							}
-							var resetsFCnt *ttnpb.BoolValue
-							if stored.ResetsFCnt != nil {
-								resetsFCnt = &ttnpb.BoolValue{
-									Value: stored.ResetsFCnt.Value,
-								}
-							}
-							var supports32BitFCnt *ttnpb.BoolValue
-							if stored.Supports32BitFCnt != nil {
-								supports32BitFCnt = &ttnpb.BoolValue{
-									Value: stored.Supports32BitFCnt.Value,
-								}
-							}
-							b, err := msgpack.Marshal(&nsredis.UplinkMatchSession{
-								FNwkSIntKey: &ttnpb.KeyEnvelope{
-									Key:          key.Bytes(),
-									KekLabel:     stored.FNwkSIntKey.KEKLabel,
-									EncryptedKey: stored.FNwkSIntKey.EncryptedKey,
-								},
-								ResetsFCnt:        resetsFCnt,
-								Supports32BitFCnt: supports32BitFCnt,
-								LoRaWANVersion:    stored.LoRaWANVersion,
-								LastFCnt:          stored.LastFCnt,
-							})
-							if err != nil {
-								logger.WithError(err).Error("Failed to marshal current session fields")
-								return nil
-							}
-							if err := tx.HSet(ctx, k, uid, string(b)).Err(); err != nil {
-								logger.WithError(err).Error("Failed to set current session fields")
-								return err
-							}
-							migratedSubkeys++
-							return nil
-						}, k); err != nil {
-							logger.WithError(err).Error("Transaction failed")
-						}
-						return true, nil
-					}); err != nil {
-						logger.WithError(err).Error("Failed to scan current session field key")
-						return true, nil
-					}
-					if migratedSubkeys == 0 {
-						return true, nil
-					}
-
-				case addrRegexp3_11_PendingFields.MatchString(k):
-					var migratedSubkeys uint64
-					if err := ttnredis.RangeRedisHMap(ctx, cl, k, "*", 1, func(uid string, s string) (bool, error) {
-						logger := logger.WithField("uid", uid)
-						if err := cl.Watch(ctx, func(tx *redis.Tx) error {
-							if err := msgpack.Unmarshal([]byte(s), &nsredis.UplinkMatchPendingSession{}); err == nil {
-								return nil
-							}
-							stored := &struct {
-								FNwkSIntKey    KeyEnvelope3_11Snapshot
-								LoRaWANVersion ttnpb.MACVersion
-							}{}
-							if err := msgpack.Unmarshal([]byte(s), stored); err != nil {
-								logger.WithError(err).Error("Failed to unmarshal legacy pending session fields")
-								return err
-							}
-							var key *types.AES128Key
-							if len(stored.FNwkSIntKey.Key) > 0 {
-								key = &types.AES128Key{}
-								copy(key[:], stored.FNwkSIntKey.Key)
-							}
-							b, err := msgpack.Marshal(&nsredis.UplinkMatchSession{
-								FNwkSIntKey: &ttnpb.KeyEnvelope{
-									Key:          key.Bytes(),
-									KekLabel:     stored.FNwkSIntKey.KEKLabel,
-									EncryptedKey: stored.FNwkSIntKey.EncryptedKey,
-								},
-								LoRaWANVersion: stored.LoRaWANVersion,
-							})
-							if err != nil {
-								logger.WithError(err).Error("Failed to marshal pending session fields")
-								return nil
-							}
-							if err := tx.HSet(ctx, k, uid, string(b)).Err(); err != nil {
-								logger.WithError(err).Error("Failed to set pending session fields")
-								return err
-							}
-							migratedSubkeys++
-							return nil
-						}, k); err != nil {
-							logger.WithError(err).Error("Transaction failed")
-						}
-						return true, nil
-					}); err != nil {
-						logger.WithError(err).Error("Failed to scan pending session field key")
-						return true, nil
-					}
-					if migratedSubkeys == 0 {
-						return true, nil
-					}
-
-				case uidRegexp.MatchString(k),
-					euiRegexp.MatchString(k),
-					addrRegexp3_11_Current.MatchString(k):
-					logger.Debug("Skip valid key")
+					removed++
 					return true, nil
-
-				default:
-					d, err := cl.TTL(ctx, k).Result()
-					if err != nil {
-						logger.WithError(err).Error("Failed to determine TTL of unmatched key")
-						return true, nil
-					}
-					if d < 0 {
-						logger.Error("Skip unmatched key with no TTL")
-						return true, nil
-					}
-					logger.Debug("Skip unmatched key with a TTL")
-					return true, nil
-				}
-				logger.Debug("Migrated key to 3.11 format")
-				migrated++
-				return true, nil
-			})
+				})
 			if err != nil {
 				return err
 			}
+			if _, err := pipeliner.Exec(ctx); err != nil {
+				return err
+			}
 
-			return recordSchemaVersion(cl, nsredis.SchemaVersion)
+			if err := recordSchemaVersion(uplinkClient, nsredis.SchemaVersion); err != nil {
+				return err
+			}
+			return recordSchemaVersion(devicesClient, nsredis.SchemaVersion)
 		},
 	}
 	nsDBCleanupCommand = &cobra.Command{

--- a/pkg/applicationserver/io/packages/loradms/v1/api/objects/objects.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/api/objects/objects.go
@@ -58,6 +58,8 @@ type PositionSolutionType uint8
 const (
 	// GNSSPositionSolutionType is GNSS position solution type.
 	GNSSPositionSolutionType PositionSolutionType = iota
+	// GNSSNGPositionSolutionType is GNSSNG position solution type.
+	GNSSNGPositionSolutionType
 	// WiFiPositionSolutionType is WiFi position solution type.
 	WiFiPositionSolutionType
 	// UnknownPositionSolutionType is used when the position solution type is unknown.
@@ -73,6 +75,7 @@ type PositionSolution struct {
 
 const (
 	gnssPositionSolutionType    = "gnss"
+	gnssngPositionSolutionType  = "gnssng"
 	wifiPositionSolutionType    = "wifi"
 	unknownPositionSolutionType = "unknown"
 )
@@ -83,6 +86,8 @@ func (t PositionSolutionType) MarshalJSON() ([]byte, error) {
 	switch t {
 	case GNSSPositionSolutionType:
 		tp = gnssPositionSolutionType
+	case GNSSNGPositionSolutionType:
+		tp = gnssngPositionSolutionType
 	case WiFiPositionSolutionType:
 		tp = wifiPositionSolutionType
 	default:
@@ -101,6 +106,8 @@ func (t *PositionSolutionType) UnmarshalJSON(b []byte) error {
 	switch tp {
 	case gnssPositionSolutionType:
 		*t = GNSSPositionSolutionType
+	case gnssngPositionSolutionType:
+		*t = GNSSNGPositionSolutionType
 	case wifiPositionSolutionType:
 		*t = WiFiPositionSolutionType
 	default:
@@ -114,6 +121,8 @@ func (t PositionSolutionType) String() string {
 	switch t {
 	case GNSSPositionSolutionType:
 		return gnssPositionSolutionType
+	case GNSSNGPositionSolutionType:
+		return gnssngPositionSolutionType
 	case WiFiPositionSolutionType:
 		return wifiPositionSolutionType
 	default:

--- a/pkg/applicationserver/io/packages/loradms/v1/package.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/package.go
@@ -215,7 +215,7 @@ func (p *DeviceManagementPackage) sendLocationSolved(ctx context.Context, ids *t
 		ReceivedAt:     ttnpb.ProtoTimePtr(time.Now()),
 		Up: &ttnpb.ApplicationUp_LocationSolved{
 			LocationSolved: &ttnpb.ApplicationLocation{
-				Service: fmt.Sprintf("%v-%s", PackageName, position.Algorithm),
+				Service: PackageName,
 				Location: &ttnpb.Location{
 					Latitude:  position.LLH[0],
 					Longitude: position.LLH[1],

--- a/pkg/applicationserver/io/packages/loradms/v1/package.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/package.go
@@ -336,7 +336,7 @@ func float64PtrOfTimestamp(x *pbtypes.Timestamp) *float64 {
 	if x == nil {
 		return nil
 	}
-	f := float64(ttnpb.StdTime(x).UnixNano())
+	f := float64(ttnpb.StdTime(x).UnixNano()) / float64(1e9)
 	return &f
 }
 

--- a/pkg/applicationserver/io/packages/loradms/v1/package.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/package.go
@@ -204,7 +204,7 @@ func (p *DeviceManagementPackage) sendLocationSolved(ctx context.Context, ids *t
 	}
 	source := ttnpb.LocationSource_SOURCE_UNKNOWN
 	switch position.Algorithm {
-	case objects.GNSSPositionSolutionType:
+	case objects.GNSSPositionSolutionType, objects.GNSSNGPositionSolutionType:
 		source = ttnpb.LocationSource_SOURCE_GPS
 	case objects.WiFiPositionSolutionType:
 		source = ttnpb.LocationSource_SOURCE_WIFI_RSSI_GEOLOCATION

--- a/pkg/applicationserver/io/packages/loradms/v1/package.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/package.go
@@ -85,7 +85,7 @@ func (p *DeviceManagementPackage) HandleUp(ctx context.Context, def *ttnpb.Appli
 	case *ttnpb.ApplicationUp_UplinkMessage:
 		msg := m.UplinkMessage
 		settings := msg.GetSettings()
-		receivedAt := lorautil.ExtractApplicationUplinkReceivedAt(msg)
+		receivedAt := lorautil.GetAdjustedReceivedAt(msg)
 		loraUp := &objects.LoRaUplink{
 			Type:      objects.UplinkUplinkType,
 			FCnt:      uint32Ptr(msg.GetFCnt()),

--- a/pkg/applicationserver/io/packages/loragls/v3/package.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/package.go
@@ -294,7 +294,7 @@ func (p *GeolocationPackage) sendLocationSolved(ctx context.Context, ids *ttnpb.
 		ReceivedAt:     ttnpb.ProtoTimePtr(time.Now()),
 		Up: &ttnpb.ApplicationUp_LocationSolved{
 			LocationSolved: &ttnpb.ApplicationLocation{
-				Service:  fmt.Sprintf("%v-%s", PackageName, result.Algorithm()),
+				Service:  PackageName,
 				Location: loc,
 			},
 		},

--- a/pkg/networkserver/mac/device_time.go
+++ b/pkg/networkserver/mac/device_time.go
@@ -34,7 +34,7 @@ var (
 
 func HandleDeviceTimeReq(ctx context.Context, dev *ttnpb.EndDevice, msg *ttnpb.UplinkMessage) (events.Builders, error) {
 	ans := &ttnpb.MACCommand_DeviceTimeAns{
-		Time: lorautil.ExtractUplinkReceivedAt(msg),
+		Time: lorautil.GetAdjustedReceivedAt(msg),
 	}
 	dev.MacState.QueuedResponses = append(dev.MacState.QueuedResponses, ans.MACCommand())
 	return events.Builders{

--- a/pkg/networkserver/mac/device_time.go
+++ b/pkg/networkserver/mac/device_time.go
@@ -17,10 +17,9 @@ package mac
 import (
 	"context"
 
-	pbtypes "github.com/gogo/protobuf/types"
-
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	lorautil "go.thethings.network/lorawan-stack/v3/pkg/util/lora"
 )
 
 var (
@@ -35,27 +34,11 @@ var (
 
 func HandleDeviceTimeReq(ctx context.Context, dev *ttnpb.EndDevice, msg *ttnpb.UplinkMessage) (events.Builders, error) {
 	ans := &ttnpb.MACCommand_DeviceTimeAns{
-		Time: messageTimestamp(msg),
+		Time: lorautil.ExtractUplinkReceivedAt(msg),
 	}
 	dev.MacState.QueuedResponses = append(dev.MacState.QueuedResponses, ans.MACCommand())
 	return events.Builders{
 		EvtReceiveDeviceTimeRequest,
 		EvtEnqueueDeviceTimeAnswer.With(events.WithData(ans)),
 	}, nil
-}
-
-func messageTimestamp(msg *ttnpb.UplinkMessage) *pbtypes.Timestamp {
-	var ts *pbtypes.Timestamp
-	for _, md := range msg.RxMetadata {
-		if t := md.GpsTime; t != nil {
-			return t
-		}
-		if ts == nil && md.ReceivedAt != nil {
-			ts = md.ReceivedAt
-		}
-	}
-	if ts != nil {
-		return ts
-	}
-	return msg.ReceivedAt
 }

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -40,7 +40,12 @@ var (
 )
 
 // SchemaVersion is the Network Server database schema version. Bump when a migration is required.
-const SchemaVersion = 1
+const SchemaVersion = 2
+
+// UnsupportedMigrationVersionBreakpoint indicates the breakpoint for versions that
+// cannot be auto-migrated to latest. Use v3.23.0 of The Things Stack to migrate
+// to a supported SchemaVersion before migrating to latest.
+const UnsupportedMigrationVersionBreakpoint = 1
 
 // DeviceRegistry is an implementation of networkserver.DeviceRegistry.
 type DeviceRegistry struct {

--- a/pkg/util/lora/lora.go
+++ b/pkg/util/lora/lora.go
@@ -34,11 +34,11 @@ func AdjustedRSSI(channelRSSI, snr float32) float32 {
 	return rssi
 }
 
-// ExtractUplinkReceivedAt returns the correct ReceivedAt timestamp based on
-// the uplink's RxMetadata and actual time of receival.
-func ExtractUplinkReceivedAt(msg *ttnpb.UplinkMessage) *pbtypes.Timestamp {
+// ExtractRxMetadataReceivedAt returns the ReceivedAt timestamp based on the
+// provided metadatas or nil if no md.GpsTime nor md.ReceivedAt is found.
+func ExtractRxMetadataReceivedAt(mds []*ttnpb.RxMetadata) *pbtypes.Timestamp {
 	var ts *pbtypes.Timestamp
-	for _, md := range msg.RxMetadata {
+	for _, md := range mds {
 		if t := md.GpsTime; t != nil {
 			return t
 		}
@@ -46,8 +46,25 @@ func ExtractUplinkReceivedAt(msg *ttnpb.UplinkMessage) *pbtypes.Timestamp {
 			ts = md.ReceivedAt
 		}
 	}
-	if ts != nil {
-		return ts
+	return ts
+}
+
+// ExtractUplinkReceivedAt returns the correct ReceivedAt timestamp based on
+// the uplink message's RxMetadata and the msg.ReceivedAt.
+func ExtractUplinkReceivedAt(msg *ttnpb.UplinkMessage) *pbtypes.Timestamp {
+	mdReceivedAt := ExtractRxMetadataReceivedAt(msg.RxMetadata)
+	if mdReceivedAt != nil {
+		return mdReceivedAt
+	}
+	return msg.ReceivedAt
+}
+
+// ExtractApplicationUplinkReceivedAt returns the correct ReceivedAt timestamp based on
+// the application uplink message's RxMetadata and the msg.ReceivedAt.
+func ExtractApplicationUplinkReceivedAt(msg *ttnpb.ApplicationUplink) *pbtypes.Timestamp {
+	mdReceivedAt := ExtractRxMetadataReceivedAt(msg.RxMetadata)
+	if mdReceivedAt != nil {
+		return mdReceivedAt
 	}
 	return msg.ReceivedAt
 }

--- a/pkg/webui/console/components/events/previews/application-location.js
+++ b/pkg/webui/console/components/events/previews/application-location.js
@@ -29,7 +29,12 @@ const ApplicationLocationPreview = React.memo(({ event }) => {
       <DescriptionList.Item title={sharedMessages.longitude} data={longitude} />
       <DescriptionList.Item title={sharedMessages.altitude} data={altitude} />
       <DescriptionList.Item title={sharedMessages.accuracy} data={accuracy} />
-      <DescriptionList.Item title={sharedMessages.source} data={source.replace(/^(SOURCE_)/, '')} />
+      {source && (
+        <DescriptionList.Item
+          title={sharedMessages.source}
+          data={source.replace(/^(SOURCE_)/, '')}
+        />
+      )}
     </DescriptionList>
   )
 })

--- a/pkg/webui/console/constants/lora-cloud-das.js
+++ b/pkg/webui/console/constants/lora-cloud-das.js
@@ -14,6 +14,7 @@
 
 export default Object.freeze({
   DEFAULT_PORT: 199,
+  DEFAULT_PORT_SET: [192, 197, 198, 199],
   DEFAULT_PACKAGE_NAME: 'lora-cloud-device-management-v1',
   DEFAULT_SERVER_URL: 'https://mgs.loracloud.com',
 })

--- a/pkg/webui/console/containers/lora-cloud-das-form/index.js
+++ b/pkg/webui/console/containers/lora-cloud-das-form/index.js
@@ -95,6 +95,7 @@ const defaultValues = {
   data: {
     token: '',
     server_url: LORA_CLOUD_DAS.DEFAULT_SERVER_URL,
+    f_port_set: LORA_CLOUD_DAS.DEFAULT_PORT,
   },
 }
 

--- a/pkg/webui/console/containers/lora-cloud-das-form/index.js
+++ b/pkg/webui/console/containers/lora-cloud-das-form/index.js
@@ -95,7 +95,7 @@ const defaultValues = {
   data: {
     token: '',
     server_url: LORA_CLOUD_DAS.DEFAULT_SERVER_URL,
-    f_port_set: LORA_CLOUD_DAS.DEFAULT_PORT,
+    f_port_set: LORA_CLOUD_DAS.DEFAULT_PORT_SET,
   },
 }
 


### PR DESCRIPTION
#### Summary
Replace the v3.10 to v3.11 Network Server db migration with last invalidation keys and add version warnings accordingly.

Closes #4652.

TODO: Update CHANGELOG.md

#### Changes
- Removed the v3.10 to v3.11 key migration from `ns-db migrate`
- Added last invalidation keys migration

#### Testing
- Added the keys to Redis and verified that they don't exist after the migration
- Verified that the version numbers are properly set after the migration under the correct namespace 

##### Regressions
- Direct migrations of version 0 to version 2 of the Network Server db are not supported. Tested by manually setting the versions in the db and verified that the correct warning is displayed.

#### Notes for Reviewers
...


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
