### PR TITLE
Do not submit LNSURI change accidentally

### DIFF
--- a/pkg/basicstation/cups/update_info.go
+++ b/pkg/basicstation/cups/update_info.go
@@ -302,15 +302,14 @@ func (s *Server) updateInfo(w http.ResponseWriter, r *http.Request) (err error) 
 				gtw.GatewayServerAddress = s.defaultLNSURI
 			}
 		}
-		var scheme, host, port string
-		if gtw.GatewayServerAddress != req.LNSURI {
-			scheme, host, port, err = parseAddress("wss", gtw.GatewayServerAddress)
-			if err != nil {
-				return err
-			}
-			address := host
-			address = net.JoinHostPort(host, port)
-			res.LNSURI = fmt.Sprintf("%s://%s", scheme, address)
+
+		scheme, host, port, err := parseAddress("wss", gtw.GatewayServerAddress)
+		if err != nil {
+			return err
+		}
+		lnsURI := fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(host, port))
+		if lnsURI != req.LNSURI {
+			res.LNSURI = lnsURI
 		}
 
 		// Only fetch Trust and Credentials for TLS end points.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes a bug in our CUPS implementation which claimed that the LNS URI always changed, due to the fact that we compared an address without a scheme and port (the `GatewayServerAddress`) with the address provided in the request.

#### Changes
<!-- What are the changes made in this pull request? -->

- Make sure that the request LNS URI and response LNS URI differ.


#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This is a bug on our side and per specification we should not have a LNS URI in the response unless it differs from the one in the request.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
