### PR TITLE
Configure NSID consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Deprecated
 
+- Device Claiming Server configuration option `dcs.edcs.network-server.home-ns-id`. Use `dcs.edcs.ns-id` instead.
+
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Network Server ID (NSID) used for Backend Interfaces interoperability via the `ns.interop.id` and `dcs.edcs.ns-id` configuration options.
+  - In the Network Server, `ns.interop.id` acts as a fallback value for `sender-ns-id` in Join Server interoperability configuration.
+
 ### Changed
 
 ### Deprecated

--- a/pkg/applicationserver/config.go
+++ b/pkg/applicationserver/config.go
@@ -41,7 +41,7 @@ type InteropClient interface {
 // InteropConfig represents interoperability client configuration.
 type InteropConfig struct {
 	config.InteropClient `name:",squash"`
-	ID                   string `name:"id" description:"AS-ID used for interoperability"`
+	ID                   string `name:"id" description:"AS-ID of this Application Server"`
 }
 
 // EndDeviceFetcherConfig represents configuration for the end device fetcher in Application Server.

--- a/pkg/deviceclaimingserver/enddevices/config.go
+++ b/pkg/deviceclaimingserver/enddevices/config.go
@@ -27,19 +27,22 @@ import (
 const JSClientConfigurationName = "config.yml"
 
 // NetworkServer contains information related to the Network Server.
+// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6048)
 type NetworkServer struct {
-	HomeNSID *types.EUI64 `name:"home-ns-id" description:"HomeNSID of the Network Server (EUI)"`
-
-	Hostname string `name:"hostname" description:"DEPRECATED"`
+	HomeNSID *types.EUI64 `name:"home-ns-id" description:"DEPRECATED"`
+	Hostname string       `name:"hostname" description:"DEPRECATED"`
 }
 
 // Config contains options for end device claiming clients.
 //
 //nolint:lll
 type Config struct {
-	NetID         types.NetID   `name:"net-id" description:"NetID of the Network Server to configure when claiming"`
-	NetworkServer NetworkServer `name:"network-server" description:"Network Server of the cluster that handles claimed device traffic"`
-	ASID          string        `name:"as-id" description:"AS-ID of the Application Server to configure when claiming"`
+	NetID types.NetID  `name:"net-id" description:"NetID of the Network Server to configure when claiming"`
+	NSID  *types.EUI64 `name:"ns-id" description:"NSID of the Network Server to configure when claiming"`
+	ASID  string       `name:"as-id" description:"AS-ID of the Application Server to configure when claiming"`
+
+	// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6048)
+	NetworkServer NetworkServer `name:"network-server" description:"DEPRECATED"`
 
 	Source    string                `name:"source" description:"Source of the file containing Join Server settings (directory, url, blob)"`
 	Directory string                `name:"directory" description:"OS filesystem directory, which contains the config.yml and the client-specific files"`

--- a/pkg/deviceclaimingserver/enddevices/enddevices.go
+++ b/pkg/deviceclaimingserver/enddevices/enddevices.go
@@ -75,6 +75,7 @@ func NewUpstream(ctx context.Context, c Component, conf Config, opts ...Option) 
 		Component: c,
 		servers:   make(map[string]EndDeviceClaimer),
 	}
+
 	fetcher, err := conf.Fetcher(ctx, c.GetBaseConfig(ctx).Blob, c)
 	if err != nil {
 		return nil, err
@@ -89,6 +90,12 @@ func NewUpstream(ctx context.Context, c Component, conf Config, opts ...Option) 
 	var baseConfig baseConfig
 	if err := yaml.UnmarshalStrict(baseConfigBytes, &baseConfig); err != nil {
 		return nil, err
+	}
+
+	nsID := conf.NSID
+	// TODO: Remove fallback logic (https://github.com/TheThingsNetwork/lorawan-stack/issues/6048)
+	if nsID == nil {
+		nsID = conf.NetworkServer.HomeNSID
 	}
 
 	// Setup upstreams.
@@ -111,7 +118,7 @@ func NewUpstream(ctx context.Context, c Component, conf Config, opts ...Option) 
 			}
 			claimer = ttjsv2.NewClient(c, fetcher, ttjsv2.Config{
 				NetID:           conf.NetID,
-				HomeNSID:        conf.NetworkServer.HomeNSID,
+				NSID:            nsID,
 				ASID:            conf.ASID,
 				JoinEUIPrefixes: js.JoinEUIs,
 				ConfigFile:      ttjsConf,

--- a/pkg/deviceclaimingserver/enddevices/ttjsv2/ttjs.go
+++ b/pkg/deviceclaimingserver/enddevices/ttjsv2/ttjs.go
@@ -38,6 +38,7 @@ type ConfigFile struct {
 	TLS TLSConfig `yaml:"tls"`
 
 	// BasicAuth is no longer used and is only kept for backwards compatibility.
+	// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6049)
 	BasicAuth struct {
 		Username string `yaml:"username"`
 		Password string `yaml:"password"`
@@ -47,7 +48,7 @@ type ConfigFile struct {
 // Config is the configuration for The Things Join Server claiming client.
 type Config struct {
 	NetID           types.NetID
-	HomeNSID        *types.EUI64
+	NSID            *types.EUI64
 	ASID            string
 	JoinEUIPrefixes []types.EUI64Prefix
 	ConfigFile
@@ -95,6 +96,7 @@ func (c *TTJS) httpClient(ctx context.Context) (*http.Client, error) {
 		}
 		opts = append(opts, httpclient.WithTLSConfig(tlsConf))
 	}
+	// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6049)
 	if c.config.BasicAuth.Username != "" || c.config.BasicAuth.Password != "" {
 		log.FromContext(ctx).Warn("Basic authentication with The Things Join Server is no longer supported and will be removed in a future version.") //nolint:lll
 	}
@@ -124,8 +126,8 @@ func (c *TTJS) Claim(ctx context.Context, joinEUI, devEUI types.EUI64, claimAuth
 		HomeNetID:  c.config.NetID.String(),
 		ASID:       c.config.ASID,
 	}
-	if c.config.HomeNSID != nil {
-		claimReq.HomeNSID = stringValue(c.config.HomeNSID.String())
+	if c.config.NSID != nil {
+		claimReq.HomeNSID = stringValue(c.config.NSID.String())
 	}
 	buf, err := json.Marshal(claimReq)
 	if err != nil {

--- a/pkg/deviceclaimingserver/enddevices/ttjsv2/ttjs_test.go
+++ b/pkg/deviceclaimingserver/enddevices/ttjsv2/ttjs_test.go
@@ -92,9 +92,9 @@ func TestTTJS(t *testing.T) { //nolint:paralleltest
 	fetcher := fetch.FromFilesystem("testdata")
 
 	client1 := ttjsv2.NewClient(c, fetcher, ttjsv2.Config{
-		NetID:    test.DefaultNetID,
-		HomeNSID: &homeNSID,
-		ASID:     "localhost",
+		NetID: test.DefaultNetID,
+		NSID:  &homeNSID,
+		ASID:  "localhost",
 		JoinEUIPrefixes: []types.EUI64Prefix{
 			supportedJoinEUIPrefix,
 		},
@@ -169,9 +169,9 @@ func TestTTJS(t *testing.T) { //nolint:paralleltest
 
 	// Claim locked.
 	client2 := ttjsv2.NewClient(c, fetcher, ttjsv2.Config{
-		NetID:    test.DefaultNetID,
-		HomeNSID: &homeNSID,
-		ASID:     "localhost",
+		NetID: test.DefaultNetID,
+		NSID:  &homeNSID,
+		ASID:  "localhost",
 		JoinEUIPrefixes: []types.EUI64Prefix{
 			supportedJoinEUIPrefix,
 		},

--- a/pkg/interop/client_test.go
+++ b/pkg/interop/client_test.go
@@ -275,6 +275,7 @@ func TestHandleJoinRequest(t *testing.T) { //nolint:paralleltest
 		Name              string
 		NewServer         func(*assertions.Assertion) *httptest.Server
 		NetID             types.NetID
+		NSID              *types.EUI64
 		Request           *ttnpb.JoinRequest
 		ResponseAssertion func(*assertions.Assertion, *ttnpb.JoinResponse) bool
 		ErrorAssertion    func(*assertions.Assertion, error) bool
@@ -442,6 +443,7 @@ func TestHandleJoinRequest(t *testing.T) { //nolint:paralleltest
 				}))
 			},
 			NetID: types.NetID{0x42, 0xff, 0xff},
+			NSID:  types.MustEUI64([]byte{0x70, 0xb3, 0xd5, 0x7e, 0xd0, 0x00, 0x00, 0xFF}),
 			Request: &ttnpb.JoinRequest{
 				SelectedMacVersion: ttnpb.MACVersion_MAC_V1_0_3,
 				DevAddr:            types.DevAddr{0x01, 0x02, 0x03, 0x04}.Bytes(),
@@ -527,6 +529,7 @@ func TestHandleJoinRequest(t *testing.T) { //nolint:paralleltest
 				}))
 			},
 			NetID: types.NetID{0x42, 0xff, 0xff},
+			NSID:  types.MustEUI64([]byte{0x70, 0xb3, 0xd5, 0x7e, 0xd0, 0x00, 0x00, 0xFF}),
 			Request: &ttnpb.JoinRequest{
 				SelectedMacVersion: ttnpb.MACVersion_MAC_V1_0_3,
 				DevAddr:            types.DevAddr{0x01, 0x02, 0x03, 0x04}.Bytes(),
@@ -673,7 +676,7 @@ func TestHandleJoinRequest(t *testing.T) { //nolint:paralleltest
 				t.Fatalf("Failed to create new client: %s", err)
 			}
 
-			res, err := cl.HandleJoinRequest(ctx, tc.NetID, tc.Request)
+			res, err := cl.HandleJoinRequest(ctx, tc.NetID, tc.NSID, tc.Request)
 			if a.So(tc.ErrorAssertion(a, err), should.BeTrue) {
 				a.So(tc.ResponseAssertion(a, res), should.BeTrue)
 			} else if err != nil {
@@ -852,7 +855,7 @@ func TestJoinServerRace(t *testing.T) { //nolint:paralleltest
 				t.Fatalf("Failed to create new client: %s", err)
 			}
 
-			res, err := cl.HandleJoinRequest(ctx, tc.NetID, tc.Request)
+			res, err := cl.HandleJoinRequest(ctx, tc.NetID, nil, tc.Request)
 			if a.So(tc.ErrorAssertion(a, err), should.BeTrue) {
 				a.So(tc.ResponseAssertion(a, res), should.BeTrue)
 			} else if err != nil {

--- a/pkg/networkserver/config.go
+++ b/pkg/networkserver/config.go
@@ -122,6 +122,12 @@ func (c DownlinkPriorityConfig) Parse() (DownlinkPriorities, error) {
 	return p, nil
 }
 
+// InteropConfig represents interoperability client configuration.
+type InteropConfig struct {
+	config.InteropClient `name:",squash"`
+	ID                   *types.EUI64 `name:"id" description:"NSID of this Network Server (EUI)"`
+}
+
 // Config represents the NetworkServer configuration.
 type Config struct {
 	ApplicationUplinkQueue   ApplicationUplinkQueueConfig `name:"application-uplink-queue"`
@@ -136,7 +142,7 @@ type Config struct {
 	CooldownWindow           time.Duration                `name:"cooldown-window" description:"Time window starting right after deduplication window, during which, duplicate messages are discarded"`
 	DownlinkPriorities       DownlinkPriorityConfig       `name:"downlink-priorities" description:"Downlink message priorities"`
 	DefaultMACSettings       MACSettingConfig             `name:"default-mac-settings" description:"Default MAC settings to fallback to if not specified by device, band or frequency plan"`
-	Interop                  config.InteropClient         `name:"interop" description:"Interop client configuration"`
+	Interop                  InteropConfig                `name:"interop" description:"Interop client configuration"`
 	DeviceKEKLabel           string                       `name:"device-kek-label" description:"Label of KEK used to encrypt device keys at rest"`
 	DownlinkQueueCapacity    int                          `name:"downlink-queue-capacity" description:"Maximum downlink queue size per-session"`
 }

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1146,7 +1146,7 @@ func (ns *NetworkServer) sendJoinRequest(ctx context.Context, ids *ttnpb.EndDevi
 	}
 	if ns.interopClient != nil {
 		queuedEvents = append(queuedEvents, evtInteropJoinAttempt.NewWithIdentifiersAndData(ctx, ids, req))
-		resp, err := ns.interopClient.HandleJoinRequest(ctx, ns.netID, req)
+		resp, err := ns.interopClient.HandleJoinRequest(ctx, ns.netID, ns.interopNSID, req)
 		if err == nil {
 			logger.Debug("Join-request accepted by interop Join Server")
 			queuedEvents = append(queuedEvents, evtInteropJoinSuccess.NewWithIdentifiersAndData(ctx, ids, joinResponseWithoutKeys(resp)))

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -298,15 +298,15 @@ var _ InteropClient = MockInteropClient{}
 
 // MockInteropClient is a mock InteropClient used for testing.
 type MockInteropClient struct {
-	HandleJoinRequestFunc func(context.Context, types.NetID, *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error)
+	HandleJoinRequestFunc func(context.Context, types.NetID, *types.EUI64, *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error)
 }
 
 // HandleJoinRequest calls HandleJoinRequestFunc if set and panics otherwise.
-func (m MockInteropClient) HandleJoinRequest(ctx context.Context, netID types.NetID, req *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error) {
+func (m MockInteropClient) HandleJoinRequest(ctx context.Context, netID types.NetID, nsID *types.EUI64, req *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error) {
 	if m.HandleJoinRequestFunc == nil {
 		panic("HandleJoinRequest called, but not set")
 	}
-	return m.HandleJoinRequestFunc(ctx, netID, req)
+	return m.HandleJoinRequestFunc(ctx, netID, nsID, req)
 }
 
 type InteropClientHandleJoinRequestResponse struct {
@@ -321,8 +321,8 @@ type InteropClientHandleJoinRequestRequest struct {
 	Response chan<- InteropClientHandleJoinRequestResponse
 }
 
-func MakeInteropClientHandleJoinRequestChFunc(reqCh chan<- InteropClientHandleJoinRequestRequest) func(context.Context, types.NetID, *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error) {
-	return func(ctx context.Context, netID types.NetID, msg *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error) {
+func MakeInteropClientHandleJoinRequestChFunc(reqCh chan<- InteropClientHandleJoinRequestRequest) func(context.Context, types.NetID, *types.EUI64, *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error) {
+	return func(ctx context.Context, netID types.NetID, nsID *types.EUI64, msg *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error) {
 		respCh := make(chan InteropClientHandleJoinRequestResponse)
 		reqCh <- InteropClientHandleJoinRequestRequest{
 			Context:  ctx,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This configures the NSID consistently across components.

#### Changes
<!-- What are the changes made in this pull request? -->

This changes the configuration as follows:

Setting | Current | New
--- | --- | ---
NetID | `ns.net-id` | `ns.net-id` (unchanged)
NSID | `dcs.edcs.network-server.home-ns-id` | `ns.interop.id` and `dcs.edcs.ns-id`
AS-ID | `as.interop.id` and `dcs.edcs.as-id` | `as.interop.id` and `dcs.edcs.as-id` (unchanged)

Fallbacks are in place.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing and local integration testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Should be no regressions, this is cleaner going forward.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

`sender-ns-id` in the JS interop configuration takes precedence over `ns.interop.id`. Typically, `sender-ns-id` no longer needs to be configured.

Documentation and deployment templates are coming.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
