### PR TITLE
Support key vault cache TTL for errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Key vault cache time-to-live for errors configuration option `key-vault.cache.error-ttl`. This defaults to `key-vault.cache.ttl`.
+
 ### Changed
 
 ### Deprecated

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -160,8 +160,9 @@ type Rights struct {
 
 // KeyVaultCache represents the configuration for key vault caching.
 type KeyVaultCache struct {
-	Size int           `name:"size" description:"Cache size. Caching is disabled if size is 0"`
-	TTL  time.Duration `name:"ttl" description:"Cache elements time to live. No expiration mechanism is used if TTL is 0"`
+	Size     int           `name:"size" description:"Cache size. Caching is disabled if size is 0"`
+	TTL      time.Duration `name:"ttl" description:"Cache elements time to live. No expiration mechanism is used if TTL is 0"` //nolint:lll
+	ErrorTTL time.Duration `name:"error-ttl" description:"Cache elements time to live for errors. If 0, the TTL is used"`
 }
 
 // KeyVault represents configuration for key vaults.
@@ -192,8 +193,12 @@ func (v KeyVault) KeyService(ctx context.Context, httpClientProvider httpclient.
 		kv = cryptoutil.EmptyKeyVault
 	}
 	if v.Cache.Size > 0 {
+		errTTL := v.Cache.ErrorTTL
+		if errTTL == 0 {
+			errTTL = v.Cache.TTL
+		}
 		kv = cryptoutil.NewCacheKeyVault(kv,
-			cryptoutil.WithCacheKeyVaultTTL(v.Cache.TTL),
+			cryptoutil.WithCacheKeyVaultTTL(v.Cache.TTL, errTTL),
 			cryptoutil.WithCacheKeyVaultSize(v.Cache.Size),
 		)
 	}

--- a/pkg/crypto/cryptoutil/keyvault_cache_test.go
+++ b/pkg/crypto/cryptoutil/keyvault_cache_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -74,38 +75,47 @@ func TestCacheKeyVault(t *testing.T) {
 
 	var (
 		keys, serverCerts []string
-		now               = &mockClock{time.Now()}
+		ref               = time.Now()
+		now               = &mockClock{ref}
+		err               error
 	)
-	kv := cryptoutil.NewCacheKeyVault(&mockKeyVault{
-		KeyFunc: func(ctx context.Context, label string) ([]byte, error) {
-			keys = append(keys, label)
-			return []byte(label), nil
+	kv := cryptoutil.NewCacheKeyVault(
+		&mockKeyVault{
+			KeyFunc: func(ctx context.Context, label string) ([]byte, error) {
+				keys = append(keys, label)
+				if label == "error" {
+					return nil, errors.New("error")
+				}
+				return []byte(label), nil
+			},
+			ServerCertificateFunc: func(ctx context.Context, label string) (tls.Certificate, error) {
+				serverCerts = append(serverCerts, label)
+				tmpl := &x509.Certificate{
+					IsCA: true,
+					Subject: pkix.Name{
+						CommonName: label,
+					},
+					DNSNames: []string{label},
+					NotAfter: time.Now().Add(3 * time.Hour),
+					ExtKeyUsage: []x509.ExtKeyUsage{
+						x509.ExtKeyUsageServerAuth,
+					},
+					SerialNumber: big.NewInt(1),
+				}
+				key, err := rsa.GenerateKey(rand.Reader, 2048)
+				if err != nil {
+					return tls.Certificate{}, err
+				}
+				cert, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+				if err != nil {
+					return tls.Certificate{}, err
+				}
+				return tls.Certificate{Certificate: [][]byte{cert}}, nil
+			},
 		},
-		ServerCertificateFunc: func(ctx context.Context, label string) (tls.Certificate, error) {
-			serverCerts = append(serverCerts, label)
-			tmpl := &x509.Certificate{
-				IsCA: true,
-				Subject: pkix.Name{
-					CommonName: label,
-				},
-				DNSNames: []string{label},
-				NotAfter: time.Now().Add(3 * time.Hour),
-				ExtKeyUsage: []x509.ExtKeyUsage{
-					x509.ExtKeyUsageServerAuth,
-				},
-				SerialNumber: big.NewInt(1),
-			}
-			key, err := rsa.GenerateKey(rand.Reader, 2048)
-			if err != nil {
-				return tls.Certificate{}, err
-			}
-			cert, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-			if err != nil {
-				return tls.Certificate{}, err
-			}
-			return tls.Certificate{Certificate: [][]byte{cert}}, nil
-		},
-	}, cryptoutil.WithCacheKeyVaultClock(now))
+		cryptoutil.WithCacheKeyVaultClock(now),
+		cryptoutil.WithCacheKeyVaultTTL(4*time.Hour, 5*time.Minute),
+	)
 
 	test.Must(kv.Key(ctx, "key1"))
 	test.Must(kv.Key(ctx, "key1"))
@@ -119,14 +129,27 @@ func TestCacheKeyVault(t *testing.T) {
 	test.Must(kv.ServerCertificate(ctx, "server1.example.com"))
 	a.So(serverCerts, should.Resemble, []string{"server1.example.com", "server2.example.com"})
 
-	// 1 hour later, the certficates are still valid.
-	now.Time = time.Now().Add(1 * time.Hour)
+	// Errors are also cached.
+	_, err = kv.Key(ctx, "error")
+	a.So(err, should.NotBeNil)
+	_, err = kv.Key(ctx, "error")
+	a.So(err, should.NotBeNil)
+	a.So(keys, should.Resemble, []string{"key1", "key2", "error"})
+
+	// 10 minutes after reference time, the error is no longer cached.
+	now.Time = ref.Add(10 * time.Minute)
+	_, err = kv.Key(ctx, "error")
+	a.So(err, should.NotBeNil)
+	a.So(keys, should.Resemble, []string{"key1", "key2", "error", "error"})
+
+	// 1 hour after reference time, the certficates are still valid.
+	now.Time = ref.Add(1 * time.Hour)
 	test.Must(kv.ServerCertificate(ctx, "server1.example.com"))
 	test.Must(kv.ServerCertificate(ctx, "server2.example.com"))
 	a.So(serverCerts, should.Resemble, []string{"server1.example.com", "server2.example.com"})
 
-	// 3 hours later, the certificates are expired.
-	now.Time = time.Now().Add(3 * time.Hour)
+	// 3 hours after reference time, the certificates are expired.
+	now.Time = ref.Add(3 * time.Hour)
 	test.Must(kv.ServerCertificate(ctx, "server1.example.com"))
 	test.Must(kv.ServerCertificate(ctx, "server2.example.com"))
 	a.So(serverCerts, should.Resemble, []string{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds support for a different cache TTL for items that failed to load from the key vault.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `key-vault.cache.error-ttl` config option, defaults to `key-vault.cache.ttl`
- If the secret fails to load, the error TTL is used for caching the error

#### Testing

<!-- How did you verify that this change works? -->

Unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
