### PR TITLE
Deprecate cross-application device claiming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Deprecated
 
+- Device claiming that transfer devices between applications is now deprecated and will be removed in a future version of The Things Stack. Device claiming on Join Servers, including The Things Join Server, remains functional. This deprecates the following components:
+  - API for managing application claim authorization (`EndDeviceClaimingServer.AuthorizeApplication` and `EndDeviceClaimingServer.UnauthorizeApplication`)
+  - CLI commands to manage application claim settings (`ttn-lw-cli application claim [authorize|unauthorize]`)
+
 ### Removed
 
 ### Fixed

--- a/api/api.md
+++ b/api/api.md
@@ -2597,6 +2597,9 @@ ApplicationRegistry, ClientRegistry, GatewayRegistry, OrganizationRegistry and U
 
 ### <a name="ttn.lorawan.v3.AuthorizeApplicationRequest">Message `AuthorizeApplicationRequest`</a>
 
+DEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed
+in a future version of The Things Stack.
+
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | `application_ids` | [`ApplicationIdentifiers`](#ttn.lorawan.v3.ApplicationIdentifiers) |  |  |
@@ -2797,8 +2800,8 @@ and allows clients to claim end devices.
 | `Unclaim` | [`EndDeviceIdentifiers`](#ttn.lorawan.v3.EndDeviceIdentifiers) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Unclaims the end device on a Join Server. |
 | `GetInfoByJoinEUI` | [`GetInfoByJoinEUIRequest`](#ttn.lorawan.v3.GetInfoByJoinEUIRequest) | [`GetInfoByJoinEUIResponse`](#ttn.lorawan.v3.GetInfoByJoinEUIResponse) | Return whether claiming is available for a given JoinEUI. |
 | `GetClaimStatus` | [`EndDeviceIdentifiers`](#ttn.lorawan.v3.EndDeviceIdentifiers) | [`GetClaimStatusResponse`](#ttn.lorawan.v3.GetClaimStatusResponse) | Gets the claim status of an end device. |
-| `AuthorizeApplication` | [`AuthorizeApplicationRequest`](#ttn.lorawan.v3.AuthorizeApplicationRequest) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Authorize the End Device Claiming Server to claim devices registered in the given application. The application identifiers are the source application, where the devices are registered before they are claimed. The API key is used to access the application, find the device, verify the claim request and delete the end device from the source application. |
-| `UnauthorizeApplication` | [`ApplicationIdentifiers`](#ttn.lorawan.v3.ApplicationIdentifiers) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Unauthorize the End Device Claiming Server to claim devices in the given application. This reverts the authorization given with rpc AuthorizeApplication. |
+| `AuthorizeApplication` | [`AuthorizeApplicationRequest`](#ttn.lorawan.v3.AuthorizeApplicationRequest) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Authorize the End Device Claiming Server to claim devices registered in the given application. The application identifiers are the source application, where the devices are registered before they are claimed. The API key is used to access the application, find the device, verify the claim request and delete the end device from the source application. DEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed in a future version of The Things Stack. |
+| `UnauthorizeApplication` | [`ApplicationIdentifiers`](#ttn.lorawan.v3.ApplicationIdentifiers) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Unauthorize the End Device Claiming Server to claim devices in the given application. This reverts the authorization given with rpc AuthorizeApplication. DEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed in a future version of The Things Stack. |
 
 #### HTTP bindings
 

--- a/api/api.swagger.json
+++ b/api/api.swagger.json
@@ -7714,7 +7714,7 @@
     },
     "/edcs/applications/{application_ids.application_id}/authorize": {
       "post": {
-        "summary": "Authorize the End Device Claiming Server to claim devices registered in the given application. The application\nidentifiers are the source application, where the devices are registered before they are claimed.\nThe API key is used to access the application, find the device, verify the claim request and delete the end device\nfrom the source application.",
+        "summary": "Authorize the End Device Claiming Server to claim devices registered in the given application. The application\nidentifiers are the source application, where the devices are registered before they are claimed.\nThe API key is used to access the application, find the device, verify the claim request and delete the end device\nfrom the source application.\nDEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed\nin a future version of The Things Stack.",
         "operationId": "EndDeviceClaimingServer_AuthorizeApplication",
         "responses": {
           "200": {
@@ -7751,7 +7751,8 @@
                 "api_key": {
                   "type": "string"
                 }
-              }
+              },
+              "description": "DEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed\nin a future version of The Things Stack."
             }
           }
         ],
@@ -7762,7 +7763,7 @@
     },
     "/edcs/applications/{application_id}/authorize": {
       "delete": {
-        "summary": "Unauthorize the End Device Claiming Server to claim devices in the given application.\nThis reverts the authorization given with rpc AuthorizeApplication.",
+        "summary": "Unauthorize the End Device Claiming Server to claim devices in the given application.\nThis reverts the authorization given with rpc AuthorizeApplication.\nDEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed\nin a future version of The Things Stack.",
         "operationId": "EndDeviceClaimingServer_UnauthorizeApplication",
         "responses": {
           "200": {

--- a/api/deviceclaimingserver.proto
+++ b/api/deviceclaimingserver.proto
@@ -102,7 +102,9 @@ message ClaimEndDeviceRequest {
   bool invalidate_authentication_code = 5;
 }
 
-message AuthorizeApplicationRequest {
+  // DEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed
+  // in a future version of The Things Stack.
+  message AuthorizeApplicationRequest {
   ApplicationIdentifiers application_ids = 1 [(validate.rules).message.required = true];
   string api_key = 2 [
     (validate.rules).string = { min_len: 1, max_len: 128 }
@@ -207,6 +209,8 @@ service EndDeviceClaimingServer {
   // identifiers are the source application, where the devices are registered before they are claimed.
   // The API key is used to access the application, find the device, verify the claim request and delete the end device
   // from the source application.
+  // DEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed
+  // in a future version of The Things Stack.
   rpc AuthorizeApplication(AuthorizeApplicationRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       post: "/edcs/applications/{application_ids.application_id}/authorize",
@@ -216,6 +220,8 @@ service EndDeviceClaimingServer {
 
   // Unauthorize the End Device Claiming Server to claim devices in the given application.
   // This reverts the authorization given with rpc AuthorizeApplication.
+  // DEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed
+  // in a future version of The Things Stack.
   rpc UnauthorizeApplication(ApplicationIdentifiers) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       delete: "/edcs/applications/{application_id}/authorize"

--- a/cmd/ttn-lw-cli/commands/applications_claim.go
+++ b/cmd/ttn-lw-cli/commands/applications_claim.go
@@ -22,12 +22,14 @@ import (
 
 var (
 	applicationClaim = &cobra.Command{
-		Use:   "claim",
-		Short: "Manage claim settings in applications",
+		Use:        "claim",
+		Deprecated: "Device claiming is deprecated and will be removed.",
+		Short:      "Manage claim settings in applications",
 	}
 	applicationClaimAuthorize = &cobra.Command{
-		Use:   "authorize [application-id]",
-		Short: "Authorize an application for claiming (EXPERIMENTAL)",
+		Use:        "authorize [application-id]",
+		Deprecated: "Device claiming is deprecated and will be removed.",
+		Short:      "Authorize an application for claiming (EXPERIMENTAL)",
 		Long: `Authorize an application for claiming (EXPERIMENTAL)
 
 The given API key must have devices and device keys read/write rights. If no API
@@ -79,8 +81,9 @@ key is provided, a new API key will be created.`,
 		},
 	}
 	applicationClaimUnauthorize = &cobra.Command{
-		Use:   "unauthorize [application-id]",
-		Short: "Unauthorize an application for claiming (EXPERIMENTAL)",
+		Use:        "unauthorize [application-id]",
+		Short:      "Unauthorize an application for claiming (EXPERIMENTAL)",
+		Deprecated: "Device claiming is deprecated and will be removed.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appID := getApplicationID(cmd.Flags(), args)
 			if appID == nil {
@@ -102,7 +105,7 @@ key is provided, a new API key will be created.`,
 
 func init() {
 	applicationClaimAuthorize.Flags().String("api-key", "", "")
-	applicationClaimAuthorize.Flags().String("api-key-expiry", "", "API key expiry date (YYYY-MM-DD:HH:mm) - only applicable when creating API Key")
+	applicationClaimAuthorize.Flags().String("api-key-expiry", "", "API key expiry date (YYYY-MM-DD:HH:mm) - only applicable when creating API Key") //nolint:lll
 	applicationClaim.AddCommand(applicationClaimAuthorize)
 	applicationClaim.AddCommand(applicationClaimUnauthorize)
 	applicationClaim.PersistentFlags().AddFlagSet(applicationIDFlags())

--- a/pkg/ttnpb/deviceclaimingserver.pb.go
+++ b/pkg/ttnpb/deviceclaimingserver.pb.go
@@ -256,6 +256,8 @@ func (m *ClaimEndDeviceRequest_AuthenticatedIdentifiers) GetAuthenticationCode()
 	return ""
 }
 
+// DEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed
+// in a future version of The Things Stack.
 type AuthorizeApplicationRequest struct {
 	ApplicationIds       *ApplicationIdentifiers `protobuf:"bytes,1,opt,name=application_ids,json=applicationIds,proto3" json:"application_ids,omitempty"`
 	ApiKey               string                  `protobuf:"bytes,2,opt,name=api_key,json=apiKey,proto3" json:"api_key,omitempty"`
@@ -1057,9 +1059,13 @@ type EndDeviceClaimingServerClient interface {
 	// identifiers are the source application, where the devices are registered before they are claimed.
 	// The API key is used to access the application, find the device, verify the claim request and delete the end device
 	// from the source application.
+	// DEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed
+	// in a future version of The Things Stack.
 	AuthorizeApplication(ctx context.Context, in *AuthorizeApplicationRequest, opts ...grpc.CallOption) (*types.Empty, error)
 	// Unauthorize the End Device Claiming Server to claim devices in the given application.
 	// This reverts the authorization given with rpc AuthorizeApplication.
+	// DEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed
+	// in a future version of The Things Stack.
 	UnauthorizeApplication(ctx context.Context, in *ApplicationIdentifiers, opts ...grpc.CallOption) (*types.Empty, error)
 }
 
@@ -1139,9 +1145,13 @@ type EndDeviceClaimingServerServer interface {
 	// identifiers are the source application, where the devices are registered before they are claimed.
 	// The API key is used to access the application, find the device, verify the claim request and delete the end device
 	// from the source application.
+	// DEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed
+	// in a future version of The Things Stack.
 	AuthorizeApplication(context.Context, *AuthorizeApplicationRequest) (*types.Empty, error)
 	// Unauthorize the End Device Claiming Server to claim devices in the given application.
 	// This reverts the authorization given with rpc AuthorizeApplication.
+	// DEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed
+	// in a future version of The Things Stack.
 	UnauthorizeApplication(context.Context, *ApplicationIdentifiers) (*types.Empty, error)
 }
 

--- a/sdk/js/generated/api.json
+++ b/sdk/js/generated/api.json
@@ -9900,7 +9900,7 @@
           "name": "AuthorizeApplicationRequest",
           "longName": "AuthorizeApplicationRequest",
           "fullName": "ttn.lorawan.v3.AuthorizeApplicationRequest",
-          "description": "",
+          "description": "DEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed\nin a future version of The Things Stack.",
           "hasExtensions": false,
           "hasFields": true,
           "hasOneofs": false,
@@ -10949,7 +10949,7 @@
             },
             {
               "name": "AuthorizeApplication",
-              "description": "Authorize the End Device Claiming Server to claim devices registered in the given application. The application\nidentifiers are the source application, where the devices are registered before they are claimed.\nThe API key is used to access the application, find the device, verify the claim request and delete the end device\nfrom the source application.",
+              "description": "Authorize the End Device Claiming Server to claim devices registered in the given application. The application\nidentifiers are the source application, where the devices are registered before they are claimed.\nThe API key is used to access the application, find the device, verify the claim request and delete the end device\nfrom the source application.\nDEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed\nin a future version of The Things Stack.",
               "requestType": "AuthorizeApplicationRequest",
               "requestLongType": "AuthorizeApplicationRequest",
               "requestFullType": "ttn.lorawan.v3.AuthorizeApplicationRequest",
@@ -10972,7 +10972,7 @@
             },
             {
               "name": "UnauthorizeApplication",
-              "description": "Unauthorize the End Device Claiming Server to claim devices in the given application.\nThis reverts the authorization given with rpc AuthorizeApplication.",
+              "description": "Unauthorize the End Device Claiming Server to claim devices in the given application.\nThis reverts the authorization given with rpc AuthorizeApplication.\nDEPRECATED: Device claiming that transfers devices between applications is no longer supported and will be removed\nin a future version of The Things Stack.",
               "requestType": "ApplicationIdentifiers",
               "requestLongType": "ApplicationIdentifiers",
               "requestFullType": "ttn.lorawan.v3.ApplicationIdentifiers",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Deprecation notice for device claiming that transfers devices across applications.

References https://github.com/TheThingsIndustries/lorawan-stack/issues/3036
References https://github.com/TheThingsIndustries/lorawan-stack/issues/2966

#### Changes
<!-- What are the changes made in this pull request? -->

No functional changes; just a notice.

Documentation sections will be removed or adapted in a separate PR.

#### Testing

<!-- How did you verify that this change works? -->

N/A

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
