### PR TITLE
Add API note for unclaiming devices on delete

### DIFF
--- a/api/api.md
+++ b/api/api.md
@@ -4104,7 +4104,7 @@ After registering an end device, it also needs to be registered in the NsEndDevi
 | `BatchUpdateLastSeen` | [`BatchUpdateEndDeviceLastSeenRequest`](#ttn.lorawan.v3.BatchUpdateEndDeviceLastSeenRequest) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Update the last seen timestamp for a batch of end devices. |
 | `Delete` | [`EndDeviceIdentifiers`](#ttn.lorawan.v3.EndDeviceIdentifiers) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Delete the end device with the given IDs.
 
-Before deleting an end device it first needs to be deleted from the NsEndDeviceRegistry, the AsEndDeviceRegistry and the JsEndDeviceRegistry. This is NOT done automatically. |
+Before deleting an end device it first needs to be deleted from the NsEndDeviceRegistry, the AsEndDeviceRegistry and the JsEndDeviceRegistry. In addition, if the device claimed on a Join Server, it also needs to be unclaimed via the DeviceClaimingServer so it can be claimed in the future. This is NOT done automatically. |
 
 #### HTTP bindings
 

--- a/api/api.swagger.json
+++ b/api/api.swagger.json
@@ -986,7 +986,7 @@
     "/applications/{application_ids.application_id}/devices/{device_id}": {
       "delete": {
         "summary": "Delete the end device with the given IDs.",
-        "description": "Before deleting an end device it first needs to be deleted from the\nNsEndDeviceRegistry, the AsEndDeviceRegistry and the JsEndDeviceRegistry.\nThis is NOT done automatically.",
+        "description": "Before deleting an end device it first needs to be deleted from the\nNsEndDeviceRegistry, the AsEndDeviceRegistry and the JsEndDeviceRegistry.\nIn addition, if the device claimed on a Join Server, it also needs to be\nunclaimed via the DeviceClaimingServer so it can be claimed in the future.\nThis is NOT done automatically.",
         "operationId": "EndDeviceRegistry_Delete",
         "responses": {
           "200": {

--- a/api/end_device_services.proto
+++ b/api/end_device_services.proto
@@ -87,6 +87,8 @@ service EndDeviceRegistry {
   //
   // Before deleting an end device it first needs to be deleted from the
   // NsEndDeviceRegistry, the AsEndDeviceRegistry and the JsEndDeviceRegistry.
+  // In addition, if the device claimed on a Join Server, it also needs to be
+  // unclaimed via the DeviceClaimingServer so it can be claimed in the future.
   // This is NOT done automatically.
   rpc Delete(EndDeviceIdentifiers) returns (google.protobuf.Empty) {
     option (google.api.http) = {

--- a/pkg/ttnpb/end_device_services.pb.go
+++ b/pkg/ttnpb/end_device_services.pb.go
@@ -114,6 +114,8 @@ type EndDeviceRegistryClient interface {
 	//
 	// Before deleting an end device it first needs to be deleted from the
 	// NsEndDeviceRegistry, the AsEndDeviceRegistry and the JsEndDeviceRegistry.
+	// In addition, if the device claimed on a Join Server, it also needs to be
+	// unclaimed via the DeviceClaimingServer so it can be claimed in the future.
 	// This is NOT done automatically.
 	Delete(ctx context.Context, in *EndDeviceIdentifiers, opts ...grpc.CallOption) (*types.Empty, error)
 }
@@ -216,6 +218,8 @@ type EndDeviceRegistryServer interface {
 	//
 	// Before deleting an end device it first needs to be deleted from the
 	// NsEndDeviceRegistry, the AsEndDeviceRegistry and the JsEndDeviceRegistry.
+	// In addition, if the device claimed on a Join Server, it also needs to be
+	// unclaimed via the DeviceClaimingServer so it can be claimed in the future.
 	// This is NOT done automatically.
 	Delete(context.Context, *EndDeviceIdentifiers) (*types.Empty, error)
 }

--- a/sdk/js/generated/api.json
+++ b/sdk/js/generated/api.json
@@ -18235,7 +18235,7 @@
             },
             {
               "name": "Delete",
-              "description": "Delete the end device with the given IDs.\n\nBefore deleting an end device it first needs to be deleted from the\nNsEndDeviceRegistry, the AsEndDeviceRegistry and the JsEndDeviceRegistry.\nThis is NOT done automatically.",
+              "description": "Delete the end device with the given IDs.\n\nBefore deleting an end device it first needs to be deleted from the\nNsEndDeviceRegistry, the AsEndDeviceRegistry and the JsEndDeviceRegistry.\nIn addition, if the device claimed on a Join Server, it also needs to be\nunclaimed via the DeviceClaimingServer so it can be claimed in the future.\nThis is NOT done automatically.",
               "requestType": "EndDeviceIdentifiers",
               "requestLongType": "EndDeviceIdentifiers",
               "requestFullType": "ttn.lorawan.v3.EndDeviceIdentifiers",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds a note in the API to unclaim devices on delete.

#### Changes
<!-- What are the changes made in this pull request? -->

Comment in `EndDeviceRegistry.Delete`, which should get propagated to API users via code generation.

#### Testing

<!-- How did you verify that this change works? -->

N/A

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

No functional changes, also no behavioral changes, just a note for developers.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
