### PR TITLE
Continue deleting devices on unclaim error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- The CLI now continues deleting devices when unclaiming from the Join Server fails. This resembles the behavior in the Console. This no longer stops devices from being deleted if the Join Server is unavailable or the claim is not held.
+
 ### Security
 
 ## [3.24.1] - 2023-02-16

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -1098,9 +1098,10 @@ var (
 				if claimInfoResp.SupportsClaiming {
 					_, err = ttnpb.NewEndDeviceClaimingServerClient(dcs).Unclaim(ctx, devID)
 					if err != nil {
-						return errEndDeviceUnclaim.WithCause(err)
+						logger.WithError(err).Warn("Failed to unclaim end device")
+					} else {
+						logger.Info("Device successfully unclaimed")
 					}
-					logger.Info("Device successfully unclaimed")
 					skipClusterJS = true
 				}
 			} else if jsMismatch {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Continue deleting devices on unclaim error

#### Changes
<!-- What are the changes made in this pull request? -->

CLI now resembles correct Console behavior: when the unclaim fails (JS unavailable, claim not held, etc), CLI continues deleting the device.

#### Testing

<!-- How did you verify that this change works? -->

Local testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
