### PR TITLE
Fix usage of direct memberships based on an organization rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - The CLI now continues deleting devices when unclaiming from the Join Server fails. This resembles the behavior in the Console. This no longer stops devices from being deleted if the Join Server is unavailable or the claim is not held.
+- Organization API Keys' rights no longer are considered invalid during fetch operations. If the proper right is attached to said API key it is possible to fetch all fields of an entity, previous to this fix only public safe fields were fetchable.
 
 ### Security
 

--- a/pkg/identityserver/bunstore/membership_store.go
+++ b/pkg/identityserver/bunstore/membership_store.go
@@ -265,17 +265,25 @@ func (s *membershipStore) FindAccountMembershipChains(
 	membershipChains := make([]*store.MembershipChain, 0, len(directMemberships)+len(indirectMemberships))
 
 	for _, directMembership := range directMemberships {
-		membershipChains = append(membershipChains, &store.MembershipChain{
-			UserIdentifiers: &ttnpb.UserIdentifiers{
-				UserId: directMembership.AccountFriendlyID,
-			},
+		mc := &store.MembershipChain{
 			RightsOnEntity: &ttnpb.Rights{
 				Rights: convertIntSlice[int, ttnpb.Right](directMembership.Rights),
 			},
 			EntityIdentifiers: getEntityIdentifiers(
 				directMembership.EntityType, directMembership.EntityFriendlyID,
 			),
-		})
+		}
+		switch directMembership.AccountType {
+		case "organization":
+			mc.OrganizationIdentifiers = &ttnpb.OrganizationIdentifiers{
+				OrganizationId: directMembership.AccountFriendlyID,
+			}
+		default:
+			mc.UserIdentifiers = &ttnpb.UserIdentifiers{
+				UserId: directMembership.AccountFriendlyID,
+			}
+		}
+		membershipChains = append(membershipChains, mc)
 	}
 
 	for _, indirectMembership := range indirectMemberships {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/927
Which in short, refers to a bug where organization API keys didn't have their rights validated properly when fetching entities. Always showing only the safe for public fields in an entity, in this case the gateways information.

#### Changes
<!-- What are the changes made in this pull request? -->

- Update `FindAccountMembershipChains` method to validate direct membership type to set the appropriate Identifier. 

#### Testing

<!-- How did you verify that this change works? -->

existing UT and manual testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This is a bug fix.

It does change behaviors, allowing API Keys with the proper rights to access non public safe information. As this is allowed by design and restricted by the rights implementation, plus is the previous behavior before removing the gormstore.

So it affects the interaction of users using API Keys of organizations and what they can do with other entities, restoring what they could do `v3.21` backwards.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

From looking into how it was previously implemented on the gormstore ( see bellow ) and that `direct` and `indirect` chains have been separated into their own `membershipChain`. The only thing conditional missing to attain the previous behavior that existed with `gormstore` is the addition of the `accountType` validation.

```go
func (m membershipChain) GetMembershipChain() *store.MembershipChain {
	indirectAccountRights := &ttnpb.Rights{Rights: m.IndirectAccountRights}
	directAccountRights := &ttnpb.Rights{Rights: m.DirectAccountRights}
	c := &store.MembershipChain{
		RightsOnEntity:    directAccountRights,
		EntityIdentifiers: buildIdentifiers(m.EntityType, m.EntityFriendlyID),
	}
	switch m.DirectAccountType {
	case user:
		c.UserIdentifiers = &ttnpb.UserIdentifiers{
			UserId: m.DirectAccountFriendlyID,
		}
	case organization:
		if m.IndirectAccountType == user {
			c.UserIdentifiers = &ttnpb.UserIdentifiers{
				UserId: m.IndirectAccountFriendlyID,
			}
			c.RightsOnOrganization = indirectAccountRights
		}
		c.OrganizationIdentifiers = &ttnpb.OrganizationIdentifiers{
			OrganizationId: m.DirectAccountFriendlyID,
		}
	}
	return c
}
```

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
