### PR TITLE
dcs: Remove two deprecated fields (home-ns-id and hostname) and fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Removed
 
+- Deprecated home-ns-id and hostname fields and respective fallback from The Device Claiming Server component 
+
 ### Fixed
 
 - The CLI now continues deleting devices when unclaiming from the Join Server fails. This resembles the behavior in the Console. This no longer stops devices from being deleted if the Join Server is unavailable or the claim is not held.

--- a/pkg/deviceclaimingserver/enddevices/config.go
+++ b/pkg/deviceclaimingserver/enddevices/config.go
@@ -26,13 +26,6 @@ import (
 // JSClientConfigurationName is the filename of Join Server client configuration.
 const JSClientConfigurationName = "config.yml"
 
-// NetworkServer contains information related to the Network Server.
-// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6048)
-type NetworkServer struct {
-	HomeNSID *types.EUI64 `name:"home-ns-id" description:"DEPRECATED"`
-	Hostname string       `name:"hostname" description:"DEPRECATED"`
-}
-
 // Config contains options for end device claiming clients.
 //
 //nolint:lll
@@ -40,9 +33,6 @@ type Config struct {
 	NetID types.NetID  `name:"net-id" description:"NetID of the Network Server to configure when claiming"`
 	NSID  *types.EUI64 `name:"ns-id" description:"NSID of the Network Server to configure when claiming"`
 	ASID  string       `name:"as-id" description:"AS-ID of the Application Server to configure when claiming"`
-
-	// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6048)
-	NetworkServer NetworkServer `name:"network-server" description:"DEPRECATED"`
 
 	Source    string                `name:"source" description:"Source of the file containing Join Server settings (directory, url, blob)"`
 	Directory string                `name:"directory" description:"OS filesystem directory, which contains the config.yml and the client-specific files"`

--- a/pkg/deviceclaimingserver/enddevices/enddevices.go
+++ b/pkg/deviceclaimingserver/enddevices/enddevices.go
@@ -92,12 +92,6 @@ func NewUpstream(ctx context.Context, c Component, conf Config, opts ...Option) 
 		return nil, err
 	}
 
-	nsID := conf.NSID
-	// TODO: Remove fallback logic (https://github.com/TheThingsNetwork/lorawan-stack/issues/6048)
-	if nsID == nil {
-		nsID = conf.NetworkServer.HomeNSID
-	}
-
 	// Setup upstreams.
 	for _, js := range baseConfig.JoinServers {
 		// Fetch and parse configuration.
@@ -118,7 +112,7 @@ func NewUpstream(ctx context.Context, c Component, conf Config, opts ...Option) 
 			}
 			claimer = ttjsv2.NewClient(c, fetcher, ttjsv2.Config{
 				NetID:           conf.NetID,
-				NSID:            nsID,
+				NSID:            conf.NSID,
 				ASID:            conf.ASID,
 				JoinEUIPrefixes: js.JoinEUIs,
 				ConfigFile:      ttjsConf,


### PR DESCRIPTION
#### Summary
Closes the issue: #6048

...

#### Changes
Removed home-ns-id and hostname from config.go and fallback from enddevices

#### Testing

Unit tests



...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
