### PR TITLE
Fix US915 downlink payload size limitations

### DIFF
--- a/pkg/band/testdata/US_902_928_PHY_V1_0.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0.json
@@ -564,8 +564,8 @@
     },
     "8": {
       "MaxMACPayloadSize": {
-        "false": 41,
-        "true": 41
+        "false": 61,
+        "true": 61
       },
       "Rate": {
         "lora": {
@@ -577,8 +577,8 @@
     },
     "9": {
       "MaxMACPayloadSize": {
-        "false": 117,
-        "true": 117
+        "false": 137,
+        "true": 137
       },
       "Rate": {
         "lora": {

--- a/pkg/band/testdata/US_902_928_PHY_V1_0_1.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0_1.json
@@ -564,8 +564,8 @@
     },
     "8": {
       "MaxMACPayloadSize": {
-        "false": 41,
-        "true": 41
+        "false": 61,
+        "true": 61
       },
       "Rate": {
         "lora": {
@@ -577,8 +577,8 @@
     },
     "9": {
       "MaxMACPayloadSize": {
-        "false": 117,
-        "true": 117
+        "false": 137,
+        "true": 137
       },
       "Rate": {
         "lora": {

--- a/pkg/band/testdata/US_902_928_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0_2_REV_A.json
@@ -564,8 +564,8 @@
     },
     "8": {
       "MaxMACPayloadSize": {
-        "false": 41,
-        "true": 41
+        "false": 61,
+        "true": 61
       },
       "Rate": {
         "lora": {
@@ -577,8 +577,8 @@
     },
     "9": {
       "MaxMACPayloadSize": {
-        "false": 117,
-        "true": 117
+        "false": 137,
+        "true": 137
       },
       "Rate": {
         "lora": {

--- a/pkg/band/testdata/US_902_928_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0_2_REV_B.json
@@ -564,8 +564,8 @@
     },
     "8": {
       "MaxMACPayloadSize": {
-        "false": 41,
-        "true": 41
+        "false": 61,
+        "true": 61
       },
       "Rate": {
         "lora": {
@@ -577,8 +577,8 @@
     },
     "9": {
       "MaxMACPayloadSize": {
-        "false": 117,
-        "true": 117
+        "false": 137,
+        "true": 137
       },
       "Rate": {
         "lora": {

--- a/pkg/band/testdata/US_902_928_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0_3_REV_A.json
@@ -564,8 +564,8 @@
     },
     "8": {
       "MaxMACPayloadSize": {
-        "false": 41,
-        "true": 41
+        "false": 61,
+        "true": 61
       },
       "Rate": {
         "lora": {
@@ -577,8 +577,8 @@
     },
     "9": {
       "MaxMACPayloadSize": {
-        "false": 117,
-        "true": 117
+        "false": 137,
+        "true": 137
       },
       "Rate": {
         "lora": {

--- a/pkg/band/testdata/US_902_928_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_1_REV_A.json
@@ -564,8 +564,8 @@
     },
     "8": {
       "MaxMACPayloadSize": {
-        "false": 41,
-        "true": 41
+        "false": 61,
+        "true": 61
       },
       "Rate": {
         "lora": {
@@ -577,8 +577,8 @@
     },
     "9": {
       "MaxMACPayloadSize": {
-        "false": 117,
-        "true": 117
+        "false": 137,
+        "true": 137
       },
       "Rate": {
         "lora": {

--- a/pkg/band/testdata/US_902_928_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_1_REV_B.json
@@ -564,8 +564,8 @@
     },
     "8": {
       "MaxMACPayloadSize": {
-        "false": 41,
-        "true": 41
+        "false": 61,
+        "true": 61
       },
       "Rate": {
         "lora": {
@@ -577,8 +577,8 @@
     },
     "9": {
       "MaxMACPayloadSize": {
-        "false": 117,
-        "true": 117
+        "false": 137,
+        "true": 137
       },
       "Rate": {
         "lora": {

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_0.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_0.json
@@ -564,8 +564,8 @@
     },
     "8": {
       "MaxMACPayloadSize": {
-        "false": 41,
-        "true": 41
+        "false": 61,
+        "true": 61
       },
       "Rate": {
         "lora": {
@@ -577,8 +577,8 @@
     },
     "9": {
       "MaxMACPayloadSize": {
-        "false": 117,
-        "true": 117
+        "false": 137,
+        "true": 137
       },
       "Rate": {
         "lora": {

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_1.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_1.json
@@ -564,8 +564,8 @@
     },
     "8": {
       "MaxMACPayloadSize": {
-        "false": 41,
-        "true": 41
+        "false": 61,
+        "true": 61
       },
       "Rate": {
         "lora": {
@@ -577,8 +577,8 @@
     },
     "9": {
       "MaxMACPayloadSize": {
-        "false": 117,
-        "true": 117
+        "false": 137,
+        "true": 137
       },
       "Rate": {
         "lora": {

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_2.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_2.json
@@ -588,8 +588,8 @@
     },
     "8": {
       "MaxMACPayloadSize": {
-        "false": 41,
-        "true": 41
+        "false": 61,
+        "true": 61
       },
       "Rate": {
         "lora": {
@@ -601,8 +601,8 @@
     },
     "9": {
       "MaxMACPayloadSize": {
-        "false": 117,
-        "true": 117
+        "false": 137,
+        "true": 137
       },
       "Rate": {
         "lora": {

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_3.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_3.json
@@ -588,8 +588,8 @@
     },
     "8": {
       "MaxMACPayloadSize": {
-        "false": 41,
-        "true": 41
+        "false": 61,
+        "true": 61
       },
       "Rate": {
         "lora": {
@@ -601,8 +601,8 @@
     },
     "9": {
       "MaxMACPayloadSize": {
-        "false": 117,
-        "true": 117
+        "false": 137,
+        "true": 137
       },
       "Rate": {
         "lora": {

--- a/pkg/band/us_902_928_rp1_v1_0_2.go
+++ b/pkg/band/us_902_928_rp1_v1_0_2.go
@@ -51,8 +51,8 @@ var US_902_928_RP1_V1_0_2 = Band{
 		ttnpb.DataRateIndex_DATA_RATE_3: makeLoRaDataRate(7, 125000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_4: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 
-		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(41)),
-		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(117)),
+		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(61)),
+		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(137)),
 		ttnpb.DataRateIndex_DATA_RATE_10: makeLoRaDataRate(10, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_11: makeLoRaDataRate(9, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_12: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),

--- a/pkg/band/us_902_928_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/us_902_928_rp1_v1_0_2_rev_b.go
@@ -51,8 +51,8 @@ var US_902_928_RP1_V1_0_2_Rev_B = Band{
 		ttnpb.DataRateIndex_DATA_RATE_3: makeLoRaDataRate(7, 125000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_4: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 
-		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(41)),
-		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(117)),
+		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(61)),
+		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(137)),
 		ttnpb.DataRateIndex_DATA_RATE_10: makeLoRaDataRate(10, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_11: makeLoRaDataRate(9, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_12: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),

--- a/pkg/band/us_902_928_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/us_902_928_rp1_v1_0_3_rev_a.go
@@ -51,8 +51,8 @@ var US_902_928_RP1_V1_0_3_Rev_A = Band{
 		ttnpb.DataRateIndex_DATA_RATE_3: makeLoRaDataRate(7, 125000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_4: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 
-		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(41)),
-		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(117)),
+		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(61)),
+		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(137)),
 		ttnpb.DataRateIndex_DATA_RATE_10: makeLoRaDataRate(10, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_11: makeLoRaDataRate(9, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_12: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),

--- a/pkg/band/us_902_928_rp1_v1_1_rev_a.go
+++ b/pkg/band/us_902_928_rp1_v1_1_rev_a.go
@@ -51,8 +51,8 @@ var US_902_928_RP1_V1_1_Rev_A = Band{
 		ttnpb.DataRateIndex_DATA_RATE_3: makeLoRaDataRate(7, 125000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_4: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 
-		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(41)),
-		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(117)),
+		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(61)),
+		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(137)),
 		ttnpb.DataRateIndex_DATA_RATE_10: makeLoRaDataRate(10, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_11: makeLoRaDataRate(9, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_12: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),

--- a/pkg/band/us_902_928_rp1_v1_1_rev_b.go
+++ b/pkg/band/us_902_928_rp1_v1_1_rev_b.go
@@ -51,8 +51,8 @@ var US_902_928_RP1_V1_1_Rev_B = Band{
 		ttnpb.DataRateIndex_DATA_RATE_3: makeLoRaDataRate(7, 125000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_4: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 
-		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(41)),
-		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(117)),
+		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(61)),
+		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(137)),
 		ttnpb.DataRateIndex_DATA_RATE_10: makeLoRaDataRate(10, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_11: makeLoRaDataRate(9, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_12: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),

--- a/pkg/band/us_902_928_rp2_v1_0_0.go
+++ b/pkg/band/us_902_928_rp2_v1_0_0.go
@@ -51,8 +51,8 @@ var US_902_928_RP2_V1_0_0 = Band{
 		ttnpb.DataRateIndex_DATA_RATE_3: makeLoRaDataRate(7, 125000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_4: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 
-		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(41)),
-		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(117)),
+		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(61)),
+		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(137)),
 		ttnpb.DataRateIndex_DATA_RATE_10: makeLoRaDataRate(10, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_11: makeLoRaDataRate(9, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_12: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),

--- a/pkg/band/us_902_928_rp2_v1_0_1.go
+++ b/pkg/band/us_902_928_rp2_v1_0_1.go
@@ -51,8 +51,8 @@ var US_902_928_RP2_V1_0_1 = Band{
 		ttnpb.DataRateIndex_DATA_RATE_3: makeLoRaDataRate(7, 125000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_4: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 
-		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(41)),
-		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(117)),
+		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(61)),
+		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(137)),
 		ttnpb.DataRateIndex_DATA_RATE_10: makeLoRaDataRate(10, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_11: makeLoRaDataRate(9, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_12: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),

--- a/pkg/band/us_902_928_rp2_v1_0_2.go
+++ b/pkg/band/us_902_928_rp2_v1_0_2.go
@@ -53,8 +53,8 @@ var US_902_928_RP2_V1_0_2 = Band{
 		ttnpb.DataRateIndex_DATA_RATE_5: makeLRFHSSDataRate(0, 1523000, "1/3", makeConstMaxMACPayloadSizeFunc(58)),
 		ttnpb.DataRateIndex_DATA_RATE_6: makeLRFHSSDataRate(0, 1523000, "2/3", makeConstMaxMACPayloadSizeFunc(133)),
 
-		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(41)),
-		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(117)),
+		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(61)),
+		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(137)),
 		ttnpb.DataRateIndex_DATA_RATE_10: makeLoRaDataRate(10, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_11: makeLoRaDataRate(9, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_12: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),

--- a/pkg/band/us_902_928_rp2_v1_0_3.go
+++ b/pkg/band/us_902_928_rp2_v1_0_3.go
@@ -53,8 +53,8 @@ var US_902_928_RP2_V1_0_3 = Band{
 		ttnpb.DataRateIndex_DATA_RATE_5: makeLRFHSSDataRate(0, 1523000, "1/3", makeConstMaxMACPayloadSizeFunc(58)),
 		ttnpb.DataRateIndex_DATA_RATE_6: makeLRFHSSDataRate(0, 1523000, "2/3", makeConstMaxMACPayloadSizeFunc(133)),
 
-		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(41)),
-		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(117)),
+		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(61)),
+		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(137)),
 		ttnpb.DataRateIndex_DATA_RATE_10: makeLoRaDataRate(10, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_11: makeLoRaDataRate(9, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_12: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),

--- a/pkg/band/us_902_928_ts1_v1_0.go
+++ b/pkg/band/us_902_928_ts1_v1_0.go
@@ -51,8 +51,8 @@ var US_902_928_TS1_V1_0 = Band{
 		ttnpb.DataRateIndex_DATA_RATE_3: makeLoRaDataRate(7, 125000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_4: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 
-		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(41)),
-		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(117)),
+		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(61)),
+		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(137)),
 		ttnpb.DataRateIndex_DATA_RATE_10: makeLoRaDataRate(10, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_11: makeLoRaDataRate(9, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_12: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),

--- a/pkg/band/us_902_928_ts1_v1_0_1.go
+++ b/pkg/band/us_902_928_ts1_v1_0_1.go
@@ -51,8 +51,8 @@ var US_902_928_TS1_V1_0_1 = Band{
 		ttnpb.DataRateIndex_DATA_RATE_3: makeLoRaDataRate(7, 125000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_4: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 
-		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(41)),
-		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(117)),
+		ttnpb.DataRateIndex_DATA_RATE_8:  makeLoRaDataRate(12, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(61)),
+		ttnpb.DataRateIndex_DATA_RATE_9:  makeLoRaDataRate(11, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(137)),
 		ttnpb.DataRateIndex_DATA_RATE_10: makeLoRaDataRate(10, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_11: makeLoRaDataRate(9, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),
 		ttnpb.DataRateIndex_DATA_RATE_12: makeLoRaDataRate(8, 500000, Cr4_5, makeConstMaxMACPayloadSizeFunc(250)),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/5563

This PR fixes the max MAC payload sizes for US915 in the downlink data rates. Specifically in the US915 band we've been using the repeater-compatible limits for downlinks, even though this is not needed for now (all of the other limits are non-repeater compatible).

_See correct picture below._

#### Changes
<!-- What are the changes made in this pull request? -->

- Add 20 bytes to the max MAC payload size of the downlink data rates in US915.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing - see the definition files.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This just enables longer downlinks on SF12 and SF11 in the 500KHz channels.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer please review.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
