### PR TITLE
Convert syscall errors

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -4175,6 +4175,15 @@
       "file": "conversion.go"
     }
   },
+  "error:pkg/errors:syscall": {
+    "translations": {
+      "en": "`{syscall}` failed"
+    },
+    "description": {
+      "package": "pkg/errors",
+      "file": "conversion.go"
+    }
+  },
   "error:pkg/errors:url": {
     "translations": {
       "en": "invalid url `{url}`"

--- a/pkg/errors/conversion_other.go
+++ b/pkg/errors/conversion_other.go
@@ -1,0 +1,22 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux && !darwin
+// +build !linux,!darwin
+
+package errors
+
+func syscallErrorAttributes(error) []interface{} {
+	return nil
+}

--- a/pkg/errors/conversion_unix.go
+++ b/pkg/errors/conversion_unix.go
@@ -1,0 +1,34 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux || darwin
+// +build linux darwin
+
+package errors
+
+import (
+	"errors"
+	"syscall"
+)
+
+func syscallErrorAttributes(err error) []interface{} {
+	if matched := (syscall.Errno)(0); errors.As(err, &matched) {
+		// syscall.Errono do not contain any sensitive information and are safe to render.
+		return []interface{}{
+			"error", matched.Error(),
+			"timeout", matched.Timeout(),
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/930

This PR adds support for conversion between standard syscall errors and `pkg/errors` errors.

#### Changes
<!-- What are the changes made in this pull request? -->

- Unwrap `os.SyscallError` in order to render the failed syscall.
- On `unix` and `darwin`, render the syscall error code number in textual form.

#### Testing

<!-- How did you verify that this change works? -->

Local testing.

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/36161392/224388580-79f187cd-cfb5-4e1a-b686-d5c5ac65b5cb.png">

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
