### PR TITLE
Telemetry Exporter

### DIFF
--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -23,6 +23,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/packetbroker"
 	"go.thethings.network/lorawan-stack/v3/pkg/redis"
+	telemetry "go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter"
 	"go.thethings.network/lorawan-stack/v3/pkg/telemetry/tracing"
 	"golang.org/x/crypto/acme"
 )
@@ -155,6 +156,19 @@ var DefaultTracingConfig = tracing.Config{
 	SampleProbability: 1.,
 }
 
+// DefaultTelemetryConfig  is the default config for telemetry.
+var DefaultTelemetryConfig = telemetry.Config{
+	// TODO: After (https://github.com/TheThingsNetwork/lorawan-stack/issues/6081) is no longer blocked.
+	// Enable the telemetry and define the target.
+	Enable:       false,
+	Target:       "",
+	NumConsumers: 1,
+	EntityCountTelemetry: telemetry.EntityCountTelemetry{
+		Enable:   false,
+		Interval: 24 * time.Hour,
+	},
+}
+
 // DefaultServiceBase is the default base config for a service.
 var DefaultServiceBase = config.ServiceBase{
 	Base:           DefaultBaseConfig,
@@ -171,6 +185,7 @@ var DefaultServiceBase = config.ServiceBase{
 	Rights:         DefaultRightsConfig,
 	KeyVault:       DefaultKeyVaultConfig,
 	Tracing:        DefaultTracingConfig,
+	Telemetry:      DefaultTelemetryConfig,
 }
 
 // DefaultPublicHost is the default public host where The Things Stack is served.

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -39,6 +39,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/experimental"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	telemetry_cli "go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter/cli"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/io"
 	pkgversion "go.thethings.network/lorawan-stack/v3/pkg/version"
 	"golang.org/x/oauth2"
@@ -78,6 +79,12 @@ var (
 
 			// clean up the API
 			api.CloseAll()
+
+			if config.Telemetry.Enable {
+				telemetry_cli.NewCLITelemetry(
+					telemetry_cli.WithCLITarget(config.Telemetry.Target),
+				).Run(ctx)
+			}
 
 			select {
 			case <-ctx.Done():

--- a/cmd/ttn-lw-stack/commands/root.go
+++ b/cmd/ttn-lw-stack/commands/root.go
@@ -125,6 +125,8 @@ var (
 				}(ctx)
 			}
 
+			telemetryConfigFallback(ctx, config)
+
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/ttn-lw-stack/commands/utils.go
+++ b/cmd/ttn-lw-stack/commands/utils.go
@@ -151,3 +151,16 @@ func getSchemaVersion(cl *ttnredis.Client) (int, error) {
 	logger.WithField("version", schemaVersion).Info("Existing database schema version")
 	return int(schemaVersion), nil
 }
+
+// telemetryConfigFallback sets the UID elements for telemetry if they are empty.
+func telemetryConfigFallback(_ context.Context, cfg *Config) {
+	if cfg != nil && len(cfg.ServiceBase.Telemetry.UIDElements) == 0 {
+		cfg.ServiceBase.Telemetry.UIDElements = []string{
+			cfg.Console.UI.IS.BaseURL,
+			cfg.Console.UI.GS.BaseURL,
+			cfg.Console.UI.NS.BaseURL,
+			cfg.Console.UI.AS.BaseURL,
+			cfg.Console.UI.JS.BaseURL,
+		}
+	}
+}

--- a/config/messages.json
+++ b/config/messages.json
@@ -8468,6 +8468,15 @@
       "file": "task.go"
     }
   },
+  "error:pkg/telemetry/exporter/istelemetry:insufficient_configuration": {
+    "translations": {
+      "en": "insufficient configuration to start task, missing `{field}`"
+    },
+    "description": {
+      "package": "pkg/telemetry/exporter/istelemetry",
+      "file": "is.go"
+    }
+  },
   "error:pkg/telemetry/exporter:callback_not_registered": {
     "translations": {
       "en": "callback not registered"

--- a/config/messages.json
+++ b/config/messages.json
@@ -8468,6 +8468,15 @@
       "file": "task.go"
     }
   },
+  "error:pkg/telemetry/exporter:callback_not_registered": {
+    "translations": {
+      "en": "callback not registered"
+    },
+    "description": {
+      "package": "pkg/telemetry/exporter",
+      "file": "task_queue.go"
+    }
+  },
   "error:pkg/telemetry/tracing:unknown_exporter": {
     "translations": {
       "en": "unknown exporter {exporter}"

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -32,6 +32,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/redis"
+	telemetry "go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter"
 	"go.thethings.network/lorawan-stack/v3/pkg/telemetry/tracing"
 	"gocloud.dev/blob"
 )
@@ -507,6 +508,7 @@ type ServiceBase struct {
 	RateLimiting     RateLimiting         `name:"rate-limiting" description:"Rate limiting configuration"`
 	Tracing          tracing.Config       `name:"tracing" yaml:"tracing" description:"Tracing configuration"`
 	SkipVersionCheck bool                 `name:"skip-version-check" yaml:"skip-version-check" description:"Skip version checks"` //nolint:lll
+	Telemetry        telemetry.Config     `name:"telemetry" yaml:"telemetry" description:"Telemetry configuration"`
 }
 
 // FrequencyPlansFetcher returns a fetch.Interface based on the frequency plans configuration.

--- a/pkg/identityserver/config.go
+++ b/pkg/identityserver/config.go
@@ -26,6 +26,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/fetch"
 	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 	"go.thethings.network/lorawan-stack/v3/pkg/oauth"
+	telemetry "go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	ttntypes "go.thethings.network/lorawan-stack/v3/pkg/types"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -113,6 +114,7 @@ type Config struct {
 		NetID    ttntypes.NetID `name:"net-id" description:"NetID of this network"`
 		TenantID string         `name:"tenant-id" description:"Tenant ID in the host NetID"`
 	} `name:"network"`
+	TelemetryQueue telemetry.TaskQueue `name:"-"`
 }
 
 type emailTemplatesConfig struct {

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -36,6 +36,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/hooks"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/rpclog"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/rpctracer"
+	telemetry "go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter"
 	"go.thethings.network/lorawan-stack/v3/pkg/telemetry/tracing/tracer"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/webui"
@@ -59,6 +60,8 @@ type IdentityServer struct {
 	redis   *redis.Client
 	account account.Server
 	oauth   oauth.Server
+
+	telemetryQueue telemetry.TaskQueue
 }
 
 // Context returns the context of the Identity Server.
@@ -142,9 +145,10 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 	ctx := tracer.NewContextWithTracer(c.Context(), tracerNamespace)
 
 	is = &IdentityServer{
-		Component: c,
-		ctx:       log.NewContextWithField(ctx, "namespace", logNamespace),
-		config:    config,
+		Component:      c,
+		ctx:            log.NewContextWithField(ctx, "namespace", logNamespace),
+		config:         config,
+		telemetryQueue: config.TelemetryQueue,
 	}
 
 	if err := is.setupStore(); err != nil {
@@ -169,6 +173,11 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 		ctx = rights.NewContextWithCache(ctx)
 		return ctx
 	})
+
+	// Tasks initialization.
+	if err := is.initilizeTelemetryTasks(is.Context()); err != nil {
+		return nil, err
+	}
 
 	for _, hook := range []struct {
 		name       string

--- a/pkg/identityserver/telemetry.go
+++ b/pkg/identityserver/telemetry.go
@@ -1,0 +1,96 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identityserver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	"go.thethings.network/lorawan-stack/v3/pkg/task"
+	telemetry "go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter"
+	"go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter/istelemetry"
+)
+
+// initilizeTelemetryTasks starts the telemetry dispatcher, consumers and Identity Server's tasks.
+func (is *IdentityServer) initilizeTelemetryTasks(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+
+	tmCfg := is.GetBaseConfig(is.Context()).Telemetry
+	tq := is.telemetryQueue
+	if tq == nil || !tmCfg.Enable {
+		return nil
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+	consumerIDPrefix := fmt.Sprintf("%s:%d", hostname, os.Getpid())
+
+	if entityCntTm := tmCfg.EntityCountTelemetry; entityCntTm.Enable {
+		cl, err := is.HTTPClient(ctx)
+		if err != nil {
+			return err
+		}
+
+		entityTask := istelemetry.New(
+			istelemetry.WithUID(telemetry.GenerateHash(is.Context(), tmCfg.UIDElements...)),
+			istelemetry.WithBunDB(bun.NewDB(is.db, pgdialect.New())),
+			istelemetry.WithTarget(tmCfg.Target),
+			istelemetry.WithHTTPClient(cl),
+		)
+		if err := entityTask.Validate(ctx); err != nil {
+			return err
+		}
+
+		logger.WithField("task", istelemetry.EntityCountTaskName).Debug("Add task to queue")
+		err = tq.Add(ctx, istelemetry.EntityCountTaskName, time.Now().Add(entityCntTm.Interval), false)
+		if err != nil {
+			return err
+		}
+		logger.WithField("task", istelemetry.EntityCountTaskName).Debug("Register task callback")
+		tq.RegisterCallback(
+			istelemetry.EntityCountTaskName,
+			telemetry.CallbackWithInterval(ctx, entityCntTm.Interval, entityTask.CountEntities),
+		)
+	}
+
+	logger.Debug("Start telemetry queue dispatcher")
+	is.RegisterTask(&task.Config{
+		Context: ctx,
+		ID:      "is_telemetry_dispatcher",
+		Backoff: task.DefaultBackoffConfig,
+		Restart: task.RestartAlways,
+		Func:    telemetry.DispatchTask(tq, consumerIDPrefix),
+	})
+
+	logger.Debug("Start telemetry queue consumers")
+	for i := uint64(0); i < tmCfg.NumConsumers; i++ {
+		consumerID := fmt.Sprintf("%s:%d", consumerIDPrefix, i)
+		is.RegisterTask(&task.Config{
+			Context: ctx,
+			ID:      fmt.Sprintf("%s_%d", "is_telemetry_consumer", i),
+			Backoff: task.DefaultBackoffConfig,
+			Restart: task.RestartAlways,
+			Func:    telemetry.PopTask(tq, consumerID),
+		})
+	}
+	return nil
+}

--- a/pkg/telemetry/exporter/cli/cli.go
+++ b/pkg/telemetry/exporter/cli/cli.go
@@ -1,0 +1,198 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cli contains telemetry functions regarding the collection of data in the CLI. Should be imported as
+// cli_telemetry.
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	telemetry "go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter"
+	"go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter/models"
+	"gopkg.in/yaml.v2"
+)
+
+// defaultTimeout sends CLI data every 24 hours.
+var defaultTimeout = 24 * time.Hour
+
+// cliStateTelemetry contains relevant data to the execution of the CLI telemetry.
+//
+// The CLI telemetry is essentially different from other telemetry collections of the Stack, this is due to the fact
+// that we don't have to consider the possibility of having multiple servers for each component of the Stack. With this
+// information we can simply just use a unique randomly generated number as an ID, writing it on the local machine.
+type cliStateTelemetry struct {
+	UID      string    `yaml:"uid"`
+	LastSent time.Time `yaml:"last_sent"`
+}
+
+// Write telemetry state into the provided path.
+func (cst *cliStateTelemetry) Write(p string) error {
+	b, err := yaml.Marshal(cst)
+	if err != nil {
+		return err
+	}
+
+	// Creates the file since it does not exist.
+	if err := os.WriteFile(p, b, 0o644); err != nil { //nolint:gas
+		return err
+	}
+	return nil
+}
+
+// ttnPath returns the path to the folder in which the configuration of telemetry is stored.
+func ttnPath() (string, error) {
+	configPath, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(configPath, "ttn-lorawan"), nil
+}
+
+// cliStatePath returns the path to the file in which the CLI telemetry is stored.
+func cliStatePath() (string, error) {
+	p, err := ttnPath()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(p, "cli-telemetry-state.yml"), nil
+}
+
+// getCLIState returns the telemetry state, if it doesn't exist it creates a file with default values for the state.
+func getCLIState() (*cliStateTelemetry, bool, error) {
+	folderPath, err := ttnPath()
+	if err != nil {
+		return nil, false, err
+	}
+	if _, err := os.Stat(folderPath); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, false, err
+		}
+		// Creates the folder since it does not exist.
+		if err := os.Mkdir(folderPath, 0o755); err != nil {
+			return nil, false, err
+		}
+	}
+
+	statePath, err := cliStatePath()
+	if err != nil {
+		return nil, false, err
+	}
+
+	cliState := &cliStateTelemetry{}
+
+	if _, err := os.Stat(statePath); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, false, err
+		}
+
+		cliState.UID = uuid.NewV4().String()
+		cliState.LastSent = time.Now()
+		return cliState, true, nil
+	}
+
+	b, err := os.ReadFile(statePath)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := yaml.Unmarshal(b, cliState); err != nil {
+		return nil, false, err
+	}
+	return cliState, false, nil
+}
+
+func shouldSendTelemetry(t time.Time) bool {
+	return time.Now().After(t.Add(defaultTimeout))
+}
+
+type cliTask struct {
+	target string
+}
+
+// Task is a small task that sends telemetry data once a day.
+type Task interface {
+	Run(context.Context)
+}
+
+// Option is an option for the CLI telemetry.
+type Option interface {
+	apply(*cliTask)
+}
+
+type option func(*cliTask)
+
+func (opt option) apply(ct *cliTask) { opt(ct) }
+
+// WithCLITarget defines the URL to which the CLI data will be sent.
+func WithCLITarget(s string) Option {
+	return option(func(ct *cliTask) {
+		ct.target = s
+	})
+}
+
+// NewCLITelemetry returns a wrapper that contains the necessary methods to collect and send telemetry data regarding
+// CLI usage.
+func NewCLITelemetry(opts ...Option) Task {
+	ct := &cliTask{}
+	for _, opt := range opts {
+		opt.apply(ct)
+	}
+	return ct
+}
+
+// Run a small task that send telemetry data once a day.
+func (ct *cliTask) Run(ctx context.Context) {
+	logger := log.FromContext(ctx)
+	state, send, err := getCLIState()
+	if err != nil {
+		logger.WithError(err).Debug("Failed to retrieve telemetry state")
+	}
+
+	if send || shouldSendTelemetry(state.LastSent) {
+		state.LastSent = time.Now()
+		if statePath, err := cliStatePath(); err != nil {
+			logger.WithError(err).Debug("Failed to retrieve telemetry state file path")
+		} else {
+			// If no error fetching the state file path, update the LastSeen field.
+			state.Write(statePath) //nolint:errcheck
+		}
+
+		b, err := json.Marshal(&models.TelemetryMessage{
+			UID: state.UID,
+			OS:  telemetry.OSTelemetryData(),
+			CLI: &models.CLITelemetry{},
+		})
+		if err != nil {
+			logger.WithError(err).Debug("Failed to marshal telemetry information")
+			return
+		}
+		resp, err := http.DefaultClient.Post(ct.target, "application/json", bytes.NewReader(b))
+		if err != nil {
+			logger.WithError(err).Debug("Failed to send telemetry information")
+			return
+		}
+		defer resp.Body.Close()
+		io.Copy(io.Discard, resp.Body) // nolint:errcheck
+		logger.Info("Sent telemetry information")
+	}
+}

--- a/pkg/telemetry/exporter/config.go
+++ b/pkg/telemetry/exporter/config.go
@@ -1,0 +1,41 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package telemetry contains the telemetry configuration and the hash generator that is used in other telemetry related
+// packages.
+package telemetry
+
+import "time"
+
+// CLI contains information regarding the telemetry collection for the CLI.
+type CLI struct {
+	Enable bool   `name:"enable" description:"Enables telemetry for CLI"`
+	Target string `name:"target" description:"Target to which the information will be sent to"`
+}
+
+// EntityCountTelemetry contains information regarding the telemetry collection for the amount of entities.
+type EntityCountTelemetry struct {
+	Enable   bool          `name:"enable" description:"Enables entity count collection"`
+	Interval time.Duration `name:"interval" description:"Interval between each run of the collection"`
+}
+
+// Config contains information regarding the telemetry collection.
+type Config struct {
+	Enable bool `name:"enable" description:"Enables telemetry collection"`
+	// UIDElements is a list of elements that will be used to generate the UID.
+	UIDElements          []string             `name:"-"`
+	Target               string               `name:"target" description:"Target to which the information will be sent to"`                                 // nolint:lll
+	NumConsumers         uint64               `name:"num-consumers" description:"Number of consumers that will be used to monitor telemetry related tasks"` // nolint:lll
+	EntityCountTelemetry EntityCountTelemetry `name:"entity-count-telemetry"`
+}

--- a/pkg/telemetry/exporter/hash.go
+++ b/pkg/telemetry/exporter/hash.go
@@ -1,0 +1,30 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"crypto/sha512"
+	"encoding/base64"
+)
+
+// GenerateHash receives a string slice and returns a string of a UID.
+func GenerateHash(_ context.Context, elems ...string) string {
+	s := sha512.New()
+	for _, elem := range elems {
+		s.Write([]byte(elem + ":"))
+	}
+	return base64.StdEncoding.EncodeToString(s.Sum(nil))
+}

--- a/pkg/telemetry/exporter/istelemetry/is.go
+++ b/pkg/telemetry/exporter/istelemetry/is.go
@@ -1,0 +1,299 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package istelemetry contains telemetry functions regarding the collection of data in the IdentityServer.
+package istelemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/uptrace/bun"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	store "go.thethings.network/lorawan-stack/v3/pkg/identityserver/bunstore"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	telemetry "go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter"
+	"go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter/models"
+	storeutil "go.thethings.network/lorawan-stack/v3/pkg/util/store"
+)
+
+// EntityCountTaskName is the name of the task that collects entity counts.
+// This is used as the task name in the TaskQueue's callback registry.
+const EntityCountTaskName = "entity-count-task"
+
+type isTelemetry struct {
+	uid        string
+	target     string
+	httpClient *http.Client
+	DB         *bun.DB
+}
+
+// Option to apply at istelemetry initialization.
+type Option interface {
+	apply(*isTelemetry)
+}
+
+type optionFunc func(*isTelemetry)
+
+func (f optionFunc) apply(it *isTelemetry) { f(it) }
+
+// WithUID sets the uid of the task.
+func WithUID(uid string) Option {
+	return optionFunc(func(it *isTelemetry) {
+		it.uid = uid
+	})
+}
+
+// WithTarget sets the URL to which the content will be sent to.
+func WithTarget(target string) Option {
+	return optionFunc(func(it *isTelemetry) {
+		it.target = target
+	})
+}
+
+// WithBunDB sets the DB to be used for the queries.
+func WithBunDB(db *bun.DB) Option {
+	return optionFunc(func(it *isTelemetry) {
+		it.DB = db
+	})
+}
+
+// WithHTTPClient sets the HTTP client to be used for the requests.
+func WithHTTPClient(httpClient *http.Client) Option {
+	return optionFunc(func(it *isTelemetry) {
+		it.httpClient = httpClient
+	})
+}
+
+// Task is the interface that wraps the EntitiesCountTask method.
+type Task interface {
+	// Validate determines if the necessary requirement to run telemetry tasks are set.
+	Validate(ctx context.Context) error
+	// CountEntities fetches the number of entities in the database and sends it to the target.
+	CountEntities(ctx context.Context) error
+}
+
+// New returns a instance of the identity server telemetry task.
+func New(opts ...Option) Task {
+	it := &isTelemetry{}
+	for _, opt := range opts {
+		opt.apply(it)
+	}
+	return it
+}
+
+func (it *isTelemetry) countApplications(ctx context.Context) (uint64, error) {
+	n, err := it.DB.NewSelect().Model(&store.Application{}).Count(ctx)
+	return uint64(n), storeutil.WrapDriverError(err)
+}
+
+func (it *isTelemetry) countEndDevices(ctx context.Context) (uint64, error) {
+	n, err := it.DB.NewSelect().Model(&store.EndDevice{}).Count(ctx)
+	return uint64(n), storeutil.WrapDriverError(err)
+}
+
+func (it *isTelemetry) countOrganizations(ctx context.Context) (resp models.OrganizationsCount, err error) {
+	for _, q := range []struct {
+		query *bun.SelectQuery
+		num   *uint64
+	}{
+		{
+			query: it.DB.NewSelect().Model(&store.Organization{}),
+			num:   &resp.Total,
+		},
+	} {
+		n, err := q.query.Count(ctx)
+		if err != nil {
+			return resp, storeutil.WrapDriverError(err)
+		}
+		*q.num = uint64(n)
+	}
+	return resp, nil
+}
+
+// countActiveDevices returns the ActivatedEndDevicesAmount, which counts active devices by day, week and month.
+func (it *isTelemetry) countActiveDevices(ctx context.Context) (resp models.ActivateEndDevicesCount, err error) {
+	for _, q := range []struct {
+		query *bun.SelectQuery
+		num   *uint64
+	}{
+		{
+			query: it.DB.NewSelect().Model(&store.EndDevice{}).Where("activated_at IS NOT NULL"),
+			num:   &resp.Total,
+		},
+		{
+			query: it.DB.NewSelect().Model(&store.EndDevice{}).Where("activated_at > NOW() - INTERVAL '1 DAY'"),
+			num:   &resp.LastDay,
+		},
+		{
+			query: it.DB.NewSelect().Model(&store.EndDevice{}).Where("activated_at > NOW() - INTERVAL '1 WEEK'"),
+			num:   &resp.LastWeek,
+		},
+		{
+			query: it.DB.NewSelect().Model(&store.EndDevice{}).Where("activated_at > NOW() - INTERVAL '1 MONTH'"),
+			num:   &resp.LastMonth,
+		},
+	} {
+		n, err := q.query.Count(ctx)
+		if err != nil {
+			return resp, storeutil.WrapDriverError(err)
+		}
+		*q.num = uint64(n)
+	}
+	return resp, nil
+}
+
+func (it *isTelemetry) countGatewaysByFreqPlan(ctx context.Context) (map[string]uint64, error) {
+	type result struct {
+		FrequencyPlanID string `bun:"frequency_plan_id"`
+		Count           uint64 `bun:"count"`
+	}
+	var results []result
+	err := it.DB.NewSelect().
+		Model(&store.Gateway{}).
+		ColumnExpr("frequency_plan_id").
+		ColumnExpr("COUNT(frequency_plan_id)").
+		Order("frequency_plan_id").
+		Group("frequency_plan_id").Scan(ctx, &results)
+	if err != nil {
+		return nil, storeutil.WrapDriverError(err)
+	}
+
+	m := make(map[string]uint64)
+	for _, r := range results {
+		for _, freqPlan := range strings.Split(r.FrequencyPlanID, " ") {
+			m[freqPlan] += r.Count
+		}
+	}
+	return m, nil
+}
+
+func (it *isTelemetry) countUserByTypes(ctx context.Context) (resp models.UsersCount, err error) {
+	for _, q := range []struct {
+		query *bun.SelectQuery
+		num   *uint64
+	}{
+		{
+			query: it.DB.NewSelect().Model(&store.User{}),
+			num:   &resp.Total,
+		},
+		{
+			query: it.DB.NewSelect().Model(&store.User{}).Where("admin IS TRUE"),
+			num:   &resp.Admin,
+		},
+		{
+			query: it.DB.NewSelect().Model(&store.User{}).Where("admin IS FALSE"),
+			num:   &resp.Standard,
+		},
+	} {
+		n, err := q.query.Count(ctx)
+		if err != nil {
+			return resp, storeutil.WrapDriverError(err)
+		}
+		*q.num = uint64(n)
+	}
+	return resp, nil
+}
+
+var errInsufficientConfiguration = errors.DefineFailedPrecondition(
+	"insufficient_configuration", "insufficient configuration to start task, missing `{field}`",
+)
+
+// Validate if the necessary fields for the tasks are set.
+func (it *isTelemetry) Validate(_ context.Context) error {
+	if it.uid == "" {
+		return errInsufficientConfiguration.WithAttributes("field", "uid")
+	}
+	if it.DB == nil {
+		return errInsufficientConfiguration.WithAttributes("field", "db")
+	}
+	if it.httpClient == nil {
+		return errInsufficientConfiguration.WithAttributes("field", "http_client")
+	}
+	if it.target == "" {
+		return errInsufficientConfiguration.WithAttributes("field", "target")
+	}
+	return nil
+}
+
+// CountEntities is the task that collects data regarding the amount of each entity in the IS database.
+func (it *isTelemetry) CountEntities(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+
+	apps, err := it.countApplications(ctx)
+	if err != nil {
+		return err
+	}
+	devs, err := it.countEndDevices(ctx)
+	if err != nil {
+		return err
+	}
+	gtws, err := it.countGatewaysByFreqPlan(ctx)
+	if err != nil {
+		return err
+	}
+	orgs, err := it.countOrganizations(ctx)
+	if err != nil {
+		return err
+	}
+	activeDevs, err := it.countActiveDevices(ctx)
+	if err != nil {
+		return err
+	}
+	usrs, err := it.countUserByTypes(ctx)
+	if err != nil {
+		return err
+	}
+
+	data := &models.TelemetryMessage{
+		UID: it.uid,
+		OS:  telemetry.OSTelemetryData(),
+		EntitiesCount: &models.EntitiesCount{
+			Gateways: models.GatewaysCount{
+				GatewaysByFrequencyPlanID: gtws,
+			},
+			EndDevices: models.EndDevicesCount{
+				Total:              devs,
+				ActivateEndDevices: activeDevs,
+			},
+			Applications: models.ApplicationsCount{
+				Total: apps,
+			},
+			Accounts: models.AccountsCount{
+				Users:         usrs,
+				Organizations: orgs,
+			},
+		},
+	}
+	logger.WithField("message", data).Debug("Collected entity count telemetry data")
+
+	b, err := json.Marshal(data)
+	if err != nil {
+		logger.WithError(err).Debug("Failed to marshal telemetry information")
+		return err
+	}
+
+	resp, err := it.httpClient.Post(it.target, "application/json", bytes.NewBuffer(b))
+	if err != nil {
+		logger.WithError(err).Debug("Failed to send information to telemetry server")
+		return err
+	}
+	defer resp.Body.Close()
+	_, err = io.Copy(io.Discard, resp.Body)
+	return err
+}

--- a/pkg/telemetry/exporter/models/base.go
+++ b/pkg/telemetry/exporter/models/base.go
@@ -1,0 +1,27 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package models contains telemetry models.
+package models
+
+// CLITelemetry contains telemetry information about the CLI.
+type CLITelemetry struct{}
+
+// OSTelemetry contains telemetry information about the operating system.
+type OSTelemetry struct {
+	OperatingSystem string `json:"operating_system"`
+	Arch            string `json:"arch"`
+	BinaryVersion   string `json:"binary_version" `
+	GolangVersion   string `json:"golang_version"`
+}

--- a/pkg/telemetry/exporter/models/entity_data.go
+++ b/pkg/telemetry/exporter/models/entity_data.go
@@ -1,0 +1,66 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+// AccountsCount telemetry data about the amount of accounts, total and the amount on each type.
+type AccountsCount struct {
+	Users         UsersCount         `json:"users"`
+	Organizations OrganizationsCount `json:"organizations"`
+}
+
+// UsersCount telemetry data about the amount of users, total and the amount on each type.
+type UsersCount struct {
+	Total    uint64 `json:"total"`
+	Standard uint64 `json:"standard"`
+	Admin    uint64 `json:"admin"`
+}
+
+// OrganizationsCount telemetry data about the total amount of orgainizations.
+type OrganizationsCount struct {
+	Total uint64 `json:"total"`
+}
+
+// ApplicationsCount telemetry data about the amount of applications.
+type ApplicationsCount struct {
+	Total uint64 `json:"total"`
+}
+
+// ActivateEndDevicesCount contains the amount of devices that are active respecting the described time frame.
+type ActivateEndDevicesCount struct {
+	Total     uint64 `json:"total"`
+	LastDay   uint64 `json:"last_day"`
+	LastWeek  uint64 `json:"last_week"`
+	LastMonth uint64 `json:"last_month"`
+}
+
+// EndDevicesCount contains telemetry data regarding the amount of end devices and its different types.
+type EndDevicesCount struct {
+	Total              uint64                  `json:"total"`
+	ActivateEndDevices ActivateEndDevicesCount `json:"activate_end_devices"`
+}
+
+// GatewaysCount contains telemetry data regarding the amount of gateways and some extra insights.
+type GatewaysCount struct {
+	Total                     uint64            `json:"total"`
+	GatewaysByFrequencyPlanID map[string]uint64 `json:"gateways_by_frequency_plan_id"`
+}
+
+// EntitiesCount contains telemetry data regarding the amount of each entity and its different types.
+type EntitiesCount struct {
+	Gateways     GatewaysCount     `json:"gateways"`
+	EndDevices   EndDevicesCount   `json:"end_devices"`
+	Applications ApplicationsCount `json:"applications"`
+	Accounts     AccountsCount     `json:"accounts"`
+}

--- a/pkg/telemetry/exporter/models/message.go
+++ b/pkg/telemetry/exporter/models/message.go
@@ -1,0 +1,26 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+// TelemetryMessage contains all the telemetry data that is to be exported by all services and CLI.
+//
+// This message is not supposed to be sent in its fullest. Meaning that tasks related to EntitiesCount should send only
+// data regarding the entity amount, while the CLI information should be empty.
+type TelemetryMessage struct {
+	UID           string         `json:"uid"`
+	OS            *OSTelemetry   `json:"os,omitempty"`
+	CLI           *CLITelemetry  `json:"cli"`
+	EntitiesCount *EntitiesCount `json:"entities_count"`
+}

--- a/pkg/telemetry/exporter/task_queue.go
+++ b/pkg/telemetry/exporter/task_queue.go
@@ -1,0 +1,143 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
+	"go.thethings.network/lorawan-stack/v3/pkg/task"
+)
+
+const (
+	telemetryKey = "telemetry"
+)
+
+var errCallbackNotRegistered = errors.DefineNotFound("callback_not_registered", "callback not registered")
+
+// TaskQueue represents a queue of telemetry tasks.
+type TaskQueue interface {
+	// Add telemetry task identified by `id` at time t.
+	// Implementations must ensure that Add returns fast.
+	Add(ctx context.Context, id string, t time.Time, replace bool) error
+
+	// RegisterCallback registers a callback that is called when a task is popped.
+	// All callbacks should be registered before the dispatch of the tasks in the queue, otherwise they are proned to
+	// fail within the first pop call.
+	RegisterCallback(callbackID string, callback TaskCallback)
+
+	// Dispatch the tasks in the queue.
+	Dispatch(ctx context.Context, consumerID string) error
+
+	// Pop pops the most recent task in the schedule, for which timestamp is in range [0, time.Now()], the value of
+	// the queue goes through the registered callback and determines which one should be called.
+	Pop(ctx context.Context, consumerID string) error
+}
+
+// TaskQueueCloser is a function that closes the task queue.
+type TaskQueueCloser func(context.Context) error
+
+// RedisTaskQueue is an implementation of telemetry.TaskQueue.
+type RedisTaskQueue struct {
+	queue     *ttnredis.TaskQueue
+	callbacks sync.Map
+}
+
+// TaskCallback is a callback that is called when a telemetry task is popped.
+type TaskCallback func(context.Context) (time.Time, error)
+
+// CallbackWithInterval is a wrapper that takes a task.Func and a time.Duration and returns a TaskCallback.
+func CallbackWithInterval(_ context.Context, interval time.Duration, callback task.Func) TaskCallback {
+	return func(ctx context.Context) (time.Time, error) {
+		t := time.Now().Add(interval)
+		if err := callback(ctx); err != nil {
+			return t, err
+		}
+		return t, nil
+	}
+}
+
+// NewRedisTaskQueue returns new telemetry task queue.
+func NewRedisTaskQueue(
+	ctx context.Context, cl *ttnredis.Client, maxLen int64, group string, streamBlockLimit time.Duration,
+) (TaskQueue, TaskQueueCloser, error) {
+	tq := &RedisTaskQueue{
+		queue: &ttnredis.TaskQueue{
+			Redis:            cl,
+			MaxLen:           maxLen,
+			Group:            group,
+			Key:              cl.Key(telemetryKey),
+			StreamBlockLimit: streamBlockLimit,
+		},
+	}
+	if err := tq.Init(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	return tq, tq.Close, nil
+}
+
+// Init initializes the TelemetryTaskQueue.
+func (q *RedisTaskQueue) Init(ctx context.Context) error {
+	return q.queue.Init(ctx)
+}
+
+// Close closes the TelemetryTaskQueue.
+func (q *RedisTaskQueue) Close(ctx context.Context) error {
+	return q.queue.Close(ctx)
+}
+
+// Add telemetry task's identifier at time startAt.
+func (q *RedisTaskQueue) Add(ctx context.Context, id string, startAt time.Time, replace bool) error {
+	return q.queue.Add(ctx, nil, id, startAt, replace)
+}
+
+// RegisterCallback registers a callback that is called when a task is popped.
+// All callbacks should be registered before the dispatch of the tasks in the queue, otherwise they are proned to fail
+// within the first pop call.
+func (q *RedisTaskQueue) RegisterCallback(callbackID string, callback TaskCallback) {
+	q.callbacks.Store(callbackID, callback)
+}
+
+// Dispatch the tasks in the queue.
+func (q *RedisTaskQueue) Dispatch(ctx context.Context, consumerID string) error {
+	return q.queue.Dispatch(ctx, consumerID, nil)
+}
+
+// Pop pops the most recent task in the schedule, for which timestamp is in range [0, time.Now()], the value of
+// the queue goes through the registered callback and determines which one should be called.
+func (q *RedisTaskQueue) Pop(ctx context.Context, consumerID string) error {
+	return q.queue.Pop(
+		ctx, consumerID, nil, func(p redis.Pipeliner, id string, t time.Time) error {
+			v, ok := q.callbacks.Load(id)
+			if !ok {
+				return errCallbackNotRegistered.WithAttributes("id", id)
+			}
+
+			tt, err := v.(TaskCallback)(ctx)
+			if err != nil {
+				log.FromContext(ctx).WithError(err).WithField("id", id).Warn("Failed to execute task from queue")
+				return q.Add(ctx, id, tt, false)
+			}
+
+			return q.Add(ctx, id, tt, false)
+		},
+	)
+}

--- a/pkg/telemetry/exporter/task_queue_test.go
+++ b/pkg/telemetry/exporter/task_queue_test.go
@@ -1,0 +1,192 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/redis"
+	. "go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+type mockTaskQueue struct {
+	dispatchCounter map[string]uint
+	popCounter      map[string]uint
+	sync.Mutex
+}
+
+func (mtq *mockTaskQueue) GetDispatchCounter(consumerID string) uint {
+	mtq.Lock()
+	defer mtq.Unlock()
+	return mtq.dispatchCounter[consumerID]
+}
+
+func (mtq *mockTaskQueue) GetPopCounter(consumerID string) uint {
+	mtq.Lock()
+	defer mtq.Unlock()
+	return mtq.popCounter[consumerID]
+}
+
+func (*mockTaskQueue) Add(context.Context, string, time.Time, bool) error {
+	return nil
+}
+
+func (*mockTaskQueue) RegisterCallback(string, TaskCallback) {}
+
+func (mtq *mockTaskQueue) Dispatch(_ context.Context, consumerID string) error {
+	mtq.Lock()
+	defer mtq.Unlock()
+	mtq.dispatchCounter[consumerID]++
+	return nil
+}
+
+func (mtq *mockTaskQueue) Pop(_ context.Context, consumerID string) error {
+	mtq.Lock()
+	defer mtq.Unlock()
+	mtq.popCounter[consumerID]++
+	return nil
+}
+
+// TestTaskWrappers tests that the task wrappers works as intended.
+func TestTaskWrappers(t *testing.T) {
+	t.Parallel()
+	mtq := &mockTaskQueue{
+		dispatchCounter: make(map[string]uint),
+		popCounter:      make(map[string]uint),
+	}
+	t.Run("DispatchTask", func(t *testing.T) {
+		t.Parallel()
+		a, ctx := test.New(t)
+		consumerID := "dispatch_func"
+
+		f := DispatchTask(mtq, consumerID)
+		a.So(f(ctx), should.BeNil)
+		a.So(mtq.GetDispatchCounter(consumerID), should.Equal, 1)
+	})
+
+	t.Run("PopTask", func(t *testing.T) {
+		t.Parallel()
+		a, ctx := test.New(t)
+		consumerID := "pop_func"
+
+		f := PopTask(mtq, consumerID)
+		a.So(f(ctx), should.BeNil)
+		a.So(mtq.GetPopCounter(consumerID), should.Equal, 1)
+	})
+}
+
+// TestConcurentTaskSet adds two distinct tasks within the task queue in order to test the all of its operations.
+//
+// Involves in creating the dispatch loop, adding tasks, registering callback, popping tasks and validating the amount
+// of times the callback have been called.
+func TestConcurentTaskSet(t *testing.T) {
+	t.Parallel()
+	a, ctx := test.New(t)
+
+	callbackDelay := 10 * test.Delay
+	testTimeout := 200 * test.Delay
+
+	// Add timeout to context. Garanties that the callbacks will be called a limited amount of times.
+	ctx, cancel := context.WithTimeout(ctx, testTimeout)
+	defer cancel()
+
+	cl, closer := test.NewRedis(ctx, "telemetry_test")
+	defer closer()
+
+	redisConsumerGroup := "tm"
+	tq, tqCloser, err := NewRedisTaskQueue(ctx, cl, 100000, redisConsumerGroup, redis.DefaultStreamBlockLimit)
+	a.So(err, should.BeNil)
+	defer func() {
+		a.So(tqCloser(ctx), should.BeNil)
+	}()
+
+	// Add tasks.
+	a.So(tq.Add(ctx, "test_task_1", time.Now().Add(callbackDelay), false), should.BeNil)
+	a.So(tq.Add(ctx, "test_task_2", time.Now().Add(callbackDelay), false), should.BeNil)
+
+	cntA := 0
+	cntB := 0
+
+	// Register callbacks.
+	tq.RegisterCallback("test_task_1", func(ctx context.Context) (time.Time, error) {
+		cntA++
+		return time.Now().Add(callbackDelay), nil
+	})
+	tq.RegisterCallback("test_task_2", func(ctx context.Context) (time.Time, error) {
+		cntB++
+		return time.Now().Add(callbackDelay), nil
+	})
+
+	hostname, err := os.Hostname()
+	a.So(err, should.BeNil)
+	consumerIDPrefix := fmt.Sprintf("%s:%d", hostname, os.Getpid())
+
+	errCh := make(chan error, 1)
+
+	// Create the dispatch loop.
+	go func(ctx context.Context, consumerID string) {
+		for {
+			select {
+			case <-ctx.Done():
+				errCh <- ctx.Err()
+			default:
+				if err := tq.Dispatch(ctx, consumerID); err != nil {
+					errCh <- err
+				}
+			}
+		}
+	}(ctx, consumerIDPrefix)
+
+	// Create the pop loop with 3 consumers.
+	for i := 0; i < 3; i++ {
+		consumerID := fmt.Sprintf("%s:%d", consumerIDPrefix, i)
+		go func(ctx context.Context, consumerID string) {
+			for {
+				select {
+				case <-ctx.Done():
+					errCh <- ctx.Err()
+				default:
+					if err := tq.Pop(ctx, consumerID); err != nil {
+						errCh <- err
+					}
+				}
+			}
+		}(ctx, consumerID)
+	}
+
+	// Wait for the callbacks to be called a few times.
+	time.Sleep(testTimeout / 2)
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("Timeout %v, Error: %v", testTimeout, err)
+	default:
+		// Test delay is 200 * test.Delay.
+		// The default callback delay is 5 * test.Delay.
+		// The time to call the callbacks a few times is 50 * test.Delay.
+		// Considering the delay within interacting with redis, it is still expected to have at least 5 calls to each
+		// callback.
+		//
+		a.So(cntA, should.BeGreaterThanOrEqualTo, 5)
+		a.So(cntB, should.BeGreaterThanOrEqualTo, 5)
+	}
+}

--- a/pkg/telemetry/exporter/utils.go
+++ b/pkg/telemetry/exporter/utils.go
@@ -1,0 +1,48 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"context"
+	"runtime"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/task"
+	"go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter/models"
+	"go.thethings.network/lorawan-stack/v3/pkg/version"
+)
+
+// DispatchTask returns a task that calls Dispatch with the provided consumerID.
+func DispatchTask(q TaskQueue, consumerID string) task.Func {
+	return func(ctx context.Context) error {
+		return q.Dispatch(ctx, consumerID)
+	}
+}
+
+// PopTask returns a task that calls Pop with the provided consumerID.
+func PopTask(q TaskQueue, consumerID string) task.Func {
+	return func(ctx context.Context) error {
+		return q.Pop(ctx, consumerID)
+	}
+}
+
+// OSTelemetryData returns the OS telemetry data which is attached to telemetry messages.
+func OSTelemetryData() *models.OSTelemetry {
+	return &models.OSTelemetry{
+		OperatingSystem: runtime.GOOS,
+		Arch:            runtime.GOARCH,
+		BinaryVersion:   version.String(),
+		GolangVersion:   runtime.Version(),
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
Closes #6021  and also is a backport of https://github.com/TheThingsIndustries/lorawan-stack/pull/3574

References
#### Changes
<!-- What are the changes made in this pull request? -->

- Add of the telemetry pkg, has the implementation for the tasks of all components.
  - Create telemetry for CLI, it runs on `PostRun` of the root command.
  - Create IS telemetry task regarding the collection of entity data, in specific, the amount of each entity. 
- Create telemetry task queue within the `pkg/telemetry/exporter`
- Add Telemetry task queue to Identity Server
- Register Entity count task to IS

#### Testing

<!-- How did you verify that this change works? -->

Local testing and unit tests regarding the task queue usage.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Adding telemetry should not affect the behavior of other components.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
