### PR TITLE
Deprecate end devices claim command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ For details about compatibility between different releases, see the **Commitment
 - Device claiming that transfer devices between applications is now deprecated and will be removed in a future version of The Things Stack. Device claiming on Join Servers, including The Things Join Server, remains functional. This deprecates the following components:
   - API for managing application claim authorization (`EndDeviceClaimingServer.AuthorizeApplication` and `EndDeviceClaimingServer.UnauthorizeApplication`)
   - CLI commands to manage application claim settings (`ttn-lw-cli application claim [authorize|unauthorize]`)
+  - CLI command to claim end devices  (`ttn-lw-cli devices claim`)
 
 ### Fixed
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -1137,6 +1137,7 @@ As part of claiming, you can optionally provide the target NetID, Network Server
 KEK label and Application Server ID and KEK label. The Network Server and
 Application Server addresses will be taken from the CLI configuration. These
 values will be stored in the Join Server.`,
+		Deprecated: "End device claiming is integrated into the device creation flow.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			targetAppID := getApplicationID(cmd.Flags(), args)
 			if targetAppID == nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Deprecate end devices claim command. Refs; https://github.com/TheThingsIndustries/lorawan-stack-support/issues/936#issuecomment-1484784745

#### Changes
<!-- What are the changes made in this pull request? -->

- Deprecate `ttn-lw-cli devices claim`
- Add note to Changelog.

#### Testing

<!-- How did you verify that this change works? -->

Locally

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

NA. This feature was broken anyway.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
