### PR TITLE
Round trip decoded payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ For details about compatibility between different releases, see the **Commitment
 - Optional Network Server database migration that removes obsolete last invalidation keys is now available.
 - `Use LoRa Application Layer Clock Sync package` field is now available in the Console.
 
+### Deprecated
+
+- Returning special float values, such as `NaN` and `Infinity` as part of the decoded payloads.
+  - While the concepts of `NaN` and `Infinity` are part of JavaScript, JSON does not have a dedicated value for such values.
+  - Historically we have rendered them in their string form, i.e. `"NaN"` and `"Infinity"`, but this form is not standard nor accepted by the standard libraries of most programming languages (at least by default).
+  - Most usages of `NaN` are actually result of operations with the JavaScript concept of `undefined`, and are not intentional. Mathematical operations that interact with `undefined` return `NaN` - for example `undefined * 5` is `NaN`. It is not hard to reach `undefined` in JavaScript, as array access to undefined indices is `undefined`, and payload decoders generally work by consuming the frame payload bytes.
+  - Future The Things Stack versions may not render such values, or may discard the decoded payload completely. The deprecation discussion can be tracked [on GitHub](https://github.com/TheThingsNetwork/lorawan-stack/issues/6128).
+
 ### Removed
 
 - Automatic migrations of the Network Server database using `ns-db migrate` from versions prior to v3.24 are removed. Migrating from prior versions should be done through v3.24 instead.

--- a/pkg/goproto/validate.go
+++ b/pkg/goproto/validate.go
@@ -1,0 +1,97 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goproto
+
+import (
+	"fmt"
+	"math"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func validateNumber(n float64, prefix string) []string {
+	if math.IsNaN(n) {
+		return []string{fmt.Sprintf("%s: invalid NaN value", prefix)}
+	}
+	if math.IsInf(n, 1) {
+		return []string{fmt.Sprintf("%s: invalid Infinity value", prefix)}
+	}
+	if math.IsInf(n, -1) {
+		return []string{fmt.Sprintf("%s: invalid -Infinity value", prefix)}
+	}
+	return nil
+}
+
+func validateList(l *structpb.ListValue, prefix string) []string {
+	if l == nil {
+		return nil
+	}
+	total := make([]string, 0)
+	for i, v := range l.Values {
+		prefix := fmt.Sprintf("%s[%d]", prefix, i)
+		switch vv := v.GetKind().(type) {
+		case *structpb.Value_NumberValue:
+			if vv == nil {
+				break
+			}
+			total = append(total, validateNumber(vv.NumberValue, prefix)...)
+		case *structpb.Value_StructValue:
+			if vv == nil {
+				break
+			}
+			total = append(total, validateStruct(vv.StructValue, prefix)...)
+		case *structpb.Value_ListValue:
+			if vv == nil {
+				break
+			}
+			total = append(total, validateList(vv.ListValue, prefix)...)
+		}
+	}
+	return total
+}
+
+func validateStruct(st *structpb.Struct, prefix string) []string {
+	if st == nil {
+		return nil
+	}
+	total := make([]string, 0)
+	for k, v := range st.Fields {
+		prefix := fmt.Sprintf("%s.%s", prefix, k)
+		switch vv := v.GetKind().(type) {
+		case *structpb.Value_NumberValue:
+			if vv == nil {
+				break
+			}
+			total = append(total, validateNumber(vv.NumberValue, prefix)...)
+		case *structpb.Value_StructValue:
+			if vv == nil {
+				break
+			}
+			total = append(total, validateStruct(vv.StructValue, prefix)...)
+		case *structpb.Value_ListValue:
+			if vv == nil {
+				break
+			}
+			total = append(total, validateList(vv.ListValue, prefix)...)
+		}
+	}
+	return total
+}
+
+// ValidateStruct recursively verifies if the struct contains any invalid values (NaN, -Infinity, Infinity)
+// and emits warning messages for such fields.
+func ValidateStruct(st *structpb.Struct) []string {
+	return validateStruct(st, "")
+}

--- a/pkg/goproto/validate_test.go
+++ b/pkg/goproto/validate_test.go
@@ -1,0 +1,108 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goproto_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/goproto"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestValidateStruct(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+
+		st       map[string]interface{}
+		expected []string
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "simple object",
+
+			st: map[string]interface{}{
+				"foo": 123,
+			},
+		},
+		{
+			name: "top level NaN",
+
+			st: map[string]interface{}{
+				"foo": math.NaN(),
+			},
+			expected: []string{
+				".foo: invalid NaN value",
+			},
+		},
+		{
+			name: "nested object Infinity",
+
+			st: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": math.Inf(1),
+				},
+			},
+			expected: []string{
+				".foo.bar: invalid Infinity value",
+			},
+		},
+		{
+			name: "nested object -Infinity",
+			st: map[string]interface{}{
+				"foo": []interface{}{
+					math.Inf(-1),
+				},
+			},
+			expected: []string{
+				".foo[0]: invalid -Infinity value",
+			},
+		},
+		{
+			name: "nested object NaN",
+			st: map[string]interface{}{
+				"foo": []interface{}{
+					map[string]interface{}{
+						"bar": math.NaN(),
+					},
+				},
+			},
+			expected: []string{
+				".foo[0].bar: invalid NaN value",
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := assertions.New(t)
+
+			st, err := structpb.NewStruct(tc.st)
+			if !a.So(err, should.BeNil) {
+				t.FailNow()
+			}
+
+			warnings := goproto.ValidateStruct(st)
+			a.So(warnings, should.Resemble, tc.expected)
+		})
+	}
+}

--- a/pkg/messageprocessors/javascript/javascript.go
+++ b/pkg/messageprocessors/javascript/javascript.go
@@ -379,6 +379,11 @@ func (*host) decodeUplink(
 			msg.NormalizedPayloadWarnings = appendValidationErrors(msg.NormalizedPayloadWarnings, normalizedMeasurements)
 		}
 	}
+
+	// Roundtrip the message in order to convert special number values such as NaN and Infinity to their string form.
+	// TODO: Clean up, or fail, the message (https://github.com/TheThingsNetwork/lorawan-stack/issues/6128).
+	msg.DecodedPayload, _ = structpb.NewStruct(msg.DecodedPayload.AsMap())
+
 	return nil
 }
 
@@ -480,5 +485,10 @@ func (*host) decodeDownlink(
 	}
 	msg.DecodedPayload = s
 	msg.DecodedPayloadWarnings = output.Warnings
+
+	// Roundtrip the message in order to convert special number values such as NaN and Infinity to their string form.
+	// TODO: Clean up, or fail, the message (https://github.com/TheThingsNetwork/lorawan-stack/issues/6128).
+	msg.DecodedPayload, _ = structpb.NewStruct(msg.DecodedPayload.AsMap())
+
 	return nil
 }

--- a/pkg/messageprocessors/javascript/javascript.go
+++ b/pkg/messageprocessors/javascript/javascript.go
@@ -381,8 +381,12 @@ func (*host) decodeUplink(
 	}
 
 	// Roundtrip the message in order to convert special number values such as NaN and Infinity to their string form.
-	// TODO: Clean up, or fail, the message (https://github.com/TheThingsNetwork/lorawan-stack/issues/6128).
-	msg.DecodedPayload, _ = structpb.NewStruct(msg.DecodedPayload.AsMap())
+	// TODO: Clean up the message and emit warning (https://github.com/TheThingsNetwork/lorawan-stack/issues/6128).
+	msg.DecodedPayload, err = structpb.NewStruct(decodedPayload.AsMap())
+	if err != nil {
+		return errOutput.WithCause(err)
+	}
+	msg.DecodedPayloadWarnings = append(msg.DecodedPayloadWarnings, goproto.ValidateStruct(decodedPayload)...)
 
 	return nil
 }
@@ -487,8 +491,12 @@ func (*host) decodeDownlink(
 	msg.DecodedPayloadWarnings = output.Warnings
 
 	// Roundtrip the message in order to convert special number values such as NaN and Infinity to their string form.
-	// TODO: Clean up, or fail, the message (https://github.com/TheThingsNetwork/lorawan-stack/issues/6128).
-	msg.DecodedPayload, _ = structpb.NewStruct(msg.DecodedPayload.AsMap())
+	// TODO: Clean up the message and emit warning (https://github.com/TheThingsNetwork/lorawan-stack/issues/6128).
+	msg.DecodedPayload, err = structpb.NewStruct(s.AsMap())
+	if err != nil {
+		return errOutput.WithCause(err)
+	}
+	msg.DecodedPayloadWarnings = append(msg.DecodedPayloadWarnings, goproto.ValidateStruct(s)...)
 
 	return nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/6128

#### Changes
<!-- What are the changes made in this pull request? -->

- Round trip decoded payloads through `structpb.NewStruct` in order to convert special values (`NaN`, `Infinity`) to strings.
- Add a deprecation warning for the handling of such values by future values of The Things Stack.


#### Testing

<!-- How did you verify that this change works? -->

CI and local.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This change changes the binary format for the decoded payload. What this means is that previously `NaN` was encoded as a `Value_NumberValue`. Due to the round trip, it will now be rendered as a `Value_StringValue` instead.

The JSON format is unaffected, and the changes allow such values to be rendered.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
