### PR TITLE
Minor fixes for end device claiming with the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Deprecated
 
+- `--with-claim-authentication-code` flag for the end device `create` command via the CLI. Users must use a valid claim authentication code that is registered on a Join Server instead of generating one during end device creation.
+
 ### Removed
 
 ### Fixed
+
+- Attempting to claim an end device with a generate DevEUI will now result in an error.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
-- Attempting to claim an end device with a generate DevEUI will now result in an error.
+- Attempting to claim an end device with a generated DevEUI will now result in an error.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -168,10 +168,22 @@ func generateKey() *types.AES128Key {
 }
 
 var (
-	errJoinServerDisabled         = errors.DefineFailedPrecondition("join_server_disabled", "Join Server is disabled")
-	errNetworkServerDisabled      = errors.DefineFailedPrecondition("network_server_disabled", "Network Server is disabled")
-	errEndDeviceClaimInfo         = errors.DefineFailedPrecondition("end_device_claim_info", "could not get end device claim info from DCS")
-	errEndDeviceClaim             = errors.DefineFailedPrecondition("end_device_claim", "could not claim end device")
+	errJoinServerDisabled = errors.DefineFailedPrecondition(
+		"join_server_disabled",
+		"Join Server is disabled",
+	)
+	errNetworkServerDisabled = errors.DefineFailedPrecondition(
+		"network_server_disabled",
+		"Network Server is disabled",
+	)
+	errEndDeviceClaimInfo = errors.DefineFailedPrecondition(
+		"end_device_claim_info",
+		"could not get end device claim info from DCS",
+	)
+	errEndDeviceClaim = errors.DefineFailedPrecondition(
+		"end_device_claim",
+		"could not claim end device",
+	)
 	errEndDeviceClaimGeneratedEUI = errors.DefineInvalidArgument(
 		"claim_generated_eui",
 		"cannot claim end device with a randomly generated DevEUI. Use a valid DevEUI registered with a Join Server",
@@ -524,13 +536,14 @@ var (
 
 			claimOnExternalJS := len(device.ClaimAuthenticationCode.GetValue()) > 0
 
-			// TODO: Remove this flag once the legacy DCS is deprecated (https://github.com/TheThingsIndustries/lorawan-stack/issues/3036).
+			// TODO: Remove this flag once the legacy DCS is deprecated
+			// https://github.com/TheThingsIndustries/lorawan-stack/issues/3036
 			if withClaimAuthenticationCode, _ := cmd.Flags().GetBool("with-claim-authentication-code"); withClaimAuthenticationCode {
 				device.ClaimAuthenticationCode = &ttnpb.EndDeviceAuthenticationCode{
 					Value: strings.ToUpper(hex.EncodeToString(random.Bytes(4))),
 				}
 				paths = append(paths, "claim_authentication_code")
-				logger.Warn("Generating claim authentication codes will be deprecated in the future. Use a valid claim authentication code registered with a Join Server instead.")
+				logger.Warn("Generating claim authentication codes will be deprecated in the future. Use a valid claim authentication code registered with a Join Server instead.") //nolint:lll
 			}
 
 			if hasUpdateDeviceLocationFlags(cmd.Flags()) {

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -166,11 +166,14 @@ func generateKey() *types.AES128Key {
 }
 
 var (
-	errJoinServerDisabled    = errors.DefineFailedPrecondition("join_server_disabled", "Join Server is disabled")
-	errNetworkServerDisabled = errors.DefineFailedPrecondition("network_server_disabled", "Network Server is disabled")
-	errEndDeviceClaimInfo    = errors.DefineFailedPrecondition("end_device_claim_info", "could not get end device claim info from DCS")
-	errEndDeviceClaim        = errors.DefineFailedPrecondition("end_device_claim", "could not claim end device")
-	errEndDeviceUnclaim      = errors.DefineFailedPrecondition("end_device_unclaim", "could not unclaim end device")
+	errJoinServerDisabled         = errors.DefineFailedPrecondition("join_server_disabled", "Join Server is disabled")
+	errNetworkServerDisabled      = errors.DefineFailedPrecondition("network_server_disabled", "Network Server is disabled")
+	errEndDeviceClaimInfo         = errors.DefineFailedPrecondition("end_device_claim_info", "could not get end device claim info from DCS")
+	errEndDeviceClaim             = errors.DefineFailedPrecondition("end_device_claim", "could not claim end device")
+	errEndDeviceClaimGeneratedEUI = errors.DefineInvalidArgument(
+		"claim_generated_eui",
+		"cannot claim end device with a randomly generated DevEUI. Use a valid DevEUI registered with a Join Server",
+	)
 )
 
 var (
@@ -564,6 +567,9 @@ var (
 
 			requestDevEUI, _ := cmd.Flags().GetBool("request-dev-eui")
 			if requestDevEUI {
+				if claimOnExternalJS {
+					return errEndDeviceClaimGeneratedEUI.New()
+				}
 				logger.Debug("request-dev-eui flag set, requesting a DevEUI")
 				devEUIResponse, err := ttnpb.NewApplicationRegistryClient(is).IssueDevEUI(ctx, devID.ApplicationIds)
 				if err != nil {

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"encoding/hex"
 	stdio "io"
 	"mime"
 	"os"
@@ -33,7 +32,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
-	"go.thethings.network/lorawan-stack/v3/pkg/random"
 	"go.thethings.network/lorawan-stack/v3/pkg/specification/macspec"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
@@ -518,13 +516,6 @@ var (
 					)
 				}
 			}
-			if withClaimAuthenticationCode, _ := cmd.Flags().GetBool("with-claim-authentication-code"); withClaimAuthenticationCode {
-				device.ClaimAuthenticationCode = &ttnpb.EndDeviceAuthenticationCode{
-					Value: strings.ToUpper(hex.EncodeToString(random.Bytes(4))),
-				}
-				paths = append(paths, "claim_authentication_code")
-			}
-
 			claimOnExternalJS := len(device.ClaimAuthenticationCode.GetValue()) > 0
 
 			if hasUpdateDeviceLocationFlags(cmd.Flags()) {
@@ -1664,6 +1655,13 @@ func init() {
 
 	endDevicesListPhyVersionsCommand.Flags().AddFlagSet(listPhyVersionFlags)
 	endDevicesCommand.AddCommand(endDevicesListPhyVersionsCommand)
+
+	// Deprecate flags.
+	util.DeprecateWithoutForwarding(
+		endDevicesCreateCommand.Flags(),
+		"with-claim-authentication-code",
+		"use a valid claim authentication code registered with a Join Server instead",
+	)
 
 	Root.AddCommand(endDevicesCommand)
 

--- a/cmd/ttn-lw-cli/internal/util/flags.go
+++ b/cmd/ttn-lw-cli/internal/util/flags.go
@@ -40,6 +40,14 @@ func DeprecateFlag(flagSet *pflag.FlagSet, old string, new string) {
 	}
 }
 
+// DeprecateWithoutForwarding deprecates a CLI flag without forwarding it to a new flag.
+func DeprecateWithoutForwarding(flagSet *pflag.FlagSet, flag string, reason string) {
+	if flag := flagSet.Lookup(flag); flag != nil {
+		flag.Deprecated = reason
+		flag.Hidden = true
+	}
+}
+
 // ForwardFlag forwards the flag value of old to new if new is not set while old is.
 func ForwardFlag(flagSet *pflag.FlagSet, old string, new string) {
 	if oldFlag := flagSet.Lookup(old); oldFlag != nil && oldFlag.Changed {

--- a/cmd/ttn-lw-cli/internal/util/flags.go
+++ b/cmd/ttn-lw-cli/internal/util/flags.go
@@ -40,8 +40,8 @@ func DeprecateFlag(flagSet *pflag.FlagSet, old string, new string) {
 	}
 }
 
-// DeprecateWithoutForwarding deprecates a CLI flag without forwarding it to a new flag.
-func DeprecateWithoutForwarding(flagSet *pflag.FlagSet, flag string, reason string) {
+// DeprecateFlagWithoutForwarding deprecates a CLI flag without forwarding it to a new flag.
+func DeprecateFlagWithoutForwarding(flagSet *pflag.FlagSet, flag string, reason string) {
 	if flag := flagSet.Lookup(flag); flag != nil {
 		flag.Deprecated = reason
 		flag.Hidden = true

--- a/config/messages.json
+++ b/config/messages.json
@@ -1331,6 +1331,15 @@
       "file": "simulate.go"
     }
   },
+  "error:cmd/ttn-lw-cli/commands:claim_generated_eui": {
+    "translations": {
+      "en": "cannot claim end device with a randomly generated DevEUI. Use a valid DevEUI registered with a Join Server"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "end_devices.go"
+    }
+  },
   "error:cmd/ttn-lw-cli/commands:conflicting_paths": {
     "translations": {
       "en": "conflicting set and unset field mask paths"
@@ -1406,15 +1415,6 @@
   "error:cmd/ttn-lw-cli/commands:end_device_server_address_mismatch": {
     "translations": {
       "en": "Network/Application/Join Server address mismatch"
-    },
-    "description": {
-      "package": "cmd/ttn-lw-cli/commands",
-      "file": "end_devices.go"
-    }
-  },
-  "error:cmd/ttn-lw-cli/commands:end_device_unclaim": {
-    "translations": {
-      "en": "could not unclaim end device"
     },
     "description": {
       "package": "cmd/ttn-lw-cli/commands",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Minor fixes for End Device claiming with the CLI Refs https://github.com/TheThingsNetwork/lorawan-stack/issues/6131
#### Changes
<!-- What are the changes made in this pull request? -->

- Truly deprecate `with-claim-authentication-code`.
- Prevent claiming if there is no DevEUI.

#### Testing

<!-- How did you verify that this change works? -->

Local

```
go run -tags=tti ./cmd/ttn-lw-cli dev create --with-claim-authentication-code
Flag --with-claim-authentication-code has been deprecated, Use a valid claim authentication code registered with a Join Server instead
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None. 

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We don't actually currently deprecate a flag but forward it's contents to a replacement flag. This PR adds a function for "true" deprecation.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
