### PR TITLE
Do not use connection state in peer computation call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Attempting to claim an end device with a generated DevEUI will now result in an error.
 - Claiming an end device using command line flags.
+- 24 hour stack components deadlock when the default clustering mode is used.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/internal/api/grpc.go
+++ b/cmd/ttn-lw-cli/internal/api/grpc.go
@@ -28,7 +28,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/rpclog"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/rpcretry"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -184,7 +183,7 @@ func CloseAll() {
 	defer connMu.Unlock()
 	for target, conn := range conns {
 		delete(conns, target)
-		if conn == nil || conn.GetState() == connectivity.Shutdown {
+		if conn == nil {
 			continue
 		}
 		conn.Close()

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -27,7 +27,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/random"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -317,18 +316,16 @@ func (c *cluster) Leave() error {
 }
 
 func (c *cluster) GetPeers(ctx context.Context, role ttnpb.ClusterRole) ([]Peer, error) {
-	var matches []Peer
+	matches := make([]Peer, 0, len(c.peers))
 	for _, peer := range c.peers {
 		if !peer.HasRole(role) {
 			continue
 		}
-		conn, err := peer.Conn()
+		_, err := peer.Conn()
 		if err != nil {
 			continue
 		}
-		if conn.GetState() == connectivity.Ready {
-			matches = append(matches, peer)
-		}
+		matches = append(matches, peer)
 	}
 	return matches, nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/grpc/grpc-go/pull/4613

This issue fixes a problem with the cluster package which occurs after the stack has been running for 24 hours. For context, our `pkg/rpcserver` implementation enforces that connections live for 24 hours at most.

https://github.com/TheThingsNetwork/lorawan-stack/blob/9c610e67498a664ababf128acaf27ffe6a5cc653/pkg/rpcserver/rpcserver.go#L203

This is fine, as gRPC clients automatically reconnect when a new RPC is available. However, the above referenced changed their behavior to reconnect on-demand, instead of immediately. This shouldn't be a problem, right ? Wrong.

https://github.com/TheThingsNetwork/lorawan-stack/blob/9c610e67498a664ababf128acaf27ffe6a5cc653/pkg/cluster/cluster.go#L319-L334

Our default cluster implementation skips connections which are not in the `READY` state. This is problematic as connections that are stopped because for example the server has sent a `GOAWAY` message (which does happen with our 24 hour connection time limit) [move to `IDLE`, not `READY`](https://grpc.github.io/grpc/core/md_doc_connectivity-semantics-and-api.html).

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not look at the connection state while evaluating possible peers in the default cluster implementation.
  - The `GetState` API has always been experimental, and it is racing on the connection state anyway.

#### Testing

<!-- How did you verify that this change works? -->

Tested that this is the root cause using the following test:
```go
func TestAutomaticDisconnect(t *testing.T) {
	a := assertions.New(t)

	lis, err := net.Listen("tcp", "127.0.0.1:0")
	if !a.So(err, should.BeNil) {
		t.FailNow()
	}
	defer lis.Close()

	server := grpc.NewServer(
		grpc.KeepaliveParams(keepalive.ServerParameters{
			MaxConnectionAge: 5 * time.Second,
		}),
	)
	go server.Serve(lis)
	defer server.Stop()

	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithInsecure(), grpc.WithBlock())
	if !a.So(err, should.BeNil) {
		t.FailNow()
	}

	a.So(conn.GetState(), should.Equal, connectivity.Ready)

	time.Sleep(6 * time.Second)

	a.So(conn.GetState(), should.Equal, connectivity.Idle)
}
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This fixes a regression in itself. We no longer filter the connections by state now, but this is fine as the default cluster implementation can connect to at most one peer, and the connection state API is unstable anyway.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This will be backported to the `v3.25.1` release. We will also put a warning in the `v3.25.0` release that it should be skipped for single machine deployments.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
