### PR TITLE
console: Fix payload formatters test form

### DIFF
--- a/pkg/webui/console/containers/device-payload-formatters/uplink.js
+++ b/pkg/webui/console/containers/device-payload-formatters/uplink.js
@@ -173,7 +173,10 @@ class DevicePayloadFormatters extends React.PureComponent {
         rx_metadata: [
           { gateway_ids: { gateway_id: 'test' }, rssi: 42, channel_rssi: 42, snr: 4.2 },
         ],
-        settings: { data_rate: { lora: { bandwidth: 125000, spreading_factor: 7 } } },
+        settings: {
+          data_rate: { lora: { bandwidth: 125000, spreading_factor: 7 } },
+          frequency: 868000000,
+        },
       },
       version_ids: Object.keys(version_ids).length > 0 ? version_ids : undefined,
       formatter,


### PR DESCRIPTION
#### Summary

References #6151 

The new validation introduced in PR #6151 broke the payload formatters test form.
This commit applies the same fix used previously in the `UplinkForm` component.

#### Changes

- Set frequency to 868MHz when testing payload formatters.

#### Testing

- Manual tests

##### Regressions

- None

#### Notes for Reviewers

Same fix was used here: https://github.com/TheThingsNetwork/lorawan-stack/pull/6151/commits/775746a3c4c95d2bfbde603320349b35e0fbf929

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
