### PR TITLE
Skip AWS credentials configuration if secrets are missing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -84,6 +84,7 @@ jobs:
           entrypoint: /usr/bin/createdb
           args: -h postgres -U root ttn_lorawan_is_store_test
       - name: Configure AWS Credentials
+        if: "${{ secrets.AWS_REGION != '' }}"
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: "${{ secrets.AWS_REGION }}"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes the AWS credentials login action conditional on the presence of the AWS region secret. This should ensure that the AWS credentials are not configured by forks, and that the AWS tests are skipped.
