### PR TITLE
Fix CI usage of secrets

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -84,12 +84,14 @@ jobs:
           entrypoint: /usr/bin/createdb
           args: -h postgres -U root ttn_lorawan_is_store_test
       - name: Configure AWS Credentials
-        if: "${{ secrets.AWS_REGION != '' }}"
+        if: "${{ env.AWS_REGION != '' }}"
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: "${{ secrets.AWS_REGION }}"
           role-to-assume: "arn:aws:iam::${{ secrets.AWS_USER_ID }}:role/${{ secrets.AWS_ROLE_NAME }}"
           role-session-name: "${{ secrets.AWS_ROLE_NAME }}-${{ github.job }}-${{ github.run_id }}"
+        env:
+          AWS_REGION: "${{ secrets.AWS_REGION }}"
       - name: Check out code
         uses: actions/checkout@v3
       - name: Install Go and Dependencies


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/github/docs/issues/6861
References https://github.com/TheThingsNetwork/lorawan-stack/pull/6154#issuecomment-1508619342

Apparently `secrets` are not available as part of `if`, so we need to inject the secret (which is not really secret, the region is not that special) as an environment variable and compare that.

#### Changes
<!-- What are the changes made in this pull request? -->

- Inject the `AWS_REGION` as an environment variable, and then use it for the comparison.


#### Testing

<!-- How did you verify that this change works? -->

CI.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This fixes a regression in itself.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
