### PR TITLE
Fix region name usage in Basics Station

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For details about compatibility between different releases, see the **Commitment
 - LoRa Basics Station `PONG` messages will now contain the application payload of the associated `PING`, as required by the WebSockets specification.
   - This fix enables `PING`/`PONG` behavior for non reference implementations of the LNS protocol.
 - Fix crash of "Edit webhook" view due to invalid Authorization header encoding in the Console.
+- LoRa Basics Station 2.0.6 downlink support in the `AS923` region.
 
 ### Security
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes our usage of the `region` field in the `router_config` we send to Basics Station gateways.

Version 2.0.6 of Basics Station started being more thorough in the checks it does for the region names. Historically, you could provide any `region` and unknown regions would just be [silently accepted without any form of validation](https://github.com/lorabasics/basicstation/blob/817e6e1e7f0c3affce078bac7b060ba675043664/src/s2e.c#L957-L1000).

Version 2.0.6 [no longer does that](https://github.com/lorabasics/basicstation/blob/ba4f85d80a438a5c2b659e568cd2d0f0de08e5a7/src/s2e.c#L973-L1041). If we send an 'unknown' `region`, Basics Station [will refuse any downlinks](https://github.com/lorabasics/basicstation/blob/ba4f85d80a438a5c2b659e568cd2d0f0de08e5a7/src/s2e.c#L1794-L1798).

#### Changes
<!-- What are the changes made in this pull request? -->

- Convert the band IDs to region IDs using explicit mappings.
   - The resulting region is the region which was previously used, except for `AS923` which was supposed to be `AS923JP` actually.
   - Since we send the legacy names, we ensure that versions predating 2.0.6 also continue to act the same.


#### Testing

<!-- How did you verify that this change works? -->

Local testing with my physical gateway fleet, unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Certain gateway vendors _may_ use the `region` field to limit the regions in which the gateway operates. If they were expecting the wrong value for `AS923` (`AS923` instead of `AS923JP`), we may have some compatibility issues.

Preliminary assessment of connected gateways connected to TTSC shows that we don't have large fleets of Basic Station gateways connected with `AS923`-based frequency plans.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
