### PR TITLE
Avoid automaxprocs logs

### DIFF
--- a/cmd/internal/shared/init.go
+++ b/cmd/internal/shared/init.go
@@ -19,8 +19,6 @@ import (
 
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
-
-	_ "go.uber.org/automaxprocs" // Automatically set `GOMAXPROCS` in derived commands.
 )
 
 // InitializeFallbacks initializes configuration fallbacks.

--- a/cmd/ttn-lw-stack/commands/root.go
+++ b/cmd/ttn-lw-stack/commands/root.go
@@ -32,6 +32,7 @@ import (
 	logobservability "go.thethings.network/lorawan-stack/v3/pkg/log/middleware/observability"
 	logsentry "go.thethings.network/lorawan-stack/v3/pkg/log/middleware/sentry"
 	pkgversion "go.thethings.network/lorawan-stack/v3/pkg/version"
+	"go.uber.org/automaxprocs/maxprocs"
 )
 
 var errMissingFlag = errors.DefineInvalidArgument("missing_flag", "missing CLI flag `{flag}`")
@@ -103,6 +104,10 @@ var (
 					return err
 				}
 				logger.Use(logsentry.New())
+			}
+
+			if _, err := maxprocs.Set(); err != nil {
+				logger.WithError(err).Debug("Failed to set GOMAXPROCS")
 			}
 
 			ctx = log.NewContext(ctx, logger)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/6149

This PR uses `maxprocs` implicitly in order to avoid logs to `stderr`. It also moves the initialization to the `ttn-lw-stack` command, as the CLI will not benefit from the `automaxprocs`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Manually call `maxprocs.Set` instead of depending on the `init` of `automaxprocs`.


#### Testing

<!-- How did you verify that this change works? -->

Local testing and checking that the message is not visible.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

No need to review - the PR exists for historical context.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
