### PR TITLE
Add soil to the normalized message preview in the events view

### DIFF
--- a/pkg/webui/console/components/events/previews/application-uplink-normalized.js
+++ b/pkg/webui/console/components/events/previews/application-uplink-normalized.js
@@ -33,6 +33,11 @@ const ApplicationUplinkNormalizedPreview = React.memo(({ event }) => {
   return (
     <DescriptionList>
       <DescriptionList.Byte title={messages.devAddr} data={deviceIds.dev_addr} />
+      {data.normalized_payload.soil && (
+        <DescriptionList.Item title={sharedMessages.normalizedPayloadSoil}>
+          <JSONPayload data={data.normalized_payload.soil} />
+        </DescriptionList.Item>
+      )}
       {data.normalized_payload.air && (
         <DescriptionList.Item title={sharedMessages.normalizedPayloadAir}>
           <JSONPayload data={data.normalized_payload.air} />

--- a/pkg/webui/console/components/events/previews/application-uplink-normalized.js
+++ b/pkg/webui/console/components/events/previews/application-uplink-normalized.js
@@ -14,8 +14,6 @@
 
 import React from 'react'
 
-import { getDataRate, getSignalInformation } from '@console/components/events/utils'
-
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
@@ -27,8 +25,6 @@ import JSONPayload from './shared/json-payload'
 const ApplicationUplinkNormalizedPreview = React.memo(({ event }) => {
   const { data, identifiers } = event
   const deviceIds = identifiers[0].device_ids
-  const { snr, rssi } = getSignalInformation(data)
-  const dataRate = getDataRate(data)
 
   return (
     <DescriptionList>
@@ -48,10 +44,6 @@ const ApplicationUplinkNormalizedPreview = React.memo(({ event }) => {
           <JSONPayload data={data.normalized_payload.wind} />
         </DescriptionList.Item>
       )}
-      <DescriptionList.Item title={messages.fPort} data={data.f_port} />
-      <DescriptionList.Item title={messages.dataRate} data={dataRate} />
-      <DescriptionList.Item title={messages.snr} data={snr} />
-      <DescriptionList.Item title={messages.rssi} data={rssi} />
     </DescriptionList>
   )
 })

--- a/pkg/webui/lib/shared-messages.js
+++ b/pkg/webui/lib/shared-messages.js
@@ -298,6 +298,7 @@ export default defineMessages({
   noLocation: 'No location information available',
   noMatch: 'No items found',
   none: 'None',
+  normalizedPayloadSoil: 'Soil',
   normalizedPayloadAir: 'Air',
   normalizedPayloadWind: 'Wind',
   notAvailable: 'n/a',

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -1366,6 +1366,7 @@
   "lib.shared-messages.noLocation": "No location information available",
   "lib.shared-messages.noMatch": "No items found",
   "lib.shared-messages.none": "None",
+  "lib.shared-messages.normalizedPayloadSoil": "Soil",
   "lib.shared-messages.normalizedPayloadAir": "Air",
   "lib.shared-messages.normalizedPayloadWind": "Wind",
   "lib.shared-messages.notAvailable": "n/a",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Part of #5758 
Follow-up  to #6154

![image](https://user-images.githubusercontent.com/51208565/232792935-4db4eee7-1e73-4e19-9ced-5986b9e4cd9e.png)


#### Changes
<!-- What are the changes made in this pull request? -->

- Add Soil object to the event view
- Clean preview UI of the normalized uplink messages


#### Testing

<!-- How did you verify that this change works? -->

- Manual tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

- None

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I've decided to remove FPort, data rate, SNR and RSSI from the preview of normalized
uplink messages because these previews can get quite long and messy as the number of objects and properties in the normalized schema grows. I think that they are not critical info to have there either, because these values are the same that in the normal uplink message.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
