### PR TITLE
Check frontend stream status before emiting stats message

### DIFF
--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -452,6 +452,7 @@ func (gs *GatewayServer) Connect(
 	frontend io.Frontend,
 	ids *ttnpb.GatewayIdentifiers,
 	addr *ttnpb.GatewayRemoteAddress,
+	opts ...io.ConnectionOption,
 ) (*io.Connection, error) {
 	if err := gs.entityRegistry.AssertGatewayRights(ctx, ids, ttnpb.Right_RIGHT_GATEWAY_LINK); err != nil {
 		return nil, err
@@ -520,7 +521,7 @@ func (gs *GatewayServer) Connect(
 	}
 
 	conn, err := io.NewConnection(
-		ctx, frontend, gtw, fps, gtw.EnforceDutyCycle, ttnpb.StdDuration(gtw.ScheduleAnytimeDelay), addr,
+		ctx, frontend, gtw, fps, gtw.EnforceDutyCycle, ttnpb.StdDuration(gtw.ScheduleAnytimeDelay), addr, opts...,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -116,10 +116,10 @@ func TestGatewayServer(t *testing.T) {
 						Config: udp.Config{
 							PacketHandlers:      2,
 							PacketBuffer:        10,
-							DownlinkPathExpires: 100 * time.Millisecond,
-							ConnectionExpires:   250 * time.Millisecond,
+							DownlinkPathExpires: 1 * time.Second,
+							ConnectionExpires:   2 * time.Second,
 							ScheduleLateTime:    0,
-							AddrChangeBlock:     250 * time.Millisecond,
+							AddrChangeBlock:     2 * time.Second,
 						},
 						Listeners: map[string]string{
 							":1700": test.EUFrequencyPlanID,

--- a/pkg/gatewayserver/io/mock/server.go
+++ b/pkg/gatewayserver/io/mock/server.go
@@ -82,6 +82,7 @@ func (s *server) Connect(
 	frontend io.Frontend,
 	ids *ttnpb.GatewayIdentifiers,
 	addr *ttnpb.GatewayRemoteAddress,
+	opts ...io.ConnectionOption,
 ) (*io.Connection, error) {
 	if err := rights.RequireGateway(ctx, ids, ttnpb.Right_RIGHT_GATEWAY_LINK); err != nil {
 		return nil, err
@@ -98,7 +99,7 @@ func (s *server) Connect(
 		return nil, err
 	}
 
-	conn, err := io.NewConnection(ctx, frontend, gtw, fps, true, nil, addr)
+	conn, err := io.NewConnection(ctx, frontend, gtw, fps, true, nil, addr, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gatewayserver/io/stream_state.go
+++ b/pkg/gatewayserver/io/stream_state.go
@@ -18,11 +18,11 @@ package io
 type MessageStream uint32
 
 const (
-	UplinkStream   MessageStream = 0 // UplinkStream is the uplink message stream.
-	DownlinkStream MessageStream = 1 // DownlinkStream is the downlink message stream.
-	TxAckStream    MessageStream = 2 // TxAckStream is the transmission acknowledgment stream.
-	StatusStream   MessageStream = 3 // StatusStream is the status message stream.
-	RTTStream      MessageStream = 4 // RTTStream is the round-trip times stream.
+	UplinkStream   MessageStream = iota // UplinkStream is the uplink message stream.
+	DownlinkStream                      // DownlinkStream is the downlink message stream.
+	TxAckStream                         // TxAckStream is the transmission acknowledgment stream.
+	StatusStream                        // StatusStream is the status message stream.
+	RTTStream                           // RTTStream is the round-trip times stream.
 )
 
 func alwaysOnStreamState(MessageStream) bool { return true }

--- a/pkg/gatewayserver/io/stream_state.go
+++ b/pkg/gatewayserver/io/stream_state.go
@@ -1,0 +1,28 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+// MessageStream is a message stream.
+type MessageStream uint32
+
+const (
+	UplinkStream   MessageStream = 0 // UplinkStream is the uplink message stream.
+	DownlinkStream MessageStream = 1 // DownlinkStream is the downlink message stream.
+	TxAckStream    MessageStream = 2 // TxAckStream is the transmission acknowledgment stream.
+	StatusStream   MessageStream = 3 // StatusStream is the status message stream.
+	RTTStream      MessageStream = 4 // RTTStream is the round-trip times stream.
+)
+
+func alwaysOnStreamState(MessageStream) bool { return true }

--- a/pkg/gatewayserver/io/udp/firewall_ratelimit.go
+++ b/pkg/gatewayserver/io/udp/firewall_ratelimit.go
@@ -51,13 +51,9 @@ func (f *rateLimitingFirewall) Filter(packet encoding.Packet) error {
 	}
 	now := time.Now().UTC()
 	eui := *packet.GatewayEUI
-	val, ok := f.m.Load(eui)
-	var ts *timestamps
-	if ok {
+	ts := newTimestamps(f.messages)
+	if val, ok := f.m.LoadOrStore(eui, ts); ok {
 		ts = val.(*timestamps)
-	} else {
-		ts = newTimestamps(f.messages)
-		f.m.Store(eui, ts)
 	}
 
 	oldestTimestamp := ts.Append(now)

--- a/pkg/gatewayserver/io/ws/lbslns/discover_util_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/discover_util_test.go
@@ -38,7 +38,7 @@ func (srv mockServer) FillGatewayContext(ctx context.Context, ids *ttnpb.Gateway
 }
 
 func (mockServer) Connect(
-	_ context.Context, _ io.Frontend, _ *ttnpb.GatewayIdentifiers, _ *ttnpb.GatewayRemoteAddress,
+	context.Context, io.Frontend, *ttnpb.GatewayIdentifiers, *ttnpb.GatewayRemoteAddress, ...io.ConnectionOption,
 ) (*io.Connection, error) {
 	return nil, nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/6160

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a simple stream states mechanism which allows GS frontends to be queried if a stream is still active.
- Fix a race condition in the rate limiting UDP frontend.

#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This functionality affects only stats book keeping, without affecting the hot path behavior.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
