### PR TITLE
Show reactivation warning only on unhealthy

### DIFF
--- a/pkg/webui/console/components/webhook-form/index.js
+++ b/pkg/webui/console/components/webhook-form/index.js
@@ -392,10 +392,9 @@ export default class WebhookForm extends Component {
 
     const hasTemplate = Boolean(webhookTemplate)
 
-    const mayReactivate =
-      update && hasUnhealthyWebhookConfig && !initialWebhookValue?.health_status?.healthy
-
-    const isPending = healthStatusEnabled && update && !initialWebhookValue?.health_status
+    const healthStatus = initialWebhookValue?.health_status
+    const mayReactivate = update && hasUnhealthyWebhookConfig && healthStatus?.unhealthy
+    const isPending = update && healthStatusEnabled && !healthStatus
 
     return (
       <>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR changes the webhook re-activation button and warning only if the webhook is unhealthy, not if it is not healthy (as a pending webhook is also not healthy).

#### Changes
<!-- What are the changes made in this pull request? -->

- Show the webhook re-activation warning only if the webhook is unhealthy.


#### Testing

<!-- How did you verify that this change works? -->

Local.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Can be tested on [staging1](https://tti.staging1.cloud.thethings.industries/console/applications/testttt/integrations/webhooks/qwe).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
