### PR TITLE
Remove unused invalidation key

### DIFF
--- a/pkg/networkserver/redis/redis.go
+++ b/pkg/networkserver/redis/redis.go
@@ -20,7 +20,6 @@ import (
 	"hash/fnv"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
-	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 )
 
 type keyer interface {
@@ -29,10 +28,6 @@ type keyer interface {
 
 func UIDKey(r keyer, uid string) string {
 	return r.Key("uid", uid)
-}
-
-func uidLastInvalidationKey(r keyer, uid string) string {
-	return ttnredis.Key(UIDKey(r, uid), "last-invalidation")
 }
 
 var keyEncoding = base64.RawStdEncoding

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -749,7 +749,6 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID *ttnpb.ApplicationId
 			if pb == nil && len(sets) == 0 {
 				trace.Log(ctx, "ns:redis", "delete end device")
 				p.Del(ctx, uk)
-				p.Del(ctx, uidLastInvalidationKey(r.Redis, uid))
 				if stored.Ids.JoinEui != nil && stored.Ids.DevEui != nil {
 					p.Del(
 						ctx,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/6043

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the references to `invalidation-key` in the NS device registry, as the above mentioned migration already has deleted the keys (and we haven't been setting the key for a long time).

#### Testing

<!-- How did you verify that this change works? -->

N/A. This just removes a no-op operation.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@cvetkovski98 please take a look.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
