### PR TITLE
Network Server ADR coding style changes

### DIFF
--- a/pkg/specification/macspec/specification.go
+++ b/pkg/specification/macspec/specification.go
@@ -69,13 +69,8 @@ func HasMaxFCntGap(v ttnpb.MACVersion) bool {
 	return compareMACVersion(v, ttnpb.MACVersion_MAC_V1_0_4) < 0
 }
 
-// HasNoChangeTXPowerIndex reports whether v defines a no-change TxPowerIndex value.
-func HasNoChangeTXPowerIndex(v ttnpb.MACVersion) bool {
-	return compareMACVersion(v, ttnpb.MACVersion_MAC_V1_0_4) >= 0
-}
-
-// HasNoChangeDataRateIndex reports whether v defines a no-change DataRateIndex value.
-func HasNoChangeDataRateIndex(v ttnpb.MACVersion) bool {
+// HasNoChangeADRIndices reports whether v defines a no-change TxPowerIndex and DataRateIndexValue.
+func HasNoChangeADRIndices(v ttnpb.MACVersion) bool {
 	return compareMACVersion(v, ttnpb.MACVersion_MAC_V1_0_4) >= 0
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/5551

#### Changes
<!-- What are the changes made in this pull request? -->

- Refactor the `LinkADRReq` command generation to use aliases, such as `macState`, `desiredParameters` and `currentParameters`.
  - This is in preparation for some larger changes for the above mentioned issue, and in general reduces the very long, error-prone variable access.


#### Testing

<!-- How did you verify that this change works? -->

UT.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. There are no semantical changes in this PR.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

No need to review. CI will suffice.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
