### PR TITLE
Network Server ADR rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Multiple ADR algorithm bugs:
+  - An off-by-one error which caused the ADR algorithm to not take into consideration the signal qualities of the uplink which confirmed a parameter change. In effect, this fix improves the quality of the link budget estimation.
+  - A flip-flop condition which caused the algorithm to swap back and forth between a higher and a lower transmission power index every 20 uplinks. In effect, this fix will cause the algorithm to change the transmission power index less often.
+  - A condition mistake which caused the algorithm to avoid increasing the transmission power if it would not completely fix the missing link budget. In effect, this will cause the algorithm to increase the transmission power in situations in which the link budget deteriorates rapidly.
+
 ### Security
 
 ## [3.25.1] - 2023-04-18

--- a/pkg/networkserver/mac/adr.go
+++ b/pkg/networkserver/mac/adr.go
@@ -312,7 +312,7 @@ func adrUplinks(macState *ttnpb.MACState, phy *band.Band) []*ttnpb.MACState_Upli
 		}
 		switch {
 		case up.Payload.MHdr.MType != ttnpb.MType_UNCONFIRMED_UP && up.Payload.MHdr.MType != ttnpb.MType_CONFIRMED_UP,
-			macState.LastAdrChangeFCntUp != 0 && up.Payload.GetMacPayload().FullFCnt <= macState.LastAdrChangeFCntUp,
+			macState.LastAdrChangeFCntUp != 0 && up.Payload.GetMacPayload().FullFCnt < macState.LastAdrChangeFCntUp,
 			drIdx != currentDataRateIndex:
 			return macState.RecentUplinks[i+1:]
 		}

--- a/pkg/networkserver/mac/adr.go
+++ b/pkg/networkserver/mac/adr.go
@@ -328,7 +328,7 @@ func AdaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, de
 		return nil
 	}
 
-	minDataRateIndex, maxDataRateIndex, ok := channelDataRateRange(desiredParameters.Channels...)
+	minDataRateIndex, maxDataRateIndex, _, ok := channelDataRateRange(desiredParameters.Channels...)
 	if !ok {
 		return internal.ErrCorruptedMACState.
 			WithCause(internal.ErrChannelDataRateRange)

--- a/pkg/networkserver/mac/adr.go
+++ b/pkg/networkserver/mac/adr.go
@@ -485,9 +485,12 @@ func adrAdaptTxPowerIndex(
 		desiredParameters.AdrTxPowerIndex = max
 	}
 	// If we still have margin left, we decrease the TX output power (increase the index).
-	for txPowerIdx := max; txPowerIdx > min; txPowerIdx-- {
+	// We can also compensate the missing margin by increasing the TX output power (decreasing the index).
+	for txPowerIdx := max; txPowerIdx >= min; txPowerIdx-- {
 		diff := txPowerStep(phy, desiredParameters.AdrTxPowerIndex, txPowerIdx)
-		if _, ok := rejected[txPowerIdx]; ok || diff > margin {
+		// As long as we are not at the minimal transmission power index, we skip
+		// rejected indices or indices which do not fit in the margin.
+		if _, ok := rejected[txPowerIdx]; (ok || diff > margin) && txPowerIdx != min {
 			continue
 		}
 		if !optimal && diff < 0 && -diff <= safetyMargin {

--- a/pkg/networkserver/mac/adr.go
+++ b/pkg/networkserver/mac/adr.go
@@ -215,8 +215,8 @@ func uplinkMetadata(ups ...*ttnpb.MACState_UplinkMessage) []*ttnpb.MACState_Upli
 	return mds
 }
 
-func txPowerStep(phy *band.Band, from, to uint8) float32 {
-	max := phy.MaxTxPowerIndex()
+func txPowerStep(phy *band.Band, from, to uint32) float32 {
+	max := uint32(phy.MaxTxPowerIndex())
 	if from > max {
 		from = max
 	}
@@ -226,7 +226,9 @@ func txPowerStep(phy *band.Band, from, to uint8) float32 {
 	return phy.TxOffset[from] - phy.TxOffset[to]
 }
 
-func clampDataRateRange(dev *ttnpb.EndDevice, defaults *ttnpb.MACSettings, minDataRateIndex, maxDataRateIndex ttnpb.DataRateIndex) (min, max ttnpb.DataRateIndex) {
+func clampDataRateRange(
+	dev *ttnpb.EndDevice, defaults *ttnpb.MACSettings, minDataRateIndex, maxDataRateIndex ttnpb.DataRateIndex,
+) (min, max ttnpb.DataRateIndex) {
 	clamp := func(dynamicSettings *ttnpb.ADRSettings_DynamicMode) (min, max ttnpb.DataRateIndex) {
 		min, max = minDataRateIndex, maxDataRateIndex
 		minSetting, maxSetting := dynamicSettings.MinDataRateIndex, dynamicSettings.MaxDataRateIndex
@@ -250,15 +252,17 @@ func clampDataRateRange(dev *ttnpb.EndDevice, defaults *ttnpb.MACSettings, minDa
 	}
 }
 
-func clampTxPowerRange(dev *ttnpb.EndDevice, defaults *ttnpb.MACSettings, minTxPowerIndex, maxTxPowerIndex uint8) (min, max uint8) {
-	clamp := func(dynamicSettings *ttnpb.ADRSettings_DynamicMode) (min, max uint8) {
+func clampTxPowerRange(
+	dev *ttnpb.EndDevice, defaults *ttnpb.MACSettings, minTxPowerIndex, maxTxPowerIndex uint32,
+) (min, max uint32) {
+	clamp := func(dynamicSettings *ttnpb.ADRSettings_DynamicMode) (min, max uint32) {
 		min, max = minTxPowerIndex, maxTxPowerIndex
 		minSetting, maxSetting := dynamicSettings.MinTxPowerIndex, dynamicSettings.MaxTxPowerIndex
-		if minSetting != nil && uint8(minSetting.Value) > minTxPowerIndex {
-			min = uint8(minSetting.Value)
+		if minSetting != nil && minSetting.Value > minTxPowerIndex {
+			min = minSetting.Value
 		}
-		if maxSetting != nil && uint8(maxSetting.Value) < maxTxPowerIndex {
-			max = uint8(maxSetting.Value)
+		if maxSetting != nil && maxSetting.Value < maxTxPowerIndex {
+			max = maxSetting.Value
 		}
 		return min, max
 	}
@@ -298,123 +302,141 @@ func clampNbTrans(dev *ttnpb.EndDevice, defaults *ttnpb.MACSettings, nbTrans uin
 	}
 }
 
-// AdaptDataRate adapts the end device desired ADR parameters based on previous transmissions and device settings.
-func AdaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, defaults *ttnpb.MACSettings) error {
-	macState := dev.MacState
-	if macState == nil {
-		return nil
-	}
-
-	currentParameters, desiredParameters := macState.CurrentParameters, macState.DesiredParameters
-	currentDataRateIndex := currentParameters.AdrDataRateIndex
-
-	adrUplinks := func() []*ttnpb.MACState_UplinkMessage {
-		for i := len(macState.RecentUplinks) - 1; i >= 0; i-- {
-			up := macState.RecentUplinks[i]
-			drIdx, _, ok := phy.FindUplinkDataRate(up.Settings.DataRate)
-			if !ok {
-				continue
-			}
-			switch {
-			case up.Payload.MHdr.MType != ttnpb.MType_UNCONFIRMED_UP && up.Payload.MHdr.MType != ttnpb.MType_CONFIRMED_UP,
-				macState.LastAdrChangeFCntUp != 0 && up.Payload.GetMacPayload().FullFCnt <= macState.LastAdrChangeFCntUp,
-				drIdx != currentDataRateIndex:
-				return macState.RecentUplinks[i+1:]
-			}
+func adrUplinks(macState *ttnpb.MACState, phy *band.Band) []*ttnpb.MACState_UplinkMessage {
+	currentDataRateIndex := macState.CurrentParameters.AdrDataRateIndex
+	for i := len(macState.RecentUplinks) - 1; i >= 0; i-- {
+		up := macState.RecentUplinks[i]
+		drIdx, _, ok := phy.FindUplinkDataRate(up.Settings.DataRate)
+		if !ok {
+			continue
 		}
-		return macState.RecentUplinks
-	}()
-	if len(adrUplinks) == 0 {
+		switch {
+		case up.Payload.MHdr.MType != ttnpb.MType_UNCONFIRMED_UP && up.Payload.MHdr.MType != ttnpb.MType_CONFIRMED_UP,
+			macState.LastAdrChangeFCntUp != 0 && up.Payload.GetMacPayload().FullFCnt <= macState.LastAdrChangeFCntUp,
+			drIdx != currentDataRateIndex:
+			return macState.RecentUplinks[i+1:]
+		}
+	}
+	return macState.RecentUplinks
+}
+
+func indicesMap[T comparable](indices ...T) map[T]struct{} {
+	if len(indices) == 0 {
 		return nil
 	}
+	m := make(map[T]struct{}, len(indices))
+	for _, idx := range indices {
+		m[idx] = struct{}{}
+	}
+	return m
+}
 
-	minDataRateIndex, maxDataRateIndex, _, ok := channelDataRateRange(desiredParameters.Channels...)
+func adrDataRateRange(
+	ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, defaults *ttnpb.MACSettings,
+) (min, max ttnpb.DataRateIndex, rejected map[ttnpb.DataRateIndex]struct{}, ok bool, err error) {
+	macState := dev.MacState
+	min, max, _, ok = channelDataRateRange(
+		macState.DesiredParameters.Channels...,
+	)
 	if !ok {
-		return internal.ErrCorruptedMACState.
+		return 0, 0, nil, false, internal.ErrCorruptedMACState.
 			WithCause(internal.ErrChannelDataRateRange)
 	}
-	minDataRateIndex, maxDataRateIndex = clampDataRateRange(dev, defaults, minDataRateIndex, maxDataRateIndex)
-	if minDataRateIndex > maxDataRateIndex {
+	min, max = clampDataRateRange(dev, defaults, min, max)
+	if min > max {
 		log.FromContext(ctx).Debug("No common data rate index range available, avoid ADR")
-		return nil
+		return 0, 0, nil, false, nil
 	}
-	if maxDataRateIndex > phy.MaxADRDataRateIndex {
-		maxDataRateIndex = phy.MaxADRDataRateIndex
+	if max > phy.MaxADRDataRateIndex {
+		max = phy.MaxADRDataRateIndex
 	}
-	rejectedDataRateIndexes := make(map[ttnpb.DataRateIndex]struct{}, len(macState.RejectedAdrDataRateIndexes))
-	for _, idx := range macState.RejectedAdrDataRateIndexes {
-		rejectedDataRateIndexes[idx] = struct{}{}
+	rejected = indicesMap(macState.RejectedAdrDataRateIndexes...)
+	_, ok = rejected[min]
+	for ok && min <= max {
+		min++
+		_, ok = rejected[min]
 	}
-	_, ok = rejectedDataRateIndexes[minDataRateIndex]
-	for ok && minDataRateIndex <= maxDataRateIndex {
-		minDataRateIndex++
-		_, ok = rejectedDataRateIndexes[minDataRateIndex]
+	_, ok = rejected[max]
+	for ok && max >= min {
+		max--
+		_, ok = rejected[max]
 	}
-	_, ok = rejectedDataRateIndexes[maxDataRateIndex]
-	for ok && maxDataRateIndex >= minDataRateIndex {
-		maxDataRateIndex--
-		_, ok = rejectedDataRateIndexes[maxDataRateIndex]
-	}
-	if minDataRateIndex > maxDataRateIndex {
+	if min > max {
 		log.FromContext(ctx).Debug(
 			"Device has rejected all possible data rate values given the channels enabled, avoid ADR",
 		)
-		return nil
+		return 0, 0, nil, false, nil
 	}
-	if currentDataRateIndex > minDataRateIndex {
-		minDataRateIndex = currentDataRateIndex
+	if currentDataRateIndex := macState.CurrentParameters.AdrDataRateIndex; currentDataRateIndex > min {
+		min = currentDataRateIndex
 	}
+	return min, max, rejected, true, nil
+}
 
-	minTxPowerIndex := uint8(0)
-	maxTxPowerIndex := phy.MaxTxPowerIndex()
-	minTxPowerIndex, maxTxPowerIndex = clampTxPowerRange(dev, defaults, minTxPowerIndex, maxTxPowerIndex)
-	if minTxPowerIndex > maxTxPowerIndex {
+func adrTxPowerRange(
+	ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, defaults *ttnpb.MACSettings,
+) (min, max uint32, rejected map[uint32]struct{}, ok bool) {
+	min, max = uint32(0), uint32(phy.MaxTxPowerIndex())
+	min, max = clampTxPowerRange(dev, defaults, min, max)
+	if min > max {
 		log.FromContext(ctx).Debug("No common TX power index range available, avoid ADR")
-		return nil
+		return 0, 0, nil, false
 	}
-	rejectedTxPowerIndexes := make(map[uint8]struct{}, len(macState.RejectedAdrTxPowerIndexes))
-	for _, idx := range macState.RejectedAdrTxPowerIndexes {
-		rejectedTxPowerIndexes[uint8(idx)] = struct{}{}
+	rejected = indicesMap(dev.MacState.RejectedAdrTxPowerIndexes...)
+	_, ok = rejected[min]
+	for ok && min <= max {
+		min++
+		_, ok = rejected[min]
 	}
-	_, ok = rejectedTxPowerIndexes[minTxPowerIndex]
-	for ok && minTxPowerIndex <= maxTxPowerIndex {
-		minTxPowerIndex++
-		_, ok = rejectedTxPowerIndexes[minTxPowerIndex]
+	_, ok = rejected[max]
+	for ok && max >= min {
+		max--
+		_, ok = rejected[max]
 	}
-	_, ok = rejectedTxPowerIndexes[maxTxPowerIndex]
-	for ok && maxTxPowerIndex >= minTxPowerIndex {
-		maxTxPowerIndex--
-		_, ok = rejectedTxPowerIndexes[maxTxPowerIndex]
-	}
-	if minTxPowerIndex > maxTxPowerIndex {
+	if min > max {
 		log.FromContext(ctx).Debug("Device has rejected all possible TX output power index values, avoid ADR")
-		return nil
+		return 0, 0, nil, false
 	}
+	return min, max, rejected, true
+}
 
+func adrMargin(
+	ctx context.Context, dev *ttnpb.EndDevice, defaults *ttnpb.MACSettings, adrUplinks ...*ttnpb.MACState_UplinkMessage,
+) (margin float32, ok bool, err error) {
 	maxSNR, ok := maxSNRFromMetadata(uplinkMetadata(adrUplinks...)...)
 	if !ok {
 		log.FromContext(ctx).Debug("Failed to determine max SNR, avoid ADR")
-		return nil
+		return 0, false, nil
 	}
-
 	// The link margin indicates how much stronger the signal (SNR) is than the
 	// minimum (floor) that we need to demodulate the signal. We subtract a
 	// configurable margin, and an extra safety margin if we're afraid that we
 	// don't have enough data for our decision.
-	var margin float32
 	// NOTE: We currently assume that the uplink's SF and BW correspond to currentDataRateIndex.
 	if dr := internal.LastUplink(adrUplinks...).Settings.DataRate.GetLora(); dr != nil {
 		var ok bool
 		df, ok := demodulationFloor[dr.SpreadingFactor][dr.Bandwidth]
 		if !ok {
-			return internal.ErrInvalidDataRate.New()
+			return 0, false, internal.ErrInvalidDataRate.New()
 		}
 		margin = maxSNR - df - DeviceADRMargin(dev, defaults)
 	}
 	if len(adrUplinks) < OptimalADRUplinkCount {
 		margin -= safetyMargin
 	}
+	return margin, true, nil
+}
 
+func adrAdaptDataRate(
+	macState *ttnpb.MACState,
+	phy *band.Band,
+	minDataRateIndex, maxDataRateIndex ttnpb.DataRateIndex,
+	rejectedDataRateIndices map[ttnpb.DataRateIndex]struct{},
+	minTxPowerIndex uint32,
+	margin float32,
+) float32 {
+	currentParameters, desiredParameters := macState.CurrentParameters, macState.DesiredParameters
+	currentDataRateIndex := currentParameters.AdrDataRateIndex
 	// NOTE: Network Server may only increase the data rate index of the device.
 	// NOTE(2): TX output power is reset whenever data rate is increased.
 	desiredParameters.AdrDataRateIndex = currentDataRateIndex
@@ -432,7 +454,7 @@ func AdaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, de
 		maxDataRateIndex = minDataRateIndex
 	}
 	for drIdx := maxDataRateIndex; drIdx > minDataRateIndex; drIdx-- {
-		if _, ok := rejectedDataRateIndexes[drIdx]; ok {
+		if _, ok := rejectedDataRateIndices[drIdx]; ok {
 			continue
 		}
 		margin -= float32(drIdx-desiredParameters.AdrDataRateIndex) * drStep
@@ -440,26 +462,43 @@ func AdaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, de
 		desiredParameters.AdrTxPowerIndex = 0
 		break
 	}
+	return margin
+}
 
-	if desiredParameters.AdrTxPowerIndex < uint32(minTxPowerIndex) {
-		margin -= txPowerStep(phy, uint8(desiredParameters.AdrTxPowerIndex), minTxPowerIndex)
-		desiredParameters.AdrTxPowerIndex = uint32(minTxPowerIndex)
+func adrAdaptTxPowerIndex(
+	macState *ttnpb.MACState,
+	phy *band.Band,
+	min, max uint32,
+	rejected map[uint32]struct{},
+	margin float32,
+) float32 {
+	desiredParameters := macState.DesiredParameters
+	if desiredParameters.AdrTxPowerIndex < min {
+		margin -= txPowerStep(phy, desiredParameters.AdrTxPowerIndex, min)
+		desiredParameters.AdrTxPowerIndex = min
 	}
-	if desiredParameters.AdrTxPowerIndex > uint32(maxTxPowerIndex) {
-		margin += txPowerStep(phy, maxTxPowerIndex, uint8(desiredParameters.AdrTxPowerIndex))
-		desiredParameters.AdrTxPowerIndex = uint32(maxTxPowerIndex)
+	if desiredParameters.AdrTxPowerIndex > max {
+		margin += txPowerStep(phy, max, desiredParameters.AdrTxPowerIndex)
+		desiredParameters.AdrTxPowerIndex = max
 	}
 	// If we still have margin left, we decrease the TX output power (increase the index).
-	for txPowerIdx := maxTxPowerIndex; txPowerIdx > minTxPowerIndex; txPowerIdx-- {
-		diff := txPowerStep(phy, uint8(desiredParameters.AdrTxPowerIndex), txPowerIdx)
-		if _, ok := rejectedTxPowerIndexes[txPowerIdx]; ok || diff > margin {
+	for txPowerIdx := max; txPowerIdx > min; txPowerIdx-- {
+		diff := txPowerStep(phy, desiredParameters.AdrTxPowerIndex, txPowerIdx)
+		if _, ok := rejected[txPowerIdx]; ok || diff > margin {
 			continue
 		}
-		margin -= diff // nolint:ineffassign
-		desiredParameters.AdrTxPowerIndex = uint32(txPowerIdx)
+		margin -= diff
+		desiredParameters.AdrTxPowerIndex = txPowerIdx
 		break
 	}
+	return margin
+}
 
+func adrAdaptNbTrans(
+	dev *ttnpb.EndDevice, defaults *ttnpb.MACSettings, adrUplinks []*ttnpb.MACState_UplinkMessage,
+) {
+	macState := dev.MacState
+	currentParameters, desiredParameters := macState.CurrentParameters, macState.DesiredParameters
 	nbTrans := clampNbTrans(dev, defaults, currentParameters.AdrNbTrans)
 	if len(adrUplinks) >= OptimalADRUplinkCount/2 {
 		switch r := adrLossRate(adrUplinks...); {
@@ -473,6 +512,41 @@ func AdaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, de
 		}
 	}
 	desiredParameters.AdrNbTrans = clampNbTrans(dev, defaults, nbTrans)
+}
 
+func adaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, defaults *ttnpb.MACSettings) error {
+	macState := dev.MacState
+	adrUplinks := adrUplinks(macState, phy)
+	if len(adrUplinks) == 0 {
+		return nil
+	}
+	minDataRateIndex, maxDataRateIndex, rejectedDataRateIndices, ok, err := adrDataRateRange(ctx, dev, phy, defaults)
+	if err != nil || !ok {
+		return err
+	}
+	minTxPowerIndex, maxTxPowerIndex, rejectedTxPowerIndices, ok := adrTxPowerRange(ctx, dev, phy, defaults)
+	if !ok {
+		return nil
+	}
+	margin, ok, err := adrMargin(ctx, dev, defaults, adrUplinks...)
+	if err != nil || !ok {
+		return err
+	}
+	margin = adrAdaptDataRate(
+		macState, phy, minDataRateIndex, maxDataRateIndex, rejectedDataRateIndices, minTxPowerIndex, margin,
+	)
+	margin = adrAdaptTxPowerIndex(
+		macState, phy, minTxPowerIndex, maxTxPowerIndex, rejectedTxPowerIndices, margin,
+	)
+	_ = margin
+	adrAdaptNbTrans(dev, defaults, adrUplinks)
 	return nil
+}
+
+// AdaptDataRate adapts the end device desired ADR parameters based on previous transmissions and device settings.
+func AdaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, defaults *ttnpb.MACSettings) error {
+	if dev.MacState == nil {
+		return nil
+	}
+	return adaptDataRate(ctx, dev, phy, defaults)
 }

--- a/pkg/networkserver/mac/adr_internal_test.go
+++ b/pkg/networkserver/mac/adr_internal_test.go
@@ -22,12 +22,13 @@ import (
 )
 
 var (
-	ADRLossRate      = adrLossRate
-	ADRUplinks       = adrUplinks
-	ADRDataRateRange = adrDataRateRange
-	ADRTxPowerRange  = adrTxPowerRange
-	ADRMargin        = adrMargin
-	ADRAdaptDataRate = adrAdaptDataRate
+	ADRLossRate          = adrLossRate
+	ADRUplinks           = adrUplinks
+	ADRDataRateRange     = adrDataRateRange
+	ADRTxPowerRange      = adrTxPowerRange
+	ADRMargin            = adrMargin
+	ADRAdaptDataRate     = adrAdaptDataRate
+	ADRAdaptTxPowerIndex = adrAdaptTxPowerIndex
 
 	ClampDataRateRange = clampDataRateRange
 	ClampTxPowerRange  = clampTxPowerRange

--- a/pkg/networkserver/mac/adr_internal_test.go
+++ b/pkg/networkserver/mac/adr_internal_test.go
@@ -29,6 +29,7 @@ var (
 	ADRMargin            = adrMargin
 	ADRAdaptDataRate     = adrAdaptDataRate
 	ADRAdaptTxPowerIndex = adrAdaptTxPowerIndex
+	ADRAdaptNbTrans      = adrAdaptNbTrans
 
 	ClampDataRateRange = clampDataRateRange
 	ClampTxPowerRange  = clampTxPowerRange

--- a/pkg/networkserver/mac/adr_internal_test.go
+++ b/pkg/networkserver/mac/adr_internal_test.go
@@ -23,6 +23,7 @@ import (
 
 var (
 	ADRLossRate = adrLossRate
+	ADRUplinks  = adrUplinks
 
 	ClampDataRateRange = clampDataRateRange
 	ClampTxPowerRange  = clampTxPowerRange

--- a/pkg/networkserver/mac/adr_internal_test.go
+++ b/pkg/networkserver/mac/adr_internal_test.go
@@ -27,6 +27,7 @@ var (
 	ADRDataRateRange = adrDataRateRange
 	ADRTxPowerRange  = adrTxPowerRange
 	ADRMargin        = adrMargin
+	ADRAdaptDataRate = adrAdaptDataRate
 
 	ClampDataRateRange = clampDataRateRange
 	ClampTxPowerRange  = clampTxPowerRange

--- a/pkg/networkserver/mac/adr_internal_test.go
+++ b/pkg/networkserver/mac/adr_internal_test.go
@@ -26,6 +26,7 @@ var (
 	ADRUplinks       = adrUplinks
 	ADRDataRateRange = adrDataRateRange
 	ADRTxPowerRange  = adrTxPowerRange
+	ADRMargin        = adrMargin
 
 	ClampDataRateRange = clampDataRateRange
 	ClampTxPowerRange  = clampTxPowerRange

--- a/pkg/networkserver/mac/adr_internal_test.go
+++ b/pkg/networkserver/mac/adr_internal_test.go
@@ -31,6 +31,8 @@ var (
 	ClampDataRateRange = clampDataRateRange
 	ClampTxPowerRange  = clampTxPowerRange
 	ClampNbTrans       = clampNbTrans
+
+	TxPowerStep = txPowerStep
 )
 
 func NewADRUplink(

--- a/pkg/networkserver/mac/adr_internal_test.go
+++ b/pkg/networkserver/mac/adr_internal_test.go
@@ -25,6 +25,7 @@ var (
 	ADRLossRate      = adrLossRate
 	ADRUplinks       = adrUplinks
 	ADRDataRateRange = adrDataRateRange
+	ADRTxPowerRange  = adrTxPowerRange
 
 	ClampDataRateRange = clampDataRateRange
 	ClampTxPowerRange  = clampTxPowerRange

--- a/pkg/networkserver/mac/adr_internal_test.go
+++ b/pkg/networkserver/mac/adr_internal_test.go
@@ -22,8 +22,9 @@ import (
 )
 
 var (
-	ADRLossRate = adrLossRate
-	ADRUplinks  = adrUplinks
+	ADRLossRate      = adrLossRate
+	ADRUplinks       = adrUplinks
+	ADRDataRateRange = adrDataRateRange
 
 	ClampDataRateRange = clampDataRateRange
 	ClampTxPowerRange  = clampTxPowerRange

--- a/pkg/networkserver/mac/adr_legacy.go
+++ b/pkg/networkserver/mac/adr_legacy.go
@@ -43,7 +43,7 @@ func legacyDeviceADRMargin(dev *ttnpb.EndDevice, defaults *ttnpb.MACSettings) fl
 	switch {
 	case dev.GetMacSettings().GetAdrMargin() != nil:
 		return dev.MacSettings.AdrMargin.Value
-	case defaults.AdrMargin != nil:
+	case defaults.GetAdrMargin() != nil:
 		return defaults.AdrMargin.Value
 	default:
 		return DefaultADRMargin

--- a/pkg/networkserver/mac/adr_test.go
+++ b/pkg/networkserver/mac/adr_test.go
@@ -841,11 +841,11 @@ func TestClampTxPowerRange(t *testing.T) {
 		Device   *ttnpb.EndDevice
 		Defaults *ttnpb.MACSettings
 
-		InputMinTxPowerIndex uint8
-		InputMaxTxPowerIndex uint8
+		InputMinTxPowerIndex uint32
+		InputMaxTxPowerIndex uint32
 
-		ExpectedMinTxPowerIndex uint8
-		ExpectedMaxTxPowerIndex uint8
+		ExpectedMinTxPowerIndex uint32
+		ExpectedMaxTxPowerIndex uint32
 	}{
 		{
 			Name: "no device",

--- a/pkg/networkserver/mac/adr_test.go
+++ b/pkg/networkserver/mac/adr_test.go
@@ -1414,6 +1414,7 @@ func TestADRUplinks(t *testing.T) {
 			Band: &band.EU_863_870_RP1_V1_0_2_Rev_B,
 
 			ExpectedUplinks: []*ttnpb.MACState_UplinkMessage{
+				newUplink(ttnpb.MType_UNCONFIRMED_UP, 12, 2),
 				newUplink(ttnpb.MType_UNCONFIRMED_UP, 12, 3),
 				newUplink(ttnpb.MType_UNCONFIRMED_UP, 12, 4),
 			},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/5551
Reverts https://github.com/TheThingsNetwork/lorawan-stack/pull/4642

#### Changes
<!-- What are the changes made in this pull request? -->

- Bring back the validation of ADR data rate indices in the `LinkADRReq` command generation.
  - https://github.com/TheThingsNetwork/lorawan-stack/pull/4642 was wrong. Asking the end device to turn off all of the channels of the provided data rate index is an invalid `LinkADRReq` command. The NS _needs_ to steer the end device towards the active channels via the data rate index if it wants the device to move, but the device won't move on its own.
- Decompose the ADR algorithm into phases:
  - Computing the recent uplinks which use the same channel mask, data rate index and transmission power index. It is important that we consider only the ones with the same parameters, as the SNR is relative to the transmission power index and data rate index.
  - Compute the data rate range in which the algorithm may operate.
  - Compute the transmission power range in which the algorithm may operate.
  - Compute the margin available.
  - Spend the margin on data rate increases.
  - Spend the remaining margin on transmission power increases or decreases.
  - Compute the number of transmissions based on the loss rate.
- Add tests for each ADR algorithm phase, in order to make it less of a long monolith.
- Fix recent uplinks off-by-one error which caused the uplink containing the `LinkADRAns` to be discarded from the ADR computation.
  - `LastAdrChangeFCntUp` is the frame counter of the uplink which contained the positive `LinkADRAns`, which in turn is already using the current data rate index and transmission power index.
- Fix the algorithm flip-flopping between transmission power indices due to the 'safety margin' that is used when we estimate the SNR from less than 20 uplinks.
  - The fix stops the algorithm from increasing the transmission power if the increase would be smaller than the safety margin (since the safety margin triggered the increase).
  - The 'safety margin' is still in place in order to ensure that data rate increases are conservative when the SNR estimate is not optimal.
- Fix the algorithm not lowering the transmission power index to the minimum (i.e. 0) in situations in which not even the minimum would have fully used the margin. 
  - The reasoning here is that if the link condition worsen, the algorithm should ameliorate the missing budget, even if it wouldn't completely fulfill it.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This change heavily re-works the code used by the ADR algorithm. The new unit tests are meant to both convey the expected behavior, and to check the behavior of the reworked implementation.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
