### PR TITLE
Refactor device view to fix double rendering

### DIFF
--- a/pkg/webui/components/button/button.styl
+++ b/pkg/webui/components/button/button.styl
@@ -25,6 +25,7 @@
   font-size: 1rem
   text-decoration: none
   padding: 0 $cs.s
+  white-space: nowrap
 
   &.primary
     color: white

--- a/pkg/webui/console/store/middleware/logics/events.js
+++ b/pkg/webui/console/store/middleware/logics/events.js
@@ -86,7 +86,7 @@ const createEventsConnectLogics = (reducerName, entityName, onEventsStart) => {
   return [
     createLogic({
       type: START_EVENTS,
-      cancelType: [START_EVENTS_FAILURE],
+      cancelType: [STOP_EVENTS, START_EVENTS_FAILURE],
       warnTimeout: 0,
       processOptions: {
         dispatchMultiple: true,

--- a/pkg/webui/console/views/device/device.js
+++ b/pkg/webui/console/views/device/device.js
@@ -1,0 +1,171 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { Switch, Route } from 'react-router-dom'
+import { Col, Row, Container } from 'react-grid-system'
+
+import { useBreadcrumbs } from '@ttn-lw/components/breadcrumbs/context'
+import Breadcrumb from '@ttn-lw/components/breadcrumbs/breadcrumb'
+import Tabs from '@ttn-lw/components/tabs'
+
+import IntlHelmet from '@ttn-lw/lib/components/intl-helmet'
+import NotFoundRoute from '@ttn-lw/lib/components/not-found-route'
+
+import DeviceTitleSection from '@console/containers/device-title-section'
+
+import DeviceData from '@console/views/device-data'
+import DeviceGeneralSettings from '@console/views/device-general-settings'
+import DeviceMessaging from '@console/views/device-messaging'
+import DeviceLocation from '@console/views/device-location'
+import DevicePayloadFormatters from '@console/views/device-payload-formatters'
+import DeviceClaimAuthenticationCode from '@console/views/device-claim-authentication-code'
+import DeviceOverview from '@console/views/device-overview'
+
+import getHostnameFromUrl from '@ttn-lw/lib/host-from-url'
+import sharedMessages from '@ttn-lw/lib/shared-messages'
+import {
+  selectApplicationSiteName,
+  selectAsConfig,
+  selectJsConfig,
+} from '@ttn-lw/lib/selectors/env'
+import PropTypes from '@ttn-lw/lib/prop-types'
+
+import {
+  mayScheduleDownlinks as mayScheduleDownlinksCheck,
+  maySendUplink as maySendUplinkCheck,
+  checkFromState,
+} from '@console/lib/feature-checks'
+
+import { selectSelectedDevice } from '@console/store/selectors/devices'
+import { selectSelectedApplicationId } from '@console/store/selectors/applications'
+
+import style from './device.styl'
+
+const Device = props => {
+  const devId = props.match.params.devId
+  const appId = useSelector(selectSelectedApplicationId)
+  const device = useSelector(state => selectSelectedDevice(state))
+
+  const { name, join_server_address, supports_join, root_keys, application_server_address } = device
+
+  const mayScheduleDownlinks = useSelector(state =>
+    checkFromState(mayScheduleDownlinksCheck, state),
+  )
+  const maySendUplink = useSelector(state => checkFromState(maySendUplinkCheck, state))
+
+  const {
+    location: { pathname },
+  } = props
+
+  const jsConfig = selectJsConfig()
+  const hasJs =
+    jsConfig.enabled &&
+    join_server_address === getHostnameFromUrl(jsConfig.base_url) &&
+    supports_join &&
+    Boolean(root_keys)
+
+  const siteName = selectApplicationSiteName()
+  const asConfig = selectAsConfig()
+  const hasAs =
+    asConfig.enabled && application_server_address === getHostnameFromUrl(asConfig.base_url)
+  const hideMessaging = !hasAs || !(mayScheduleDownlinks || maySendUplink)
+  const hidePayloadFormatters = !hasAs
+  const hideClaiming = !hasJs
+
+  const basePath = `/applications/${appId}/devices/${devId}`
+
+  // Prevent default redirect to uplink when tab is already open.
+  const payloadFormattersLink = pathname.startsWith(`${basePath}/payload-formatters`)
+    ? pathname
+    : `${basePath}/payload-formatters`
+  const messagingLink = pathname.startsWith(`${basePath}/messaging`)
+    ? pathname
+    : `${basePath}/messaging`
+
+  useBreadcrumbs(
+    'device.single',
+    <Breadcrumb path={`/applications/${appId}/devices/${devId}`} content={name || devId} />,
+  )
+
+  const tabs = [
+    { title: sharedMessages.overview, name: 'overview', link: basePath },
+    { title: sharedMessages.liveData, name: 'data', link: `${basePath}/data` },
+    {
+      title: sharedMessages.messaging,
+      name: 'messaging',
+      exact: false,
+      link: messagingLink,
+      hidden: hideMessaging,
+    },
+    { title: sharedMessages.location, name: 'location', link: `${basePath}/location` },
+    {
+      title: sharedMessages.payloadFormatters,
+      name: 'develop',
+      link: payloadFormattersLink,
+      exact: false,
+      hidden: hidePayloadFormatters,
+    },
+    {
+      title: sharedMessages.claiming,
+      name: 'claim-auth-code',
+      link: `${basePath}/claim-auth-code`,
+      hidden: hideClaiming,
+    },
+    {
+      title: sharedMessages.generalSettings,
+      name: 'general-settings',
+      link: `${basePath}/general-settings`,
+    },
+  ]
+
+  return (
+    <>
+      <IntlHelmet titleTemplate={`%s - ${name || devId} - ${siteName}`} />
+      <div className={style.titleSection}>
+        <Container>
+          <Row>
+            <Col sm={12}>
+              <DeviceTitleSection appId={appId} devId={devId}>
+                <Tabs className={style.tabs} narrow tabs={tabs} />
+              </DeviceTitleSection>
+            </Col>
+          </Row>
+        </Container>
+      </div>
+      <Switch>
+        <Route exact path={basePath} component={DeviceOverview} />
+        <Route exact path={`${basePath}/data`} component={DeviceData} />
+        {!hideMessaging && <Route path={`${basePath}/messaging`} component={DeviceMessaging} />}
+        <Route exact path={`${basePath}/location`} component={DeviceLocation} />
+        <Route exact path={`${basePath}/general-settings`} component={DeviceGeneralSettings} />
+        {!hidePayloadFormatters && (
+          <Route path={`${basePath}/payload-formatters`} component={DevicePayloadFormatters} />
+        )}
+        {!hideClaiming && (
+          <Route path={`${basePath}/claim-auth-code`} component={DeviceClaimAuthenticationCode} />
+        )}
+        <NotFoundRoute />
+      </Switch>
+    </>
+  )
+}
+
+Device.propTypes = {
+  location: PropTypes.location.isRequired,
+  match: PropTypes.match.isRequired,
+}
+
+export default Device

--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,114 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react'
-import { connect } from 'react-redux'
-import { Switch, Route } from 'react-router-dom'
-import { Col, Row, Container } from 'react-grid-system'
+import React, { useEffect, useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 
-import CONNECTION_STATUS from '@console/constants/connection-status'
+import RequireRequest from '@ttn-lw/lib/components/require-request'
 
-import { withBreadcrumb } from '@ttn-lw/components/breadcrumbs/context'
-import Breadcrumb from '@ttn-lw/components/breadcrumbs/breadcrumb'
-import Tabs from '@ttn-lw/components/tabs'
-
-import IntlHelmet from '@ttn-lw/lib/components/intl-helmet'
-import withRequest from '@ttn-lw/lib/components/with-request'
-import withEnv from '@ttn-lw/lib/components/env'
-import NotFoundRoute from '@ttn-lw/lib/components/not-found-route'
-
-import DeviceTitleSection from '@console/containers/device-title-section'
-
-import DeviceData from '@console/views/device-data'
-import DeviceGeneralSettings from '@console/views/device-general-settings'
-import DeviceMessaging from '@console/views/device-messaging'
-import DeviceLocation from '@console/views/device-location'
-import DevicePayloadFormatters from '@console/views/device-payload-formatters'
-import DeviceClaimAuthenticationCode from '@console/views/device-claim-authentication-code'
-import DeviceOverview from '@console/views/device-overview'
-
-import getHostnameFromUrl from '@ttn-lw/lib/host-from-url'
-import PropTypes from '@ttn-lw/lib/prop-types'
-import { selectJsConfig, selectAsConfig, selectNsConfig } from '@ttn-lw/lib/selectors/env'
-import { combineDeviceIds } from '@ttn-lw/lib/selectors/id'
-import sharedMessages from '@ttn-lw/lib/shared-messages'
 import attachPromise from '@ttn-lw/lib/store/actions/attach-promise'
+import { selectNsConfig } from '@ttn-lw/lib/selectors/env'
+import PropTypes from '@ttn-lw/lib/prop-types'
 
 import {
   mayReadApplicationDeviceKeys,
-  mayScheduleDownlinks,
-  maySendUplink,
   mayViewApplicationLink,
   checkFromState,
 } from '@console/lib/feature-checks'
 
-import { getInfoByJoinEUI } from '@console/store/actions/claim'
 import { getDevice, stopDeviceEventsStream } from '@console/store/actions/devices'
 import { getApplicationLink } from '@console/store/actions/link'
 import { getNsFrequencyPlans } from '@console/store/actions/configuration'
+import { getInfoByJoinEUI } from '@console/store/actions/claim'
 
-import {
-  selectSelectedDevice,
-  selectDeviceFetching,
-  selectDeviceError,
-  selectDeviceEventsStatus,
-} from '@console/store/selectors/devices'
-import {
-  selectApplicationLinkFetching,
-  selectSelectedApplicationId,
-} from '@console/store/selectors/applications'
-import { selectFrequencyPlansFetching } from '@console/store/selectors/configuration'
+import { selectSelectedApplicationId } from '@console/store/selectors/applications'
 
-import style from './device.styl'
+import Device from './device'
 
-@connect(
-  (state, props) => {
-    const devId = props.match.params.devId
-    const appId = selectSelectedApplicationId(state)
-    const device = selectSelectedDevice(state)
-    const eventsInitialized =
-      selectDeviceEventsStatus(state, combineDeviceIds(appId, devId)) !== CONNECTION_STATUS.UNKNOWN
+const DeviceContainer = props => {
+  const devId = props.match.params.devId
+  const appId = useSelector(selectSelectedApplicationId)
+  const mayReadKeys = useSelector(state => checkFromState(mayReadApplicationDeviceKeys, state))
+  const mayViewLink = useSelector(state => checkFromState(mayViewApplicationLink, state))
 
-    const fetching =
-      selectDeviceFetching(state) ||
-      selectApplicationLinkFetching(state) ||
-      selectFrequencyPlansFetching(state) ||
-      !eventsInitialized ||
-      !Boolean(device)
+  const dispatch = useDispatch()
 
-    return {
-      devId,
-      appId,
-      device,
-      mayReadKeys: checkFromState(mayReadApplicationDeviceKeys, state),
-      mayScheduleDownlinks: checkFromState(mayScheduleDownlinks, state),
-      maySendUplink: checkFromState(maySendUplink, state),
-      mayViewLink: checkFromState(mayViewApplicationLink, state),
-      fetching,
-      error: selectDeviceError(state),
-    }
-  },
-  dispatch => ({
-    loadDeviceData: async (appId, devId, deviceSelector, linkSelector, mayViewLink) => {
-      const nsEnabled = selectNsConfig().enabled
-
-      const device = await dispatch(
-        attachPromise(getDevice(appId, devId, deviceSelector, { ignoreNotFound: true })),
-      )
-
-      if (nsEnabled) {
-        dispatch(getNsFrequencyPlans())
-      }
-      if (mayViewLink) {
-        dispatch(getApplicationLink(appId, linkSelector))
-      }
-
-      dispatch(getInfoByJoinEUI({ join_eui: device.ids.join_eui }))
-    },
-    stopStream: id => dispatch(stopDeviceEventsStream(id)),
-  }),
-)
-@withRequest(({ appId, devId, loadDeviceData, mayReadKeys, mayViewLink }) => {
   const linkSelector = ['skip_payload_crypto', 'default_formatters']
   const deviceSelector = [
     'name',
@@ -155,136 +79,37 @@ import style from './device.styl'
     deviceSelector.push('root_keys')
   }
 
-  return loadDeviceData(appId, devId, deviceSelector, linkSelector, mayViewLink)
-})
-@withBreadcrumb('device.single', props => {
-  const {
-    devId,
-    appId,
-    device: { name },
-  } = props
-  return <Breadcrumb path={`/applications/${appId}/devices/${devId}`} content={name || devId} />
-})
-@withEnv
-export default class Device extends React.Component {
-  static propTypes = {
-    appId: PropTypes.string.isRequired,
-    devId: PropTypes.string.isRequired,
-    device: PropTypes.device.isRequired,
-    env: PropTypes.env,
-    location: PropTypes.location.isRequired,
-    mayScheduleDownlinks: PropTypes.bool.isRequired,
-    maySendUplink: PropTypes.bool.isRequired,
-    stopStream: PropTypes.func.isRequired,
-  }
+  const loadDeviceData = useCallback(
+    async dispatch => {
+      const nsEnabled = selectNsConfig().enabled
 
-  static defaultProps = {
-    env: undefined,
-  }
+      const device = await dispatch(
+        attachPromise(getDevice(appId, devId, deviceSelector, { ignoreNotFound: true })),
+      )
 
-  componentWillUnmount() {
-    const { device, stopStream } = this.props
+      if (nsEnabled) {
+        dispatch(getNsFrequencyPlans())
+      }
+      if (mayViewLink) {
+        dispatch(getApplicationLink(appId, linkSelector))
+      }
 
-    stopStream(device.ids)
-  }
+      dispatch(getInfoByJoinEUI({ join_eui: device.ids.join_eui }))
+    },
+    [appId, devId, deviceSelector, linkSelector, mayViewLink],
+  )
 
-  render() {
-    const {
-      location: { pathname },
-      appId,
-      devId,
-      device,
-      env: { siteName },
-      mayScheduleDownlinks,
-      maySendUplink,
-    } = this.props
-    const { name, join_server_address, supports_join, root_keys, application_server_address } =
-      device
+  useEffect(() => () => dispatch(stopDeviceEventsStream(devId)), [dispatch, devId])
 
-    const jsConfig = selectJsConfig()
-    const hasJs =
-      jsConfig.enabled &&
-      join_server_address === getHostnameFromUrl(jsConfig.base_url) &&
-      supports_join &&
-      Boolean(root_keys)
-
-    const asConfig = selectAsConfig()
-    const hasAs =
-      asConfig.enabled && application_server_address === getHostnameFromUrl(asConfig.base_url)
-    const hideMessaging = !hasAs || !(mayScheduleDownlinks || maySendUplink)
-    const hidePayloadFormatters = !hasAs
-    const hideClaiming = !hasJs
-
-    const basePath = `/applications/${appId}/devices/${devId}`
-
-    // Prevent default redirect to uplink when tab is already open.
-    const payloadFormattersLink = pathname.startsWith(`${basePath}/payload-formatters`)
-      ? pathname
-      : `${basePath}/payload-formatters`
-    const messagingLink = pathname.startsWith(`${basePath}/messaging`)
-      ? pathname
-      : `${basePath}/messaging`
-
-    const tabs = [
-      { title: sharedMessages.overview, name: 'overview', link: basePath },
-      { title: sharedMessages.liveData, name: 'data', link: `${basePath}/data` },
-      {
-        title: sharedMessages.messaging,
-        name: 'messaging',
-        exact: false,
-        link: messagingLink,
-        hidden: hideMessaging,
-      },
-      { title: sharedMessages.location, name: 'location', link: `${basePath}/location` },
-      {
-        title: sharedMessages.payloadFormatters,
-        name: 'develop',
-        link: payloadFormattersLink,
-        exact: false,
-        hidden: hidePayloadFormatters,
-      },
-      {
-        title: sharedMessages.claiming,
-        name: 'claim-auth-code',
-        link: `${basePath}/claim-auth-code`,
-        hidden: hideClaiming,
-      },
-      {
-        title: sharedMessages.generalSettings,
-        name: 'general-settings',
-        link: `${basePath}/general-settings`,
-      },
-    ]
-
-    return (
-      <React.Fragment>
-        <IntlHelmet titleTemplate={`%s - ${name || devId} - ${siteName}`} />
-        <div className={style.titleSection}>
-          <Container>
-            <Row>
-              <Col sm={12}>
-                <DeviceTitleSection appId={appId} devId={devId}>
-                  <Tabs className={style.tabs} narrow tabs={tabs} />
-                </DeviceTitleSection>
-              </Col>
-            </Row>
-          </Container>
-        </div>
-        <Switch>
-          <Route exact path={basePath} component={DeviceOverview} />
-          <Route exact path={`${basePath}/data`} component={DeviceData} />
-          {!hideMessaging && <Route path={`${basePath}/messaging`} component={DeviceMessaging} />}
-          <Route exact path={`${basePath}/location`} component={DeviceLocation} />
-          <Route exact path={`${basePath}/general-settings`} component={DeviceGeneralSettings} />
-          {!hidePayloadFormatters && (
-            <Route path={`${basePath}/payload-formatters`} component={DevicePayloadFormatters} />
-          )}
-          {!hideClaiming && (
-            <Route path={`${basePath}/claim-auth-code`} component={DeviceClaimAuthenticationCode} />
-          )}
-          <NotFoundRoute />
-        </Switch>
-      </React.Fragment>
-    )
-  }
+  return (
+    <RequireRequest requestAction={loadDeviceData}>
+      <Device {...props} />
+    </RequireRequest>
+  )
 }
+
+DeviceContainer.propTypes = {
+  match: PropTypes.match.isRequired,
+}
+
+export default DeviceContainer

--- a/pkg/webui/lib/components/require-request.js
+++ b/pkg/webui/lib/components/require-request.js
@@ -54,8 +54,11 @@ RequireRequest.propTypes = {
   children: PropTypes.node.isRequired,
   errorRenderFunction: PropTypes.func,
   handleErrors: PropTypes.bool,
-  requestAction: PropTypes.oneOfType([PropTypes.shape({}), PropTypes.arrayOf(PropTypes.shape({}))])
-    .isRequired,
+  requestAction: PropTypes.oneOfType([
+    PropTypes.shape({}),
+    PropTypes.arrayOf(PropTypes.shape({})),
+    PropTypes.func,
+  ]).isRequired,
   spinnerProps: PropTypes.shape(Spinner.propTypes),
 }
 

--- a/pkg/webui/lib/hooks/use-request.js
+++ b/pkg/webui/lib/hooks/use-request.js
@@ -28,6 +28,8 @@ const useRequest = requestAction => {
     const promise = (
       requestAction instanceof Array
         ? CancelablePromise.all(requestAction.map(req => dispatch(attachPromise(req))))
+        : typeof requestAction === 'function'
+        ? requestAction(dispatch)
         : dispatch(attachPromise(requestAction))
     )
       .then(() => {


### PR DESCRIPTION
#### Summary
This PR refactors the device view in the Console to make use of functional components and `<RequireRequest />`, which resolves the double rendering issue. The component was double rendering because of a jittery `fetching` value alternating between `true` and `false` while different requests where running.

#### Changes
<!-- What are the changes made in this pull request? -->

- Split up the device view into an inner and outer part
- Refactor to use `<RequireRequest />` instead of `withRequest` which relies on legacy `fetching` values
- Extend `useRequest` to allow passing a function as `requestAction` to allow for more complex control flows when fetching data (e.g. conditional fetching and waterfalling requests)
- Reintroduce a previously removed stop action for starting the event stream.

#### Testing

Manual testing on staging and e2es.

##### Regressions

It's possible that some errors were introduced when splitting up the device view components. These errors should however be fetched by the end-to-end tests.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
