### PR TITLE
Fix webhook templates not setting field masks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Console not applying webhook field masks when creating a webhook from a template that has field masks set.
+
 ### Security
 
 ## [3.25.2] - unreleased

--- a/cypress/fixtures/console/application/integrations/webhook/template.json
+++ b/cypress/fixtures/console/application/integrations/webhook/template.json
@@ -22,6 +22,7 @@
         "description":"Akenza Core device ID"
       }
     ],
+    "field_mask":  { "paths": ["up.uplink_message.decoded_payload"] },
     "uplink_message":{"path":"/"}
   }]
 }

--- a/cypress/integration/console/integrations/webhooks/create-with-template.spec.js
+++ b/cypress/integration/console/integrations/webhooks/create-with-template.spec.js
@@ -35,11 +35,9 @@ describe('Application Webhook create', () => {
 
   beforeEach(() => {
     cy.loginConsole({ user_id: userId, password: user.password })
-    cy.intercept(
-      'GET',
-      `/api/v3/as/webhook-templates?field_mask=base_url,create_downlink_api_key,description,documentation_url,downlink_ack,downlink_failed,downlink_nack,downlink_queue_invalidated,downlink_queued,downlink_sent,fields,format,headers,ids,info_url,join_accept,location_solved,logo_url,name,service_data,uplink_message,uplink_normalized`,
-      { fixture: 'console/application/integrations/webhook/template.json' },
-    )
+    cy.intercept('GET', `/api/v3/as/webhook-templates?*`, {
+      fixture: 'console/application/integrations/webhook/template.json',
+    })
     cy.visit(
       `${Cypress.config(
         'consoleRootPath',

--- a/pkg/webui/console/views/application-integrations-webhooks/connect.js
+++ b/pkg/webui/console/views/application-integrations-webhooks/connect.js
@@ -52,6 +52,7 @@ const selector = [
   'service_data',
   'uplink_message',
   'uplink_normalized',
+  'field_mask',
 ]
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
#### Summary
This PR adds the 'field_mask' selector to the list of selectors for the Connect view in the web UI.

#### Changes
- Added 'field_mask' selector to the list of selectors for the Connect view in the web UI.

#### Testing
I tested this change by adding the 'field_mask' selector to the list of selectors and verifying that it was correctly added.

#### Notes for Reviewers
No special requests or questions for reviewers.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
Copied to clipboard
