### PR TITLE
Fix connection timestamp monotonicity

### DIFF
--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -970,7 +970,14 @@ func (gs *GatewayServer) updateConnStats(ctx context.Context, conn connectionEnt
 	}
 	registerGatewayConnectionStats(ctx, ids, stats)
 	if gs.statsRegistry != nil {
-		if err := gs.statsRegistry.Set(decoupledCtx, ids, stats, ttnpb.GatewayConnectionStatsFieldPathsTopLevel, gs.config.ConnectionStatsTTL); err != nil {
+		if err := gs.statsRegistry.Set(
+			decoupledCtx,
+			ids,
+			func(*ttnpb.GatewayConnectionStats) (*ttnpb.GatewayConnectionStats, []string, error) {
+				return stats, ttnpb.GatewayConnectionStatsFieldPathsTopLevel, nil
+			},
+			gs.config.ConnectionStatsTTL,
+		); err != nil {
 			logger.WithError(err).Warn("Failed to initialize connection stats")
 		}
 	}
@@ -986,8 +993,11 @@ func (gs *GatewayServer) updateConnStats(ctx context.Context, conn connectionEnt
 			return
 		}
 		if err := gs.statsRegistry.Set(
-			decoupledCtx, ids, stats,
-			[]string{"connected_at", "disconnected_at"},
+			decoupledCtx,
+			ids,
+			func(*ttnpb.GatewayConnectionStats) (*ttnpb.GatewayConnectionStats, []string, error) {
+				return stats, []string{"connected_at", "disconnected_at"}, nil
+			},
 			gs.config.ConnectionStatsDisconnectTTL,
 		); err != nil {
 			logger.WithError(err).Warn("Failed to clear connection stats")
@@ -1028,7 +1038,14 @@ func (gs *GatewayServer) updateConnStats(ctx context.Context, conn connectionEnt
 		if gs.statsRegistry == nil {
 			continue
 		}
-		if err := gs.statsRegistry.Set(decoupledCtx, ids, stats, paths, gs.config.ConnectionStatsTTL); err != nil {
+		if err := gs.statsRegistry.Set(
+			decoupledCtx,
+			ids,
+			func(*ttnpb.GatewayConnectionStats) (*ttnpb.GatewayConnectionStats, []string, error) {
+				return stats, paths, nil
+			},
+			gs.config.ConnectionStatsTTL,
+		); err != nil {
 			logger.WithError(err).Warn("Failed to update connection stats")
 		}
 	}

--- a/pkg/gatewayserver/grpc.go
+++ b/pkg/gatewayserver/grpc.go
@@ -80,7 +80,7 @@ func (gs *GatewayServer) BatchGetGatewayConnectionStats(
 	}
 
 	if gs.statsRegistry != nil {
-		entries, err := gs.statsRegistry.BatchGet(ctx, req.GatewayIds, req.FieldMask.GetPaths())
+		entries, err := gs.statsRegistry.BatchGet(ctx, req.GatewayIds, req.FieldMask.GetPaths()...)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/gatewayserver/registry.go
+++ b/pkg/gatewayserver/registry.go
@@ -29,10 +29,16 @@ type GatewayConnectionStatsRegistry interface {
 	BatchGet(
 		ctx context.Context,
 		ids []*ttnpb.GatewayIdentifiers,
-		paths []string,
+		paths ...string,
 	) (map[string]*ttnpb.GatewayConnectionStats, error)
 	// Set sets, updates or clears the connection stats for a gateway. Only fields specified in the field mask paths are set.
-	Set(ctx context.Context, ids *ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats, paths []string, ttl time.Duration) error
+	Set(
+		ctx context.Context,
+		ids *ttnpb.GatewayIdentifiers,
+		f func(*ttnpb.GatewayConnectionStats) (*ttnpb.GatewayConnectionStats, []string, error),
+		ttl time.Duration,
+		gets ...string,
+	) error
 }
 
 // EntityRegistry abstracts the Identity server gateway functions.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://www.thethingsnetwork.org/forum/t/offline-status-on-gateways-page/62935
References https://github.com/TheThingsNetwork/lorawan-stack/pull/6161

#### Changes
<!-- What are the changes made in this pull request? -->

- Revert the periodic stats update function, such that it always updates the `connected_at`, `disconnected_at`.
  - The problem is that if we don't re-update the `connected_at` on every periodic stats a update, a disconnection from another instance can erase our `connected_at`.
- Always store the earliest `connected_at` in the stats registry.
  - This ensures that even if we have two streams connected to two GS instances, the `connected_at` does not flip-flop.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This fixes a regression introduced by the original PR, and a better fix for the original problem (flip flopping timestamps).

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This will be backported to the `v3.25.2` release.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
