### PR TITLE
Remove proto.Equal workaround

### DIFF
--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -844,7 +844,7 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID *ttnpb.ApplicationId
 					storedPendingMACState := stored.GetPendingMacState()
 					return false, false, storedPendingMACState == nil ||
 						updated.PendingMacState.LorawanVersion != storedPendingMACState.LorawanVersion ||
-						!equalKeys(updated.PendingSession.Keys.FNwkSIntKey, storedPendingSession.Keys.FNwkSIntKey)
+						!proto.Equal(updated.PendingSession.Keys.FNwkSIntKey, storedPendingSession.Keys.FNwkSIntKey)
 				}()
 				if removeStored {
 					removeAddrMapping(ctx, p, PendingAddrKey(r.addrKey(types.MustDevAddr(storedPendingSession.DevAddr).OrZero())), uid)
@@ -882,7 +882,7 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID *ttnpb.ApplicationId
 					storedMACSettings := stored.GetMacSettings()
 					return false, false, storedMACState == nil ||
 						updated.MacState.LorawanVersion != storedMACState.LorawanVersion ||
-						!equalKeys(updated.Session.Keys.FNwkSIntKey, storedSession.Keys.FNwkSIntKey) ||
+						!proto.Equal(updated.Session.Keys.FNwkSIntKey, storedSession.Keys.FNwkSIntKey) ||
 						!proto.Equal(updated.MacSettings.GetResetsFCnt(), storedMACSettings.GetResetsFCnt()) ||
 						!proto.Equal(updated.MacSettings.GetSupports_32BitFCnt(), storedMACSettings.GetSupports_32BitFCnt())
 				}()
@@ -942,25 +942,4 @@ func (r *DeviceRegistry) Range(ctx context.Context, paths []string, f func(conte
 		}
 		return true, nil
 	})
-}
-
-// TODO: Use proto.Equal instead.
-// https://github.com/TheThingsNetwork/lorawan-stack/issues/2798
-func equalKeys(a, b *ttnpb.KeyEnvelope) bool {
-	if a == b {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-	if !bytes.Equal(a.EncryptedKey, b.EncryptedKey) || a.KekLabel != b.KekLabel {
-		return false
-	}
-	if a.Key == nil && b.Key == nil {
-		return true
-	}
-	if a.Key == nil || b.Key == nil {
-		return false
-	}
-	return bytes.Equal(a.Key, b.Key)
 }

--- a/pkg/networkserver/registry.go
+++ b/pkg/networkserver/registry.go
@@ -15,7 +15,6 @@
 package networkserver
 
 import (
-	"bytes"
 	"context"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
@@ -248,17 +247,7 @@ var replacedEndDeviceFields = []registry.ReplacedEndDeviceField{
 					return errInvalidFieldValue.WithAttributes("field", "queued_application_downlinks")
 				}
 				for i := 0; i < n; i++ {
-					// TODO: Use proto.Equal instead.
-					// https://github.com/TheThingsNetwork/lorawan-stack/issues/2798
-					oldBinary, err := proto.Marshal(oldValue[i])
-					if err != nil {
-						return err
-					}
-					newBinary, err := proto.Marshal(newValue[i])
-					if err != nil {
-						return err
-					}
-					if !bytes.Equal(oldBinary, newBinary) {
+					if !proto.Equal(oldValue[i], newValue[i]) {
 						return errInvalidFieldValue.WithAttributes("field", "queued_application_downlinks")
 					}
 				}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR removes some small workarounds left from the `gogoproto` migration, relating to `proto.Equal`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove `proto.Equal` workarounds, and just use `proto.Equal`.


#### Testing

<!-- How did you verify that this change works? -->

CI.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

No need to review.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
