### PR TITLE
Use DNS resolver for dial targets

### DIFF
--- a/pkg/rpcclient/rpcclient.go
+++ b/pkg/rpcclient/rpcclient.go
@@ -37,6 +37,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/version"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/resolver"
 )
 
 // DefaultDialOptions for gRPC clients
@@ -77,4 +78,8 @@ func DefaultDialOptions(ctx context.Context) []grpc.DialOption {
 			PermitWithoutStream: false,
 		}),
 	}
+}
+
+func init() {
+	resolver.SetDefaultScheme("dns")
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes all of the external gRPC calls use the `dns` scheme, as opposed to `passthrough`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use the `dns` scheme by default.
- Use `passthrough` explicitly for the loopback connection.

#### Testing

<!-- How did you verify that this change works? -->

Local.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. By default the load balancing policy for DNS is `pick_first`, which is equivalent to `passthrough`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
