### PR TITLE
Fix LBS PONG payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Console not applying webhook field masks when creating a webhook from a template that has field masks set.
+- LoRa Basics Station `PONG` messages will now contain the application payload of the associated `PING`, as required by the WebSockets specification.
+  - This fix enables `PING`/`PONG` behavior for non reference implementations of the LNS protocol.
 
 ### Security
 

--- a/pkg/gatewayserver/io/ws/config.go
+++ b/pkg/gatewayserver/io/ws/config.go
@@ -29,8 +29,6 @@ type Config struct {
 var DefaultConfig = Config{
 	UseTrafficTLSAddress: false,
 	WSPingInterval:       30 * time.Second,
-	// Assuming 5ppm of drift, this means a drift of 5 microseconds in one second.
-	// A drift of 1 millisecond would occur every 200 seconds in such a situation.
 	MissedPongThreshold:  2,
 	TimeSyncInterval:     200 * time.Second,
 	AllowUnauthenticated: false,

--- a/pkg/gatewayserver/io/ws/lbslns/downstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream.go
@@ -169,14 +169,10 @@ func (dnmsg *DownlinkMessage) ToDownlinkMessage(bandID string) (*ttnpb.DownlinkM
 	return down, nil
 }
 
-const (
-	// transferTimeMinRTTCount is the minimum number of observed round-trip times that are taken into account before using
-	// their statistics to determine the gateway GPS time.
-	transferTimeMinRTTCount = 5
-)
-
 // TransferTime implements Formatter.
-func (*lbsLNS) TransferTime(ctx context.Context, serverTime time.Time, gpsTime *time.Time, concentratorTime *scheduling.ConcentratorTime) ([]byte, error) {
+func (*lbsLNS) TransferTime(
+	ctx context.Context, serverTime time.Time, gpsTime *time.Time, concentratorTime *scheduling.ConcentratorTime,
+) ([]byte, error) {
 	if enabled, ok := ws.GetSessionTimeSync(ctx); !ok || !enabled {
 		return nil, nil
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes our `PING`/`PONG` response behavior such that `PONG`s contain the application payload of the associated `PING`s. 

This behavior is mandated by the [WebSockets specification](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.3), but the reference LoRa Basics Station implementation [does not](https://github.com/lorabasics/basicstation/blob/ba4f85d80a438a5c2b659e568cd2d0f0de08e5a7/src/net.c#LL595C1-L595C12) verify the `PONG` payload.

#### Changes
<!-- What are the changes made in this pull request? -->

- Reply to `PING`s with `PONG`s which contain the same application payload.

#### Testing

<!-- How did you verify that this change works? -->

Tested on `staging1` with the reference implementation, with both versions 2.0.4 and 2.0.6, from multiple vendors.
Also tested with non-reference implementation such as Tektelic and Kerlink. This fix allows Kerlink gateways to `PING`/`PONG` with the server properly.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

As this was tested with the reference implementations and the alternative ones, we do not expected functional regressions. 

There are slightly more bytes (I saw that some implementations choose to send 4 bytes as `PING` payload) being sent around, but at a low interval. If the extra bandwidth is problematic for the client, they can always turn off the client side `PING`/`PONG`.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Live on `staging1`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
