### PR TITLE
Log long scheduling delay in the Gateway Server

### DIFF
--- a/pkg/gatewayserver/io/ws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream.go
@@ -510,7 +510,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids *ttnpb.GatewayIde
 			conn.RecordRTT(delta, receivedAt)
 		}
 	}
-	syncClock := func(xTime int64, gpsTime int64, rxTime float64, onlyWithGPS bool) *io.FrontendClockSynchronization {
+	syncClock := func(xTime int64, gpsTime int64, onlyWithGPS bool) *io.FrontendClockSynchronization {
 		if onlyWithGPS && gpsTime == 0 {
 			return nil
 		}
@@ -523,9 +523,9 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids *ttnpb.GatewayIde
 			ConcentratorTime: ws.ConcentratorTimeFromXTime(xTime),
 		}
 	}
-	recordTime := func(refTimeUnix float64, xTime int64, gpsTime int64, rxTime float64) *io.FrontendClockSynchronization {
+	recordTime := func(refTimeUnix float64, xTime int64, gpsTime int64) *io.FrontendClockSynchronization {
 		recordRTT(refTimeUnix)
-		return syncClock(xTime, gpsTime, rxTime, false)
+		return syncClock(xTime, gpsTime, false)
 	}
 
 	switch typ {
@@ -567,7 +567,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids *ttnpb.GatewayIde
 			return nil, err
 		}
 		ws.UpdateSessionID(ctx, ws.SessionIDFromXTime(jreq.UpInfo.XTime))
-		ct := recordTime(jreq.RefTime, jreq.UpInfo.XTime, jreq.UpInfo.GPSTime, jreq.UpInfo.RxTime)
+		ct := recordTime(jreq.RefTime, jreq.UpInfo.XTime, jreq.UpInfo.GPSTime)
 		if err := conn.HandleUp(up, ct); err != nil {
 			logger.WithError(err).Warn("Failed to handle upstream message")
 		}
@@ -588,7 +588,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids *ttnpb.GatewayIde
 			return nil, err
 		}
 		ws.UpdateSessionID(ctx, ws.SessionIDFromXTime(updf.UpInfo.XTime))
-		ct := recordTime(updf.RefTime, updf.UpInfo.XTime, updf.UpInfo.GPSTime, updf.UpInfo.RxTime)
+		ct := recordTime(updf.RefTime, updf.UpInfo.XTime, updf.UpInfo.GPSTime)
 		if err := conn.HandleUp(up, ct); err != nil {
 			logger.WithError(err).Warn("Failed to handle upstream message")
 		}
@@ -611,7 +611,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids *ttnpb.GatewayIde
 		// RTT computations. The GPS timestamp is present only if the downlink is a class
 		// B downlink. We allow clock synchronization to occur only if GPSTime is present.
 		// References https://github.com/lorabasics/basicstation/issues/134.
-		syncClock(txConf.XTime, txConf.GPSTime, 0.0, true)
+		syncClock(txConf.XTime, txConf.GPSTime, true)
 
 	case TypeUpstreamTimeSync:
 		// If the gateway sends a `timesync` request, it means that it has access to a PPS

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -174,7 +174,7 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 	})
 
 	// Tasks initialization.
-	if err := is.initilizeTelemetryTasks(is.Context()); err != nil {
+	if err := is.initializeTelemetryTasks(is.Context()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/identityserver/telemetry.go
+++ b/pkg/identityserver/telemetry.go
@@ -28,8 +28,8 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter/istelemetry"
 )
 
-// initilizeTelemetryTasks starts the telemetry dispatcher, consumers and Identity Server's tasks.
-func (is *IdentityServer) initilizeTelemetryTasks(ctx context.Context) error {
+// initializeTelemetryTasks starts the telemetry dispatcher, consumers and Identity Server's tasks.
+func (is *IdentityServer) initializeTelemetryTasks(ctx context.Context) error {
 	logger := log.FromContext(ctx)
 
 	tmCfg := is.GetBaseConfig(is.Context()).Telemetry

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1171,8 +1171,8 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 
 	pld := up.Payload.GetJoinRequestPayload()
 	ctx = log.NewContextWithFields(ctx, log.Fields(
-		"dev_eui", pld.DevEui,
-		"join_eui", pld.JoinEui,
+		"dev_eui", types.MustEUI64(pld.DevEui).OrZero(),
+		"join_eui", types.MustEUI64(pld.JoinEui).OrZero(),
 	))
 
 	ok, err := ns.deduplicateUplink(ctx, up, joinRequestCollectionWindow, initialDeduplicationRound)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/6218

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix the log fields for the join EUI and device EUI in the Network Server join request handling.
- Remove unused `rxTime` field from Basic Station frontend.
- Log scheduling delays above the scheduling window size.
- Ensure that round trip times are positive in LoRa Basics Station.

#### Testing

<!-- How did you verify that this change works? -->

Unit tests.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This PR attempts to find out which gateways are affected by this behavior, and in which situations the delay is over calculated. No semantical changes are introduced.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@johanstokking can you take a look at `Scheduler.ScheduleAnytime` and `SubBand.ScheduleAnyTime` and try to think of a which through which the scheduling delay (`res.Starts() - now`) would have absurd values (weeks to months) ?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
