### PR TITLE
Support DevEUI QR code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Support for scanning a QR code that only contains the hexadecimal encoded DevEUI.
+
 ### Changed
 
 ### Deprecated

--- a/pkg/qrcodegenerator/qrcode/enddevices/dev_eui.go
+++ b/pkg/qrcodegenerator/qrcode/enddevices/dev_eui.go
@@ -1,0 +1,85 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enddevices
+
+import (
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
+)
+
+const formatIDDevEUI = "dev_eui"
+
+type devEUIData struct {
+	DevEUI types.EUI64
+}
+
+// MarshalText implements Data.
+func (d *devEUIData) MarshalText() (text []byte, err error) {
+	return d.DevEUI.MarshalText()
+}
+
+// UnmarshalText implements Data.
+func (d *devEUIData) UnmarshalText(text []byte) error {
+	return d.DevEUI.UnmarshalText(text)
+}
+
+// Validate implements Data.
+func (d *devEUIData) Validate() error {
+	return nil
+}
+
+// Encode implements Data.
+func (d *devEUIData) Encode(dev *ttnpb.EndDevice) error {
+	if dev.Ids.DevEui == nil {
+		return errNoDevEUI.New()
+	}
+	*d = devEUIData{
+		DevEUI: types.MustEUI64(dev.Ids.DevEui).OrZero(),
+	}
+	return nil
+}
+
+// EndDeviceTemplate implements Data.
+func (d *devEUIData) EndDeviceTemplate() *ttnpb.EndDeviceTemplate {
+	return &ttnpb.EndDeviceTemplate{
+		EndDevice: &ttnpb.EndDevice{
+			Ids: &ttnpb.EndDeviceIdentifiers{
+				DevEui: d.DevEUI.Bytes(),
+			},
+		},
+		FieldMask: ttnpb.FieldMask("ids.dev_eui"),
+	}
+}
+
+// FormatID implements Data.
+func (d *devEUIData) FormatID() string {
+	return formatIDDevEUI
+}
+
+type devEUIFormat struct{}
+
+// Format implements Format.
+func (*devEUIFormat) Format() *ttnpb.QRCodeFormat {
+	return &ttnpb.QRCodeFormat{
+		Name:        "DevEUI",
+		Description: "LoRaWAN® DevEUI (hex encoded)",
+		FieldMask:   ttnpb.FieldMask("ids.dev_eui"),
+	}
+}
+
+// New implements Format.
+func (*devEUIFormat) New() Data {
+	return new(devEUIData)
+}

--- a/pkg/qrcodegenerator/qrcode/enddevices/dev_eui_test.go
+++ b/pkg/qrcodegenerator/qrcode/enddevices/dev_eui_test.go
@@ -1,0 +1,99 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enddevices
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+func TestDevEUI(t *testing.T) {
+	t.Run("Encode", func(t *testing.T) {
+		for _, tc := range []struct {
+			Name     string
+			Device   *ttnpb.EndDevice
+			Expected devEUIData
+		}{
+			{
+				Name: "Simple",
+				Device: &ttnpb.EndDevice{
+					Ids: &ttnpb.EndDeviceIdentifiers{
+						DevEui: types.EUI64{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}.Bytes(),
+					},
+				},
+				Expected: devEUIData{
+					DevEUI: types.EUI64{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8},
+				},
+			},
+		} {
+			t.Run(tc.Name, func(t *testing.T) {
+				a := assertions.New(t)
+				var res devEUIData
+				err := res.Encode(tc.Device)
+				if !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(res, should.Resemble, tc.Expected)
+			})
+		}
+	})
+
+	t.Run("Decode", func(t *testing.T) {
+		for _, tc := range []struct {
+			Name           string
+			Data           []byte
+			Expected       devEUIData
+			ErrorAssertion func(t *testing.T, err error) bool
+		}{
+			{
+				Name: "Simple",
+				Data: []byte("4242FFFFFFFFFFFF"),
+				Expected: devEUIData{
+					DevEUI: types.EUI64{0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				},
+			},
+			{
+				Name: "Invalid",
+				Data: []byte("424FFFFFFFFF"),
+				ErrorAssertion: func(t *testing.T, err error) bool {
+					return assertions.New(t).So(errors.IsInvalidArgument(err), should.BeTrue)
+				},
+			},
+		} {
+			t.Run(tc.Name, func(t *testing.T) {
+				a := assertions.New(t)
+
+				var data devEUIData
+				err := data.UnmarshalText(tc.Data)
+				if tc.ErrorAssertion != nil {
+					a.So(tc.ErrorAssertion(t, err), should.BeTrue)
+					return
+				}
+				if !a.So(err, should.BeNil) || !a.So(data, should.Resemble, tc.Expected) {
+					t.FailNow()
+				}
+
+				text := test.Must(data.MarshalText())
+				a.So(string(text), should.Equal, string(tc.Data))
+			})
+		}
+	})
+}

--- a/pkg/qrcodegenerator/qrcode/enddevices/enddevices.go
+++ b/pkg/qrcodegenerator/qrcode/enddevices/enddevices.go
@@ -72,6 +72,10 @@ func New(ctx context.Context) *Server {
 				id:     formatIDLoRaAllianceTR005Draft3,
 				format: new(LoRaAllianceTR005Draft3Format),
 			},
+			{
+				id:     formatIDDevEUI,
+				format: new(devEUIFormat),
+			},
 		},
 	}
 	return s


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds scanning (and encoding) support for a QR code that only contains the DevEUI.

Edit, it even closes https://github.com/TheThingsNetwork/lorawan-stack/issues/5953

#### Changes
<!-- What are the changes made in this pull request? -->

This adds a new QR code format. This new format is attempted last.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is certainly not ideal, but there are tens of thousands of LoRaWAN devices out there with the DevEUI as (only) QR code, including but not limited to all Dragino devices.

Although this is not the most useful addition to The Things Stack, it does removes one of the onboarding barriers that the QR code is not interpreted at all.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
