### PR TITLE
Add experimental automatic steering flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - Support for scanning a QR code that only contains the hexadecimal encoded DevEUI.
+- Experimental flag `ns.adr.auto-narrow-steer`. When enabled, end devices which do not have an explicit channel steering mode will be steered towards the LoRa narrow channels.
 
 ### Changed
 

--- a/pkg/networkserver/mac/adr.go
+++ b/pkg/networkserver/mac/adr.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
+	"go.thethings.network/lorawan-stack/v3/pkg/experimental"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/networkserver/internal"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -221,7 +222,10 @@ func demodulationFloorStep(phy *band.Band, from, to ttnpb.DataRateIndex) float32
 		demodulationFloor[toLoRa.SpreadingFactor][toLoRa.Bandwidth]
 }
 
+var automaticSteeringFeatureFlag = experimental.DefineFeature("ns.adr.auto-narrow-steer", false)
+
 func adrSteerDeviceChannels(
+	ctx context.Context,
 	dev *ttnpb.EndDevice,
 	defaults *ttnpb.MACSettings,
 	phy *band.Band,
@@ -231,7 +235,8 @@ func adrSteerDeviceChannels(
 ) (float32, bool) {
 	channelSteering := deviceADRChannelSteering(dev, defaults)
 	switch {
-	case channelSteering.GetLoraNarrow() != nil:
+	case channelSteering.GetLoraNarrow() != nil,
+		channelSteering.GetMode() == nil && automaticSteeringFeatureFlag.GetValue(ctx):
 		macState := dev.MacState
 		currentParameters, desiredParameters := macState.CurrentParameters, macState.DesiredParameters
 		currentDataRateIndex := currentParameters.AdrDataRateIndex
@@ -630,7 +635,7 @@ func adaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, de
 		return err
 	}
 	margin, ok = adrSteerDeviceChannels(
-		dev, defaults, phy, minDataRateIndex, maxDataRateIndex, allowedDataRateIndices, margin,
+		ctx, dev, defaults, phy, minDataRateIndex, maxDataRateIndex, allowedDataRateIndices, margin,
 	)
 	if !ok {
 		margin = adrAdaptDataRate(

--- a/pkg/networkserver/mac/adr_test.go
+++ b/pkg/networkserver/mac/adr_test.go
@@ -2845,10 +2845,10 @@ func TestADRSteerDeviceChannels(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			a := assertions.New(t)
+			a, ctx := test.New(t)
 			device := ttnpb.Clone(tc.InputDevice)
 			margin, ok := ADRSteerDeviceChannels(
-				device, tc.Defaults, tc.Band, tc.Min, tc.Max, tc.Allowed, tc.InputMargin,
+				ctx, device, tc.Defaults, tc.Band, tc.Min, tc.Max, tc.Allowed, tc.InputMargin,
 			)
 			a.So(margin, should.Equal, tc.OutputMargin)
 			a.So(ok, should.Equal, tc.Ok)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/6216

#### Changes
<!-- What are the changes made in this pull request? -->

- Add the `ns.adr.auto-narrow-steer` experimental flag, which automatically steers end devices to the LoRa narrow channels. 

#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This introduces semantical changes only if enabled.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
