### PR TITLE
Remove cancellable promise

### DIFF
--- a/pkg/webui/lib/hooks/use-request.js
+++ b/pkg/webui/lib/hooks/use-request.js
@@ -14,7 +14,6 @@
 
 import { useState, useEffect } from 'react'
 import { useDispatch } from 'react-redux'
-import CancelablePromise from 'cancelable-promise'
 
 import attachPromise from '@ttn-lw/lib/store/actions/attach-promise'
 
@@ -25,13 +24,14 @@ const useRequest = requestAction => {
   const [result, setResult] = useState()
 
   useEffect(() => {
-    const promise = (
+    const promise =
       requestAction instanceof Array
-        ? CancelablePromise.all(requestAction.map(req => dispatch(attachPromise(req))))
+        ? Promise.all(requestAction.map(req => dispatch(attachPromise(req))))
         : typeof requestAction === 'function'
         ? requestAction(dispatch)
         : dispatch(attachPromise(requestAction))
-    )
+
+    promise
       .then(() => {
         setResult(result)
         setFetching(false)
@@ -40,11 +40,6 @@ const useRequest = requestAction => {
         setError(error)
         setFetching(false)
       })
-
-    return () => {
-      // Cancel the promise on unmount (if still pending).
-      promise.cancel()
-    }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])


### PR DESCRIPTION
#### Summary
This PR removes the `CancellablePromise` from the `useRequest`-hook. Since an update, the functionality was changed which caused crashes in the Console. Canceling promises is a topic on its own and it is generally recommended to not use promise cancellation, so I decided to remove this functionality entirely. In some edge cases, this could mean that promises resolve after they've become obsolete. This is only a performance issue though and should not noticeably affect the UX.

#### Changes
- Remove promise cancellation and `CancellablePromise`


#### Testing

Manual and e2e

##### Regressions

None

#### Notes for Reviewers
- This caused a crash when navigating away from any page that fetched data using `useRequest`.
- I did not remove the `CancellablePromise` from `package.json` because I'll do that as part of a larger depencency update PR that I'm currently working on.
- Changelog entry is not necessary because this regression is within v3.26.0.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
