### PR TITLE
Add reference region name feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ For details about compatibility between different releases, see the **Commitment
 - LoRa Basics Station `PONG` messages will now contain the application payload of the associated `PING`, as required by the WebSockets specification.
   - This fix enables `PING`/`PONG` behavior for non reference implementations of the LNS protocol.
 - Fix crash of "Edit webhook" view due to invalid Authorization header encoding in the Console.
-- LoRa Basics Station 2.0.6 downlink support in the `AS923` region.
 
 ## [3.25.2] - 2023-05-16
 

--- a/pkg/gatewayserver/io/ws/lbslns/version.go
+++ b/pkg/gatewayserver/io/ws/lbslns/version.go
@@ -77,7 +77,7 @@ func (*lbsLNS) GetRouterConfig(
 	// to gateways that signal the presence of a PPS.
 	// References https://github.com/lorabasics/basicstation/issues/135.
 	ws.UpdateSessionTimeSync(ctx, true)
-	cfg, err := pfconfig.GetRouterConfig(bandID, fps, version, time.Now(), antennaGain)
+	cfg, err := pfconfig.GetRouterConfig(ctx, bandID, fps, version, time.Now(), antennaGain)
 	if err != nil {
 		return ctx, nil, nil, err
 	}

--- a/pkg/pfconfig/lbslns/lbslbs_test.go
+++ b/pkg/pfconfig/lbslns/lbslbs_test.go
@@ -270,9 +270,9 @@ func TestGetRouterConfig(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			a := assertions.New(t)
+			a, ctx := test.New(t)
 			fps := map[string]*frequencyplans.FrequencyPlan{tc.FrequencyPlanID: &tc.FrequencyPlan}
-			cfg, err := GetRouterConfig(tc.FrequencyPlan.BandID, fps, tc.Features, time.Now(), 0)
+			cfg, err := GetRouterConfig(ctx, tc.FrequencyPlan.BandID, fps, tc.Features, time.Now(), 0)
 			if err != nil {
 				if tc.ErrorAssertion == nil || !a.So(tc.ErrorAssertion(err), should.BeTrue) {
 					t.Fatalf("Unexpected error: %v", err)
@@ -468,8 +468,8 @@ func TestGetRouterConfigWithMultipleFP(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			a := assertions.New(t)
-			cfg, err := GetRouterConfig(tc.BandID, tc.FrequencyPlans, tc.Features, time.Now(), 3)
+			a, ctx := test.New(t)
+			cfg, err := GetRouterConfig(ctx, tc.BandID, tc.FrequencyPlans, tc.Features, time.Now(), 3)
 			if err != nil {
 				if tc.ErrorAssertion == nil || !a.So(tc.ErrorAssertion(err), should.BeTrue) {
 					t.Fatalf("Unexpected error: %v", err)

--- a/pkg/pfconfig/lbslns/lbslns.go
+++ b/pkg/pfconfig/lbslns/lbslns.go
@@ -17,6 +17,7 @@ package lbslns
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -25,6 +26,7 @@ import (
 
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/experimental"
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/pfconfig/shared"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -45,6 +47,8 @@ var bandIDToRegionID = map[string]string{
 	band.US_902_928: "US902",   // Non standard name, officially `US915`.
 	band.AU_915_928: "AU915",
 }
+
+var referenceRegionNamesFeatureFlag = experimental.DefineFeature("gs.lbslns.reference_region_names", false)
 
 var errFrequencyPlan = errors.DefineInvalidArgument("frequency_plan", "invalid frequency plan `{name}`")
 
@@ -268,6 +272,7 @@ type RouterFeatures interface {
 // Currently as per the LBS docs, all frequency plans have to be from the same region (band).
 // https://doc.sm.tc/station/tcproto.html#router-config-message.
 func GetRouterConfig(
+	ctx context.Context,
 	bandID string,
 	fps map[string]*frequencyplans.FrequencyPlan,
 	features RouterFeatures,
@@ -287,7 +292,7 @@ func GetRouterConfig(
 	if err != nil {
 		return RouterConfig{}, errFrequencyPlan.New()
 	}
-	if regionID, ok := bandIDToRegionID[phy.ID]; ok {
+	if regionID, ok := bandIDToRegionID[phy.ID]; ok && referenceRegionNamesFeatureFlag.GetValue(ctx) {
 		conf.Region = regionID
 	} else {
 		s := strings.Split(phy.ID, "_")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/6157
References https://github.com/TheThingsNetwork/lorawan-stack/issues/6286

#### Changes
<!-- What are the changes made in this pull request? -->

- Move the region naming behavior behind the `gs.lbslns.reference_region_names` feature flag.


#### Testing

<!-- How did you verify that this change works? -->

In production.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Gateways that lack CCA hardware were broken by this change. We initially hopped that this issue exists with only one vendor, but we've discovered that more vendors are actually affected.

Moving this behavioral change behind a feature flag allows us to work with vendors towards a fix without affecting our users.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer please take a look.

This will be backported to `v3.26.0`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
