### PR TITLE
Fix - tenant barrier error on contact_info refactor

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -5309,6 +5309,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/identityserver/store:contact_info_not_found": {
+    "translations": {
+      "en": "contact information with id `{contact_info_id}` not found"
+    },
+    "description": {
+      "package": "pkg/identityserver/store",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/identityserver/store:end_device_not_found": {
     "translations": {
       "en": "end device with id `{device_id}` not found in application with id `{application_id}`"

--- a/pkg/identityserver/store/errors.go
+++ b/pkg/identityserver/store/errors.go
@@ -89,8 +89,11 @@ var (
 	ErrValidationTokenAlreadyUsed = errors.DefineFailedPrecondition(
 		"validation_token_already_used", "validation token already used", "validation_id",
 	)
-	ErrValidationWithoutContactInfo = errors.DefineNotFound(
+	ErrValidationWithoutContactInfo = errors.DefineFailedPrecondition(
 		"validation_without_contact_info", "validation does not reference any valid contact information",
+	)
+	ErrContactInfoNotFound = errors.DefineNotFound(
+		"contact_info_not_found", "contact information with id `{contact_info_id}` not found",
 	)
 
 	ErrLoginTokenNotFound = errors.DefineNotFound(


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #5587 

When fetching entities the tenant constraint is always applied via the `newSelectModel` method, this PR fixes the lack of said method when fetching an `user` or an `ContactInfo` entity. 

#### Changes
<!-- What are the changes made in this pull request? -->

- Usage of `newSelectModel` when performing updates
- Added test cases to confirm that operations were done in the correct manner.
- Added an error in case the provided `ContactInfo` isn't found.
  - This is mostly a redundant check since `GetValidation` fills the contact info with the information in the `ContactInfoValidation` fetched from the DB.
  - Nevertheless this is just to have a check instead of leaving the responsibility exclusively to the `GetValidation` method 

#### Testing

<!-- How did you verify that this change works? -->

Added more cases to the unit test



#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Looked at the other PRs for something similar but couldn't find anything similar to this error on them.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
