### PR TITLE
Fix `contact_info` bug regarding bad usage of entity ID

### DIFF
--- a/pkg/identityserver/bunstore/contact_info_store.go
+++ b/pkg/identityserver/bunstore/contact_info_store.go
@@ -304,8 +304,8 @@ func (s *contactInfoStore) ValidateContactInfo(ctx context.Context, pb *ttnpb.Co
 	if len(models) != 1 {
 		return store.ErrContactInfoNotFound.New()
 	}
-
 	model := models[0]
+
 	_, err = s.DB.NewUpdate().
 		Model(model).
 		WherePK().
@@ -395,6 +395,7 @@ func validationToPB(m *ContactInfoValidation) *ttnpb.ContactInfoValidation {
 			Value:         m.Value,
 		}},
 	}
+
 	switch m.EntityType {
 	case store.EntityApplication:
 		val.Entity = (&ttnpb.ApplicationIdentifiers{ApplicationId: m.EntityID}).GetEntityIdentifiers()
@@ -523,6 +524,13 @@ func (s *contactInfoStore) GetValidation(
 			"validation_id", pb.Id,
 		)
 	}
+
+	friendlyID, err := s.getEntityID(ctx, model.EntityType, model.EntityID)
+	if err != nil {
+		return nil, err
+	}
+
+	model.EntityID = friendlyID
 	return validationToPB(model), nil
 }
 

--- a/pkg/identityserver/storetest/contact_info_store.go
+++ b/pkg/identityserver/storetest/contact_info_store.go
@@ -152,9 +152,10 @@ func (st *StoreTest) TestContactInfoStoreCRUD(t *T) {
 					ContactInfo: []*ttnpb.ContactInfo{info},
 				}
 				t.Run("GetValidation", func(t *T) {
+					// This test is meant to impact `validation` and must run before any other test within `Validate`.
 					a, ctx := test.New(t)
 					var err error
-					validation, err := s.GetValidation(ctx, validation)
+					validation, err = s.GetValidation(ctx, validation)
 					a.So(err, should.BeNil)
 					a.So(validation.Id, should.Equal, validationID)
 					a.So(validation.Token, should.Equal, "TOKEN")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix for the bug introduced in #6310
Essentially `GetValidation` was returning the `UUID` of an entity into the `EntityIdentifiers` which caused problem in the subsequent operation `ValidateContactInfo` where we fetch the  entity's UUID from the `EntityIdentifiers`.

How did this pass in the unit tests bug was supposedly caught in the front-end tests but ignored by me? Well in the unit tests we pass a valid message to each method tested independently, while in the `contact_invitation_registry` we take the direct response of `GetValidation` and pass as a parameter in the `ValidateContactInfo`.

Well isn't the test supposed to reflect what is done in the `contact_info_registry.go`? It is, the reason that didn't happen is beginner mistake in which `:=` was added instead of just `=`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add called for fetching friendlyID of and entity on `validationToPB`
- Fix `contact_info` tests to reflect the proper behaviour of its registry. 


#### Testing

<!-- How did you verify that this change works? -->

Unit tests and wait for the front-end tests as well

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
