### PR TITLE
Missing RX metadata

### DIFF
--- a/pkg/networkserver/observability.go
+++ b/pkg/networkserver/observability.go
@@ -86,6 +86,7 @@ var (
 		"ns.up.join.process", "successfully processed join-request",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithDataType(&ttnpb.UplinkMessage{}),
+		events.WithPropagateToParent(),
 	)
 	evtClusterJoinAttempt = events.Define(
 		"ns.up.join.cluster.attempt", "send join-request to cluster-local Join Server",

--- a/pkg/webui/console/constants/event-filters.js
+++ b/pkg/webui/console/constants/event-filters.js
@@ -21,6 +21,7 @@ export const END_DEVICE_EVENTS_VERBOSE_FILTERS = [
   'js.join.accept',
   'js.join.reject',
   'ns.up.data.process',
+  'ns.up.join.process',
   'ns.down.data.schedule.attempt',
   'ns.mac.*.answer.reject',
   '*.warning',


### PR DESCRIPTION
#### Summary
Extend the default end device and application filters in the Console with the `ns.up.join.process` events from the NS. Propagate the same events to application level.

Closes #6120 

#### Changes
- Added `ns.up.join.process` events to the Console filter
- Propagated the same events to parent


#### Testing
- Events are displayed in the end device and application Live Data without turning on verbose streaming and contain the `rx_metadata` field 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
