### PR TITLE
Do not use the NS peer as a label

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -692,7 +692,7 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids *ttnpb.End
 					if err != nil {
 						as.registerDropDownlinks(ctx, ids, decrypted, err)
 					} else {
-						as.registerForwardDownlinks(ctx, ids, decrypted, encrypted, peer.Name())
+						as.registerForwardDownlinks(ctx, ids, decrypted, encrypted)
 					}
 				},
 			})


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR reduces the cardinality of two AS metrics which use the NS peer as the label. The peer name is not relevant and inconsistent (it mixes peer address with peer name).

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the `network_server` label for the received uplinks and forwarded downlinks.

#### Testing

<!-- How did you verify that this change works? -->

🐒 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

We do not use these labels in our aggregations, so there shouldn't be any regressions.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
