### PR TITLE
Fix Packet Broker audience from dial address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For details about compatibility between different releases, see the **Commitment
 - HTTP API routes for parsing QR codes for the QR Generator service. We exercise our right to break compatibility with third party HTTP clients since this is a bug.
   - `/qr-code/end-devices/parse` is changed to `/qr-codes/end-devices/parse`.
   - `/qr-code/end-devices/{format_id}/parse` is changed to `/qr-codes/end-devices/{format_id}/parse`.
+- Fixed authenticating with Packet Broker when gRPC dialer schemes are used in the address.
 
 ### Security
 

--- a/pkg/packetbroker/token.go
+++ b/pkg/packetbroker/token.go
@@ -72,6 +72,11 @@ func WithAudienceFromAddresses(addresses ...string) TokenOption {
 			if addr == "" {
 				continue
 			}
+			// If the address is a URL with a scheme, check if it's a gRPC dialer scheme and remove it.
+			// gRPC dialer schemes in the target address look like passthrough:///host:port.
+			if u, err := url.Parse(addr); err == nil && u.Scheme != "" && strings.HasPrefix(addr, u.Scheme+":///") {
+				addr = addr[len(u.Scheme)+4:]
+			}
 			if h, _, err := net.SplitHostPort(addr); err == nil {
 				addr = h
 			}
@@ -110,7 +115,7 @@ func TokenSource(ctx context.Context, clientID, clientSecret string, opts ...Tok
 	return config.TokenSource(ctx)
 }
 
-// TokenNetworkClaims defines a Packet Broker network identifier.
+// TokenNetworkClaim defines a Packet Broker network identifier.
 type TokenNetworkClaim struct {
 	NetID    uint32 `json:"nid"`
 	TenantID string `json:"tid"`


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/972

#### Changes
<!-- What are the changes made in this pull request? -->

This fixes the issue that the token audience is not correctly parsed from the address to dial.

#### Testing

<!-- How did you verify that this change works? -->

Unit test

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is the least ugly version that I considered.

~I didn't update the changelog yet because we need to decide if we backport this to 3.26.~

Let's get this in for 3.26.2.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
