### PR TITLE
Backport: Show conflicting identifiers in AS/NS/JS

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2717,9 +2717,9 @@
       "file": "registry.go"
     }
   },
-  "error:pkg/applicationserver/redis:duplicate_identifiers": {
+  "error:pkg/applicationserver/redis:end_device_euis_taken": {
     "translations": {
-      "en": "duplicate identifiers"
+      "en": "an end device with JoinEUI `{join_eui}` and DevEUI `{dev_eui}` is already registered as `{device_id}` in application `{application_id}`"
     },
     "description": {
       "package": "pkg/applicationserver/redis",
@@ -6497,9 +6497,9 @@
       "file": "registry.go"
     }
   },
-  "error:pkg/joinserver/redis:duplicate_identifiers": {
+  "error:pkg/joinserver/redis:end_device_euis_taken": {
     "translations": {
-      "en": "duplicate identifiers"
+      "en": "an end device with JoinEUI `{join_eui}` and DevEUI `{dev_eui}` is already registered as `{device_id}` in application `{application_id}`"
     },
     "description": {
       "package": "pkg/joinserver/redis",
@@ -7208,9 +7208,9 @@
       "file": "redis.go"
     }
   },
-  "error:pkg/networkserver/redis:duplicate_identifiers": {
+  "error:pkg/networkserver/redis:end_device_euis_taken": {
     "translations": {
-      "en": "duplicate identifiers"
+      "en": "an end device with JoinEUI `{join_eui}` and DevEUI `{dev_eui}` is already registered as `{device_id}` in application `{application_id}`"
     },
     "description": {
       "package": "pkg/networkserver/redis",

--- a/config/messages.json
+++ b/config/messages.json
@@ -2717,15 +2717,6 @@
       "file": "registry.go"
     }
   },
-  "error:pkg/applicationserver/redis:end_device_euis_taken": {
-    "translations": {
-      "en": "an end device with JoinEUI `{join_eui}` and DevEUI `{dev_eui}` is already registered as `{device_id}` in application `{application_id}`"
-    },
-    "description": {
-      "package": "pkg/applicationserver/redis",
-      "file": "registry.go"
-    }
-  },
   "error:pkg/applicationserver/redis:invalid_fieldmask": {
     "translations": {
       "en": "invalid fieldmask"
@@ -6164,6 +6155,15 @@
       "file": "contact_info_registry.go"
     }
   },
+  "error:pkg/internal/registry:end_device_euis_taken": {
+    "translations": {
+      "en": "an end device with JoinEUI `{join_eui}` and DevEUI `{dev_eui}` is already registered as `{device_id}` in application `{application_id}`"
+    },
+    "description": {
+      "package": "pkg/internal/registry",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/interop:activation": {
     "translations": {
       "en": "activation disallowed"
@@ -6491,15 +6491,6 @@
   "error:pkg/joinserver/redis:already_provisioned": {
     "translations": {
       "en": "device already provisioned"
-    },
-    "description": {
-      "package": "pkg/joinserver/redis",
-      "file": "registry.go"
-    }
-  },
-  "error:pkg/joinserver/redis:end_device_euis_taken": {
-    "translations": {
-      "en": "an end device with JoinEUI `{join_eui}` and DevEUI `{dev_eui}` is already registered as `{device_id}` in application `{application_id}`"
     },
     "description": {
       "package": "pkg/joinserver/redis",
@@ -7206,15 +7197,6 @@
     "description": {
       "package": "pkg/networkserver/redis",
       "file": "redis.go"
-    }
-  },
-  "error:pkg/networkserver/redis:end_device_euis_taken": {
-    "translations": {
-      "en": "an end device with JoinEUI `{join_eui}` and DevEUI `{dev_eui}` is already registered as `{device_id}` in application `{application_id}`"
-    },
-    "description": {
-      "package": "pkg/networkserver/redis",
-      "file": "registry.go"
     }
   },
   "error:pkg/networkserver/redis:field": {

--- a/pkg/internal/registry/errors.go
+++ b/pkg/internal/registry/errors.go
@@ -1,0 +1,44 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package registry contains commonly used device registry functionality.
+package registry
+
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
+	"go.thethings.network/lorawan-stack/v3/pkg/unique"
+)
+
+var errEndDeviceEUIsTaken = errors.DefineAlreadyExists(
+	"end_device_euis_taken",
+	"an end device with JoinEUI `{join_eui}` and DevEUI `{dev_eui}` is already registered as `{device_id}` in application `{application_id}`", // nolint:lll
+)
+
+// UniqueEUIViolationErr creates a unique EUI violation error with the given UID.
+func UniqueEUIViolationErr(_ context.Context, joinEUI, devEUI types.EUI64, uid string) error {
+	deviceIDs, err := unique.ToDeviceID(uid)
+	if err != nil {
+		return err
+	}
+	attributes := []any{
+		"join_eui", joinEUI,
+		"dev_eui", devEUI,
+		"device_id", deviceIDs.GetDeviceId(),
+		"application_id", deviceIDs.GetApplicationIds().GetApplicationId(),
+	}
+	return errEndDeviceEUIsTaken.WithAttributes(attributes...)
+}

--- a/pkg/internal/registry/errors_test.go
+++ b/pkg/internal/registry/errors_test.go
@@ -1,0 +1,48 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"testing"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
+	"go.thethings.network/lorawan-stack/v3/pkg/unique"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+func TestUniqueEUIViolationErrDevIDs(t *testing.T) {
+	t.Parallel()
+	a, ctx := test.New(t)
+	devIDs := &ttnpb.EndDeviceIdentifiers{
+		DeviceId: "foo-device",
+		ApplicationIds: &ttnpb.ApplicationIdentifiers{
+			ApplicationId: "foo-app",
+		},
+	}
+	joinEUI := types.EUI64{0x00, 0x00, 0x00, 0x00, 0x00, 0x01}
+	devEUI := types.EUI64{0x00, 0x00, 0x00, 0x00, 0x00, 0x02}
+	devEUIStr := unique.ID(ctx, devIDs)
+	expected := errEndDeviceEUIsTaken.WithAttributes(
+		"join_eui", joinEUI,
+		"dev_eui", devEUI,
+		"device_id", devIDs.DeviceId,
+		"application_id", devIDs.ApplicationIds.ApplicationId,
+	)
+	actual := UniqueEUIViolationErr(ctx, joinEUI, devEUI, devEUIStr)
+	a.So(actual, should.NotBeNil)
+	a.So(actual.Error(), should.Equal, expected.Error())
+}


### PR DESCRIPTION
#### Summary
Provide error information in the AS/NS/JS device registries on uniqueness constraint violation.

Closes #6165

#### Changes
- Added attributes to the error definition


#### Testing
- Existing UT

##### Regressions
...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
