### PR TITLE
Count active end devices by last seen timestamps

### DIFF
--- a/pkg/telemetry/exporter/cli/cli.go
+++ b/pkg/telemetry/exporter/cli/cli.go
@@ -66,7 +66,7 @@ func ttnPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return path.Join(configPath, "ttn-lorawan"), nil
+	return path.Join(configPath, "ttn-lw-cli"), nil
 }
 
 // cliStatePath returns the path to the file in which the CLI telemetry is stored.
@@ -75,7 +75,7 @@ func cliStatePath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return path.Join(p, "cli-telemetry-state.yml"), nil
+	return path.Join(p, "telemetry.yml"), nil
 }
 
 // getCLIState returns the telemetry state, if it doesn't exist it creates a file with default values for the state.

--- a/pkg/telemetry/exporter/istelemetry/is.go
+++ b/pkg/telemetry/exporter/istelemetry/is.go
@@ -138,19 +138,19 @@ func (it *isTelemetry) countActiveDevices(ctx context.Context) (resp models.Acti
 		num   *uint64
 	}{
 		{
-			query: it.DB.NewSelect().Model(&store.EndDevice{}).Where("activated_at IS NOT NULL"),
+			query: it.DB.NewSelect().Model(&store.EndDevice{}).Where("last_seen_at IS NOT NULL"),
 			num:   &resp.Total,
 		},
 		{
-			query: it.DB.NewSelect().Model(&store.EndDevice{}).Where("activated_at > NOW() - INTERVAL '1 DAY'"),
+			query: it.DB.NewSelect().Model(&store.EndDevice{}).Where("last_seen_at > NOW() - INTERVAL '1 DAY'"),
 			num:   &resp.LastDay,
 		},
 		{
-			query: it.DB.NewSelect().Model(&store.EndDevice{}).Where("activated_at > NOW() - INTERVAL '1 WEEK'"),
+			query: it.DB.NewSelect().Model(&store.EndDevice{}).Where("last_seen_at > NOW() - INTERVAL '1 WEEK'"),
 			num:   &resp.LastWeek,
 		},
 		{
-			query: it.DB.NewSelect().Model(&store.EndDevice{}).Where("activated_at > NOW() - INTERVAL '1 MONTH'"),
+			query: it.DB.NewSelect().Model(&store.EndDevice{}).Where("last_seen_at > NOW() - INTERVAL '1 MONTH'"),
 			num:   &resp.LastMonth,
 		},
 	} {
@@ -193,10 +193,6 @@ func (it *isTelemetry) countUserByTypes(ctx context.Context) (resp models.UsersC
 		query *bun.SelectQuery
 		num   *uint64
 	}{
-		{
-			query: it.DB.NewSelect().Model(&store.User{}),
-			num:   &resp.Total,
-		},
 		{
 			query: it.DB.NewSelect().Model(&store.User{}).Where("admin IS TRUE"),
 			num:   &resp.Admin,

--- a/pkg/telemetry/exporter/models/entity_data.go
+++ b/pkg/telemetry/exporter/models/entity_data.go
@@ -22,7 +22,6 @@ type AccountsCount struct {
 
 // UsersCount telemetry data about the amount of users, total and the amount on each type.
 type UsersCount struct {
-	Total    uint64 `json:"total"`
 	Standard uint64 `json:"standard"`
 	Admin    uint64 `json:"admin"`
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the expressions used to count the number of active devices for telemetry uses.

`last_seen_at` is the timestamp at which the end device was last seen at, while `activate_at` is the timestamp of the first message processed for the end device.

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the total user count from the telemetry - it can be obtained by summing the admin and non-admin counts.
- Use `last_seen_at` to count active end devices by period.
- Use `ttn-lw-cli` as a cache folder, instead of `ttn-lorawan`. `ttn-lw-cli` is the already used path, so it's better to keep them in sync.

#### Testing

<!-- How did you verify that this change works? -->

N/A.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
