### PR TITLE
Metrics for NaN and Infinite values in payload decoders

### DIFF
--- a/pkg/applicationserver/observability.go
+++ b/pkg/applicationserver/observability.go
@@ -177,6 +177,14 @@ var asMetrics = &messageMetrics{
 		},
 		[]string{"error"},
 	),
+	uplinkPayloadValueViolations: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "uplink_payload_value_violations_total",
+			Help:      "Total number of uplink payload value violations",
+		},
+		[]string{"payload_formatter", "value_context", "value_type"},
+	),
 	nsAsUplinkLatency: metrics.NewContextualHistogramVec(
 		prometheus.HistogramOpts{
 			Subsystem: "ns_as",
@@ -219,6 +227,14 @@ var asMetrics = &messageMetrics{
 		},
 		[]string{"error"},
 	),
+	downlinkPayloadValueViolations: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "downlink_payload_value_violations_total",
+			Help:      "Total number of downlink payload value violations when decoding downlink messages",
+		},
+		[]string{"payload_formatter", "value_context", "value_type"},
+	),
 }
 
 func init() {
@@ -226,36 +242,42 @@ func init() {
 }
 
 type messageMetrics struct {
-	uplinkReceived     *metrics.ContextualCounterVec
-	uplinkForwarded    *metrics.ContextualCounterVec
-	uplinkDropped      *metrics.ContextualCounterVec
-	nsAsUplinkLatency  *metrics.ContextualHistogramVec
-	gtwAsUplinkLatency *metrics.ContextualHistogramVec
-	downlinkReceived   *metrics.ContextualCounterVec
-	downlinkForwarded  *metrics.ContextualCounterVec
-	downlinkDropped    *metrics.ContextualCounterVec
+	uplinkReceived                 *metrics.ContextualCounterVec
+	uplinkForwarded                *metrics.ContextualCounterVec
+	uplinkDropped                  *metrics.ContextualCounterVec
+	uplinkPayloadValueViolations   *metrics.ContextualCounterVec
+	nsAsUplinkLatency              *metrics.ContextualHistogramVec
+	gtwAsUplinkLatency             *metrics.ContextualHistogramVec
+	downlinkReceived               *metrics.ContextualCounterVec
+	downlinkForwarded              *metrics.ContextualCounterVec
+	downlinkDropped                *metrics.ContextualCounterVec
+	downlinkPayloadValueViolations *metrics.ContextualCounterVec
 }
 
 func (m messageMetrics) Describe(ch chan<- *prometheus.Desc) {
 	m.uplinkReceived.Describe(ch)
 	m.uplinkForwarded.Describe(ch)
 	m.uplinkDropped.Describe(ch)
+	m.uplinkPayloadValueViolations.Describe(ch)
 	m.nsAsUplinkLatency.Describe(ch)
 	m.gtwAsUplinkLatency.Describe(ch)
 	m.downlinkReceived.Describe(ch)
 	m.downlinkForwarded.Describe(ch)
 	m.downlinkDropped.Describe(ch)
+	m.downlinkPayloadValueViolations.Describe(ch)
 }
 
 func (m messageMetrics) Collect(ch chan<- prometheus.Metric) {
 	m.uplinkReceived.Collect(ch)
 	m.uplinkForwarded.Collect(ch)
 	m.uplinkDropped.Collect(ch)
+	m.uplinkPayloadValueViolations.Collect(ch)
 	m.nsAsUplinkLatency.Collect(ch)
 	m.gtwAsUplinkLatency.Collect(ch)
 	m.downlinkReceived.Collect(ch)
 	m.downlinkForwarded.Collect(ch)
 	m.downlinkDropped.Collect(ch)
+	m.downlinkPayloadValueViolations.Collect(ch)
 }
 
 func registerReceiveUp(ctx context.Context, msg *ttnpb.ApplicationUp) {

--- a/pkg/applicationserver/violations.go
+++ b/pkg/applicationserver/violations.go
@@ -1,0 +1,152 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package applicationserver
+
+import (
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// ValueType is the type of value violation (NaN, Infinity, -Infinity).
+type ValueType string
+
+func (vt ValueType) String() string {
+	return string(vt)
+}
+
+const (
+	// ValueTypeNaN is a NaN violation.
+	ValueTypeNaN ValueType = "NaN"
+
+	// ValueTypePosInf is a positive Infinity violation.
+	ValueTypePosInf ValueType = "Infinity"
+
+	// ValueTypeNegInf is a negative Infinity violation.
+	ValueTypeNegInf ValueType = "-Infinity"
+)
+
+// ValueContext is the context in which the value is located (struct, list).
+type ValueContext string
+
+func (vt ValueContext) String() string {
+	return string(vt)
+}
+
+const (
+	// ValueContextStruct indicates a violation in a struct.
+	ValueContextStruct ValueContext = "struct"
+
+	// ValueContextList indicates a violation in a list.
+	ValueContextList ValueContext = "list"
+)
+
+// ValueViolation is a violation of a value.
+type ValueViolation struct {
+	Type    ValueType
+	Context ValueContext
+}
+
+func findViolation(s string, valueContext ValueContext) *ValueViolation {
+	violation := ValueType(s)
+	switch violation {
+	case ValueTypeNaN:
+		return &ValueViolation{
+			Type:    ValueTypeNaN,
+			Context: valueContext,
+		}
+	case ValueTypePosInf:
+		return &ValueViolation{
+			Type:    ValueTypePosInf,
+			Context: valueContext,
+		}
+	case ValueTypeNegInf:
+		return &ValueViolation{
+			Type:    ValueTypeNegInf,
+			Context: valueContext,
+		}
+	}
+	return nil
+}
+
+func findListViolations(l *structpb.ListValue) []ValueViolation {
+	if l == nil {
+		return nil
+	}
+	total := make([]ValueViolation, 0)
+	for _, v := range l.Values {
+		switch vv := v.GetKind().(type) {
+		case *structpb.Value_StringValue:
+			if vv == nil {
+				break
+			}
+			violation := findViolation(vv.StringValue, ValueContextList)
+			if violation != nil {
+				total = append(total, *violation)
+			}
+		case *structpb.Value_StructValue:
+			if vv == nil {
+				break
+			}
+			total = append(total, findStructViolations(vv.StructValue)...)
+		case *structpb.Value_ListValue:
+			if vv == nil {
+				break
+			}
+			total = append(total, findListViolations(vv.ListValue)...)
+		}
+	}
+	return total
+}
+
+func findStructViolations(st *structpb.Struct) []ValueViolation {
+	if st == nil {
+		return nil
+	}
+	total := make([]ValueViolation, 0)
+	for _, v := range st.Fields {
+		switch vv := v.GetKind().(type) {
+		case *structpb.Value_StringValue:
+			if vv == nil {
+				break
+			}
+			violation := findViolation(vv.StringValue, ValueContextStruct)
+			if violation != nil {
+				total = append(total, *violation)
+			}
+		case *structpb.Value_StructValue:
+			if vv == nil {
+				break
+			}
+			stViolations := findStructViolations(vv.StructValue)
+			if len(stViolations) > 0 {
+				total = append(total, stViolations...)
+			}
+		case *structpb.Value_ListValue:
+			if vv == nil {
+				break
+			}
+			listViolations := findListViolations(vv.ListValue)
+			if len(listViolations) > 0 {
+				total = append(total, listViolations...)
+			}
+		}
+	}
+	return total
+}
+
+// FindViolations recursively verifies if the struct contains any invalid values (NaN, -Infinity, Infinity)
+// and creates ValueViolations for such fields.
+func FindViolations(st *structpb.Struct) []ValueViolation {
+	return findStructViolations(st)
+}

--- a/pkg/applicationserver/violations_test.go
+++ b/pkg/applicationserver/violations_test.go
@@ -1,0 +1,115 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package applicationserver
+
+import (
+	"testing"
+
+	"github.com/smarty/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestValidateStruct(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+
+		st       map[string]any
+		expected []ValueViolation
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "simple object",
+
+			st: map[string]any{
+				"foo": 123,
+			},
+		},
+		{
+			name: "top level NaN",
+			st: map[string]any{
+				"foo": "NaN",
+			},
+			expected: []ValueViolation{
+				{
+					Type:    ValueTypeNaN,
+					Context: ValueContextStruct,
+				},
+			},
+		},
+		{
+			name: "nested object Infinity",
+
+			st: map[string]any{
+				"foo": map[string]any{
+					"bar": "Infinity",
+				},
+			},
+			expected: []ValueViolation{
+				{
+					Type:    ValueTypePosInf,
+					Context: ValueContextStruct,
+				},
+			},
+		},
+		{
+			name: "nested object -Infinity",
+			st: map[string]any{
+				"foo": []any{"-Infinity"},
+			},
+			expected: []ValueViolation{
+				{
+					Type:    ValueTypeNegInf,
+					Context: ValueContextList,
+				},
+			},
+		},
+		{
+			name: "nested object NaN",
+			st: map[string]any{
+				"foo": []any{
+					map[string]any{
+						"bar": "NaN",
+					},
+				},
+			},
+			expected: []ValueViolation{
+				{
+					Type:    ValueTypeNaN,
+					Context: ValueContextStruct,
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := assertions.New(t)
+
+			st, err := structpb.NewStruct(tc.st)
+			if !a.So(err, should.BeNil) {
+				t.FailNow()
+			}
+
+			warnings := FindViolations(st)
+			a.So(warnings, should.Resemble, tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
Added two Prometheus counters to record the number of `NaN`, `+Infinity` and `-Infinity` values in the payload after uplink/downlink decoding.

References #6128
...

#### Changes
- Added the counters


#### Testing
- Created JavaScript payload formatters for uplink and downlinks that return `Number.NaN`, `Number.POSITIVE_INFINITY` and `Number.NEGATIVE_INFINITY` in the root of the `data`, as values in a list, and as a nested object in the `data` and inspected `/metrics`

Uplinks:
<img width="1085" alt="Screenshot 2023-07-06 at 16 29 08" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/48737089/159c5da3-9395-4d9b-8458-103fed08cb76">

Downlinks:
<img width="1110" alt="Screenshot 2023-07-06 at 16 29 37" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/48737089/4f32cb0e-44fb-47fe-ab6f-d9a949e0d022">

 
##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
