### PR TITLE
Fix device stream closure in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- End device data stream not being closed when navigating away from end device pages, which could cause event streams stopping to work due to too many open connections.
+
 ### Security
 
 ## [3.26.2] - unreleased

--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -20,6 +20,7 @@ import RequireRequest from '@ttn-lw/lib/components/require-request'
 
 import attachPromise from '@ttn-lw/lib/store/actions/attach-promise'
 import { selectNsConfig } from '@ttn-lw/lib/selectors/env'
+import { combineDeviceIds } from '@ttn-lw/lib/selectors/id'
 
 import {
   mayReadApplicationDeviceKeys,
@@ -99,7 +100,10 @@ const DeviceContainer = props => {
     [appId, devId, deviceSelector, linkSelector, mayViewLink],
   )
 
-  useEffect(() => () => dispatch(stopDeviceEventsStream(devId)), [dispatch, devId])
+  useEffect(
+    () => () => dispatch(stopDeviceEventsStream(combineDeviceIds(appId, devId))),
+    [appId, devId, dispatch],
+  )
 
   return (
     <RequireRequest requestAction={loadDeviceData}>


### PR DESCRIPTION
#### Summary
This PR fixes an issue that caused end device data streams to stay open after navigating away from the device page. This would cause event streams from working when too many connections were open already.

References #6338 

#### Changes

- Pass the correct combined ID to the end device stream stop action

#### Testing

Tested this manually.


#### Notes for Reviewers
This could be one potential cause for #6338 

cc @johanstokking @adriansmares 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
