### PR TITLE
Fix end-to-end test failed spec

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -160,6 +160,7 @@ jobs:
         continue-on-error: true
         run: |
           sed -i 's/\.\.\///g' .failed-specs-*.txt
+          sed -i 's|/integration/|/e2e/|' .failed-specs-*.txt
           echo "failed-test=$(paste -d , .failed-specs-*.txt)" >> $GITHUB_OUTPUT
           echo "neg-failed-test=!$(paste -d ',!' .failed-specs-*.txt)" >> $GITHUB_OUTPUT
       - name: Unzip build artifacts


### PR DESCRIPTION
#### Summary
This is a small quickfix to ensure that the end-to-end tests will not fail due to having old files in the failed specs cache.

#### Changes
- Replace `/integration/` with `/e2e/` (this has been changed by a cypress update)

#### Notes for Reviewers
The workflow will store the name of the previously failed test. This fails now when the cache has a filename of the spec file before the move from `/integration/` to `/e2e/`.
This is only temporarily required and can be removed once the cache has been overwritten.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
