### PR TITLE
Don't store empty LoRa GLS package associations

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2294,15 +2294,6 @@
       "file": "data.go"
     }
   },
-  "error:pkg/applicationserver/io/packages/loragls/v3:empty_data": {
-    "translations": {
-      "en": "empty data"
-    },
-    "description": {
-      "package": "pkg/applicationserver/io/packages/loragls/v3",
-      "file": "data.go"
-    }
-  },
   "error:pkg/applicationserver/io/packages/loragls/v3:encoding_field": {
     "translations": {
       "en": "encoding field `{field}`"

--- a/config/messages.json
+++ b/config/messages.json
@@ -2294,6 +2294,15 @@
       "file": "data.go"
     }
   },
+  "error:pkg/applicationserver/io/packages/loragls/v3:empty_data": {
+    "translations": {
+      "en": "empty data"
+    },
+    "description": {
+      "package": "pkg/applicationserver/io/packages/loragls/v3",
+      "file": "data.go"
+    }
+  },
   "error:pkg/applicationserver/io/packages/loragls/v3:encoding_field": {
     "translations": {
       "en": "encoding field `{field}`"
@@ -2303,9 +2312,9 @@
       "file": "data.go"
     }
   },
-  "error:pkg/applicationserver/io/packages/loragls/v3:field_not_found": {
+  "error:pkg/applicationserver/io/packages/loragls/v3:field_required": {
     "translations": {
-      "en": "field `{field}` not found"
+      "en": "field `{field}` is required"
     },
     "description": {
       "package": "pkg/applicationserver/io/packages/loragls/v3",

--- a/pkg/applicationserver/io/packages/loragls/v3/data.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/data.go
@@ -25,15 +25,19 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages/loragls/v3/api"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	urlutil "go.thethings.network/lorawan-stack/v3/pkg/util/url"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var (
-	errFieldNotFound = errors.DefineNotFound("field_not_found", "field `{field}` not found")
+	errFieldRequired = errors.DefineNotFound("field_required", "field `{field}` is required")
 	errInvalidType   = errors.DefineCorruption("invalid_type", "wrong type `{type}`")
 	errInvalidValue  = errors.DefineCorruption("invalid_value", "wrong value `{value}`")
 	errEncodingField = errors.DefineCorruption("encoding_field", "encoding field `{field}`")
 	errDecodingField = errors.DefineCorruption("decoding_field", "decoding field `{field}`")
+
+	// ErrEmptyData is a sentinel error that indicates that the data is empty.
+	ErrEmptyData = errors.DefineInvalidArgument("empty_data", "empty data")
 )
 
 // UplinkMetadata contains the uplink metadata stored by the package.
@@ -72,11 +76,7 @@ func (t QueryType) Value() *structpb.Value {
 	default:
 		panic("invalid query type")
 	}
-	return &structpb.Value{
-		Kind: &structpb.Value_StringValue{
-			StringValue: s,
-		},
-	}
+	return structpb.NewStringValue(s)
 }
 
 // FromValue sets the query type from a protobuf value.
@@ -110,17 +110,17 @@ const (
 // Data contains the package configuration.
 type Data struct {
 	// Query is the query type used by the package.
-	Query QueryType
+	Query *QueryType
 	// MultiFrame enables multi frame requests for TOARSSI queries.
-	MultiFrame bool
+	MultiFrame *bool
 	// MultiFrameWindowSize represents the number of historical frames to consider for the query.
-	MultiFrameWindowSize int
+	MultiFrameWindowSize *int
 	// MultiFrameWindowAge limits the maximum age of the historical frames considered for the query.
-	MultiFrameWindowAge time.Duration
+	MultiFrameWindowAge *time.Duration
 	// ServerURL represents the remote server to which the GLS queries are sent.
 	ServerURL *url.URL
 	// Token is the API token to be used when comunicating with the GLS server.
-	Token string
+	Token *string
 	// RecentMetadata are the metadatas from the recent uplink messages received by the gateway.
 	RecentMetadata []*UplinkMetadata
 }
@@ -134,30 +134,6 @@ const (
 	tokenField           = "token"
 	recentMDField        = "recent_metadata"
 )
-
-func toString(s string) *structpb.Value {
-	return &structpb.Value{
-		Kind: &structpb.Value_StringValue{
-			StringValue: s,
-		},
-	}
-}
-
-func toBool(b bool) *structpb.Value {
-	return &structpb.Value{
-		Kind: &structpb.Value_BoolValue{
-			BoolValue: b,
-		},
-	}
-}
-
-func toFloat64(f float64) *structpb.Value {
-	return &structpb.Value{
-		Kind: &structpb.Value_NumberValue{
-			NumberValue: f,
-		},
-	}
-}
 
 func toRecentMD(mds []*UplinkMetadata) (*structpb.Value, error) {
 	gobBytes := new(bytes.Buffer)
@@ -176,37 +152,81 @@ func toRecentMD(mds []*UplinkMetadata) (*structpb.Value, error) {
 		return nil, errEncodingField.WithCause(err).WithAttributes("field", recentMDField)
 	}
 
-	return toString(base64Bytes.String()), nil
+	return structpb.NewStringValue(base64Bytes.String()), nil
+}
+
+// GetMultiFrameWindowAge returns the value of the MultiFrameWindowAge field.
+func (d *Data) GetMultiFrameWindowAge() time.Duration {
+	if d.MultiFrameWindowAge == nil {
+		return 0
+	}
+	return *d.MultiFrameWindowAge
+}
+
+// GetMultiFrameWindowSize returns the value of the MultiFrameWindowSize field.
+func (d *Data) GetMultiFrameWindowSize() int {
+	if d.MultiFrameWindowSize == nil {
+		return 0
+	}
+	return *d.MultiFrameWindowSize
+}
+
+// GetMultiFrame returns the value of the MultiFrame field.
+func (d *Data) GetMultiFrame() bool {
+	if d.MultiFrame == nil {
+		return false
+	}
+	return *d.MultiFrame
 }
 
 // Struct serializes the configuration to *structpb.Struct.
 func (d *Data) Struct() (*structpb.Struct, error) {
-	st := &structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			queryField: d.Query.Value(),
-			tokenField: toString(d.Token),
-		},
+	fields := map[string]*structpb.Value{}
+
+	if d.Token != nil && *d.Token != "" {
+		fields[tokenField] = structpb.NewStringValue(*d.Token)
 	}
-	if d.ServerURL != nil {
-		st.Fields[serverURLField] = toString(d.ServerURL.String())
+
+	if d.Query != nil {
+		fields[queryField] = d.Query.Value()
 	}
-	if d.MultiFrame {
-		st.Fields[multiFrameField] = toBool(d.MultiFrame)
+
+	if d.MultiFrame != nil {
+		fields[multiFrameField] = structpb.NewBoolValue(*d.MultiFrame)
 	}
-	if d.MultiFrameWindowSize > 0 {
-		st.Fields[multiFrameWindowSize] = toFloat64(float64(d.MultiFrameWindowSize))
+
+	if d.ServerURL != nil && d.ServerURL.String() != "" {
+		fields[serverURLField] = structpb.NewStringValue(d.ServerURL.String())
 	}
-	if d.MultiFrameWindowAge > 0 {
-		st.Fields[multiFrameWindowAge] = toFloat64(float64(d.MultiFrameWindowAge / time.Minute))
+
+	if d.MultiFrame != nil {
+		fields[multiFrameField] = structpb.NewBoolValue(*d.MultiFrame)
 	}
+
+	if d.MultiFrameWindowSize != nil {
+		fields[multiFrameWindowSize] = structpb.NewNumberValue(float64(*d.MultiFrameWindowSize))
+	}
+
+	if d.MultiFrameWindowAge != nil {
+		windowAge := d.MultiFrameWindowAge.Minutes()
+		fields[multiFrameWindowAge] = structpb.NewNumberValue(windowAge)
+	}
+
 	if len(d.RecentMetadata) > 0 {
 		recentMD, err := toRecentMD(d.RecentMetadata)
 		if err != nil {
 			return nil, err
 		}
-		st.Fields[recentMDField] = recentMD
+		fields[recentMDField] = recentMD
 	}
-	return st, nil
+
+	if len(fields) == 0 {
+		return nil, ErrEmptyData.New()
+	}
+
+	return &structpb.Struct{
+		Fields: fields,
+	}, nil
 }
 
 func stringFromValue(v *structpb.Value) (string, error) {
@@ -257,79 +277,112 @@ func recentMDFromValue(v *structpb.Value) ([]*UplinkMetadata, error) {
 // FromStruct deserializes the configuration from *structpb.Struct.
 func (d *Data) FromStruct(st *structpb.Struct) error {
 	fields := st.GetFields()
-	{
-		value, ok := fields[queryField]
-		if !ok {
-			return errFieldNotFound.WithAttributes("field", queryField)
-		}
-		if err := d.Query.FromValue(value); err != nil {
+	if value, ok := fields[queryField]; ok {
+		query := new(QueryType)
+		if err := query.FromValue(value); err != nil {
 			return err
 		}
+		d.Query = query
 	}
-	{
-		value, ok := fields[multiFrameField]
-		if ok {
-			multiFrame, err := boolFromValue(value)
-			if err != nil {
-				return err
-			}
-			d.MultiFrame = multiFrame
+	if value, ok := fields[multiFrameField]; ok {
+		multiFrame, err := boolFromValue(value)
+		if err != nil {
+			return err
 		}
+		d.MultiFrame = &multiFrame
 	}
-	{
-		value, ok := fields[multiFrameWindowSize]
-		if ok {
-			windowSize, err := float64FromValue(value)
-			if err != nil {
-				return err
-			}
-			d.MultiFrameWindowSize = int(windowSize)
+	if value, ok := fields[multiFrameWindowSize]; ok {
+		floatValue, err := float64FromValue(value)
+		if err != nil {
+			return err
 		}
+		windowSize := int(floatValue)
+		d.MultiFrameWindowSize = &windowSize
 	}
-	{
-		value, ok := fields[multiFrameWindowAge]
-		if ok {
-			windowAge, err := float64FromValue(value)
-			if err != nil {
-				return err
-			}
-			d.MultiFrameWindowAge = time.Duration(windowAge) * time.Minute
+	if value, ok := fields[multiFrameWindowAge]; ok {
+		windowAge, err := float64FromValue(value)
+		if err != nil {
+			return err
 		}
+		windowAgeDuration := time.Duration(windowAge) * time.Minute
+		d.MultiFrameWindowAge = &windowAgeDuration
 	}
-	{
-		value, ok := fields[tokenField]
-		if !ok {
-			return errFieldNotFound.WithAttributes("field", tokenField)
-		}
+	if value, ok := fields[tokenField]; ok {
 		token, err := stringFromValue(value)
 		if err != nil {
 			return err
 		}
-		d.Token = token
+		d.Token = &token
 	}
-	{
-		value, ok := fields[serverURLField]
-		if ok {
-			serverURL, err := stringFromValue(value)
-			if err != nil {
-				return err
-			}
-			u, err := url.Parse(serverURL)
-			if err != nil {
-				return err
-			}
-			d.ServerURL = u
+	if value, ok := fields[serverURLField]; ok {
+		serverURL, err := stringFromValue(value)
+		if err != nil {
+			return err
 		}
+		u, err := url.Parse(serverURL)
+		if err != nil {
+			return err
+		}
+		d.ServerURL = u
 	}
-	{
-		value, ok := fields[recentMDField]
-		if ok {
-			uplinks, err := recentMDFromValue(value)
-			if err != nil {
-				return err
-			}
-			d.RecentMetadata = uplinks
+	if value, ok := fields[recentMDField]; ok {
+		uplinks, err := recentMDFromValue(value)
+		if err != nil {
+			return err
 		}
+		d.RecentMetadata = uplinks
+	}
+	return nil
+}
+
+func mergeData(defaultData, associationData Data) *Data {
+	merged := Data{
+		Query:                defaultData.Query,
+		MultiFrame:           defaultData.MultiFrame,
+		MultiFrameWindowSize: defaultData.MultiFrameWindowSize,
+		MultiFrameWindowAge:  defaultData.MultiFrameWindowAge,
+		ServerURL:            defaultData.ServerURL,
+		Token:                defaultData.Token,
+		RecentMetadata:       defaultData.RecentMetadata,
+	}
+
+	if associationData.Query != nil {
+		merged.Query = associationData.Query
+	}
+	if associationData.MultiFrame != nil {
+		merged.MultiFrame = associationData.MultiFrame
+	}
+	if associationData.MultiFrameWindowSize != nil {
+		merged.MultiFrameWindowSize = associationData.MultiFrameWindowSize
+	}
+	if associationData.MultiFrameWindowAge != nil {
+		merged.MultiFrameWindowAge = associationData.MultiFrameWindowAge
+	}
+	if associationData.ServerURL != nil {
+		merged.ServerURL = urlutil.CloneURL(associationData.ServerURL)
+	}
+	if associationData.Token != nil {
+		merged.Token = associationData.Token
+	}
+	if len(associationData.RecentMetadata) > 0 {
+		merged.RecentMetadata = associationData.RecentMetadata
+	}
+	if merged.ServerURL == nil {
+		merged.ServerURL = urlutil.CloneURL(api.DefaultServerURL)
+	}
+	return &merged
+}
+
+// validateData validates the package configuration.
+func validateData(data *Data) error {
+	if data.Query == nil {
+		return errFieldRequired.WithAttributes("field", queryField)
+	}
+	if data.ServerURL == nil {
+		return errFieldRequired.WithAttributes("field", serverURLField)
+	}
+	if data.Token == nil {
+		return errFieldRequired.WithAttributes("field", tokenField)
 	}
 	return nil
 }

--- a/pkg/applicationserver/io/packages/loragls/v3/data.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/data.go
@@ -35,9 +35,6 @@ var (
 	errInvalidValue  = errors.DefineCorruption("invalid_value", "wrong value `{value}`")
 	errEncodingField = errors.DefineCorruption("encoding_field", "encoding field `{field}`")
 	errDecodingField = errors.DefineCorruption("decoding_field", "decoding field `{field}`")
-
-	// ErrEmptyData is a sentinel error that indicates that the data is empty.
-	ErrEmptyData = errors.DefineInvalidArgument("empty_data", "empty data")
 )
 
 // UplinkMetadata contains the uplink metadata stored by the package.
@@ -221,7 +218,7 @@ func (d *Data) Struct() (*structpb.Struct, error) {
 	}
 
 	if len(fields) == 0 {
-		return nil, ErrEmptyData.New()
+		return nil, nil // nolint: nilnil
 	}
 
 	return &structpb.Struct{

--- a/pkg/applicationserver/io/packages/loragls/v3/data_test.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/data_test.go
@@ -180,7 +180,7 @@ func TestPackageDataSerialization(t *testing.T) {
 		{
 			Name:          "DoesNotSerializezNilValues",
 			InputData:     &Data{},
-			ExpectedError: ErrEmptyData.New(),
+			ExpectedError: nil,
 			ExpectedData:  nil,
 		},
 		{
@@ -191,7 +191,7 @@ func TestPackageDataSerialization(t *testing.T) {
 				Token:          new(string),
 				RecentMetadata: []*UplinkMetadata{},
 			},
-			ExpectedError: ErrEmptyData.New(),
+			ExpectedError: nil,
 			ExpectedData:  nil,
 		},
 		{

--- a/pkg/applicationserver/io/packages/loragls/v3/data_test.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/data_test.go
@@ -23,6 +23,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages/loragls/v3/api"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // nolint: gosec
@@ -51,7 +52,36 @@ func generateRandomizedMD(count int) [][]*api.RxMetadata {
 	return md
 }
 
-func TestPackageDataRoundtrip(t *testing.T) {
+func queryTypePtr(i uint8) *QueryType {
+	qt := QueryType(i)
+	return &qt
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func durationPtr(d time.Duration) *time.Duration {
+	return &d
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+func stringPtr(str string) *string {
+	return &str
+}
+
+func mustParse(str string) *url.URL {
+	u, err := url.Parse(str)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func TestRecentMetadataRoundtrip(t *testing.T) {
 	t.Parallel()
 	a, _ := test.New(t)
 	now := time.Now().UTC().Truncate(time.Second)
@@ -64,18 +94,13 @@ func TestPackageDataRoundtrip(t *testing.T) {
 			ReceivedAt: now.Add(time.Duration(i) * time.Second),
 		}
 	}
-
-	u, err := url.Parse("https://thethingsindustries.com")
-	if !a.So(err, should.BeNil) {
-		t.FailNow()
-	}
 	expectedData := Data{
-		Query:                1,
-		MultiFrame:           true,
-		MultiFrameWindowSize: 10,
-		MultiFrameWindowAge:  10 * time.Minute,
-		ServerURL:            u,
-		Token:                "some_random_token",
+		Query:                queryTypePtr(1),
+		MultiFrame:           boolPtr(true),
+		MultiFrameWindowSize: intPtr(10),
+		MultiFrameWindowAge:  durationPtr(10 * time.Minute),
+		ServerURL:            mustParse("https://example.com"),
+		Token:                stringPtr("test-token"),
 		RecentMetadata:       uplinkMDs,
 	}
 	st, err := expectedData.Struct()
@@ -88,4 +113,273 @@ func TestPackageDataRoundtrip(t *testing.T) {
 		t.FailNow()
 	}
 	a.So(actualData, should.Resemble, expectedData)
+}
+
+func TestPackageDataDeserialization(t *testing.T) {
+	t.Parallel()
+	a, _ := test.New(t)
+
+	testCases := []struct {
+		Name          string
+		InputData     map[string]any
+		ExpectedData  *Data
+		ExpectedError error
+	}{
+		{
+			Name:          "DoesNotDeserializeEmptyData",
+			InputData:     map[string]any{},
+			ExpectedData:  &Data{},
+			ExpectedError: nil,
+		},
+		{
+			Name: "SuccessfullyDeserializesData",
+			InputData: map[string]any{
+				queryField:           "TOARSSI",
+				multiFrameField:      true,
+				multiFrameWindowSize: 10,
+				multiFrameWindowAge:  10,
+				serverURLField:       "https://example.com",
+				tokenField:           "test-token",
+			},
+			ExpectedData: &Data{
+				Query:                queryTypePtr(1),
+				MultiFrame:           boolPtr(true),
+				MultiFrameWindowSize: intPtr(10),
+				MultiFrameWindowAge:  durationPtr(10 * time.Minute),
+				ServerURL:            mustParse("https://example.com"),
+				Token:                stringPtr("test-token"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			data := &Data{}
+			st, err := structpb.NewStruct(tc.InputData)
+			if !a.So(err, should.BeNil) {
+				t.FailNow()
+			}
+			err = data.FromStruct(st)
+			a.So(err, should.EqualErrorOrDefinition, tc.ExpectedError)
+		})
+	}
+}
+
+func TestPackageDataSerialization(t *testing.T) {
+	t.Parallel()
+	a, _ := test.New(t)
+
+	testCases := []struct {
+		Name          string
+		InputData     *Data
+		ExpectedData  *structpb.Struct
+		ExpectedError error
+	}{
+		{
+			Name:          "DoesNotSerializezNilValues",
+			InputData:     &Data{},
+			ExpectedError: ErrEmptyData.New(),
+			ExpectedData:  nil,
+		},
+		{
+			Name: "DoesNotSerializeEmptyValues",
+			InputData: &Data{
+				Query:          nil,
+				ServerURL:      &url.URL{},
+				Token:          new(string),
+				RecentMetadata: []*UplinkMetadata{},
+			},
+			ExpectedError: ErrEmptyData.New(),
+			ExpectedData:  nil,
+		},
+		{
+			Name: "SerializesData",
+			InputData: &Data{
+				Query:                queryTypePtr(0),
+				MultiFrame:           boolPtr(true),
+				MultiFrameWindowSize: intPtr(10),
+				MultiFrameWindowAge:  durationPtr(10 * time.Minute),
+				ServerURL:            mustParse("https://example.com"),
+				Token:                stringPtr("test-token"),
+			},
+			ExpectedError: nil,
+			ExpectedData: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					queryField:           structpb.NewStringValue("TOARSSI"),
+					multiFrameField:      structpb.NewBoolValue(true),
+					multiFrameWindowSize: structpb.NewNumberValue(10),
+					multiFrameWindowAge:  structpb.NewNumberValue(10),
+					serverURLField:       structpb.NewStringValue("https://example.com"),
+					tokenField:           structpb.NewStringValue("test-token"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			actualData, err := tc.InputData.Struct()
+
+			a.So(err, should.EqualErrorOrDefinition, tc.ExpectedError)
+			a.So(actualData, should.Resemble, tc.ExpectedData)
+		})
+	}
+}
+
+func TestPackageDataMerge(t *testing.T) {
+	t.Parallel()
+	a, _ := test.New(t)
+
+	testCases := []struct {
+		Name            string
+		DefaultData     Data
+		AssociationData Data
+		ExpectedData    *Data
+	}{
+		{
+			Name: "TakesDefaultData",
+			DefaultData: Data{
+				Query:                queryTypePtr(1),
+				MultiFrame:           boolPtr(true),
+				MultiFrameWindowSize: intPtr(10),
+				MultiFrameWindowAge:  durationPtr(10 * time.Minute),
+				ServerURL:            mustParse("https://example.com"),
+				Token:                stringPtr("test-token"),
+			},
+			AssociationData: Data{},
+			ExpectedData: &Data{
+				Query:                queryTypePtr(1),
+				MultiFrame:           boolPtr(true),
+				MultiFrameWindowSize: intPtr(10),
+				MultiFrameWindowAge:  durationPtr(10 * time.Minute),
+				ServerURL:            mustParse("https://example.com"),
+				Token:                stringPtr("test-token"),
+			},
+		},
+		{
+			Name: "FillsEmptyValues",
+			DefaultData: Data{
+				Query:     queryTypePtr(1),
+				ServerURL: mustParse("https://example.com"),
+				Token:     stringPtr("test-token"),
+			},
+			AssociationData: Data{
+				MultiFrame:           boolPtr(true),
+				MultiFrameWindowSize: intPtr(10),
+				MultiFrameWindowAge:  durationPtr(10 * time.Minute),
+			},
+			ExpectedData: &Data{
+				Query:                queryTypePtr(1),
+				MultiFrame:           boolPtr(true),
+				MultiFrameWindowSize: intPtr(10),
+				MultiFrameWindowAge:  durationPtr(10 * time.Minute),
+				ServerURL:            mustParse("https://example.com"),
+				Token:                stringPtr("test-token"),
+			},
+		},
+		{
+			Name: "OverridesDefaultValues",
+			DefaultData: Data{
+				Query:                queryTypePtr(1),
+				MultiFrame:           boolPtr(true),
+				MultiFrameWindowSize: intPtr(10),
+				MultiFrameWindowAge:  durationPtr(10 * time.Minute),
+				ServerURL:            mustParse("https://example.com"),
+				Token:                stringPtr("test-token"),
+			},
+			AssociationData: Data{
+				Query:                queryTypePtr(2),
+				MultiFrame:           boolPtr(false),
+				MultiFrameWindowSize: intPtr(4),
+				MultiFrameWindowAge:  durationPtr(3 * time.Minute),
+				ServerURL:            mustParse("https://other.example.com"),
+				Token:                stringPtr("other-test-token"),
+			},
+			ExpectedData: &Data{
+				Query:                queryTypePtr(2),
+				MultiFrame:           boolPtr(false),
+				MultiFrameWindowSize: intPtr(4),
+				MultiFrameWindowAge:  durationPtr(3 * time.Minute),
+				ServerURL:            mustParse("https://other.example.com"),
+				Token:                stringPtr("other-test-token"),
+			},
+		},
+		{
+			Name:            "PopulatesDefaultPackageValues",
+			DefaultData:     Data{},
+			AssociationData: Data{},
+			ExpectedData: &Data{
+				ServerURL: api.DefaultServerURL,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			actualData := mergeData(tc.DefaultData, tc.AssociationData)
+			a.So(actualData, should.Resemble, tc.ExpectedData)
+		})
+	}
+}
+
+func TestPackageDataValidation(t *testing.T) {
+	t.Parallel()
+	a, _ := test.New(t)
+	testCases := []struct {
+		Name       string
+		MergedData *Data
+		Error      error
+	}{
+		{
+			Name: "ValidData",
+			MergedData: &Data{
+				Query:     queryTypePtr(1),
+				Token:     stringPtr("test-token"),
+				ServerURL: mustParse("https://example.com"),
+			},
+			Error: nil,
+		},
+		{
+			Name: "MissingQuery",
+			MergedData: &Data{
+				Token:     stringPtr("test-token"),
+				ServerURL: mustParse("https://example.com"),
+			},
+			Error: errFieldRequired.WithAttributes("field", queryField),
+		},
+		{
+			Name: "MissingToken",
+			MergedData: &Data{
+				Query:     queryTypePtr(1),
+				ServerURL: mustParse("https://example.com"),
+			},
+			Error: errFieldRequired.WithAttributes("field", tokenField),
+		},
+		{
+			Name: "MissingServerURL",
+			MergedData: &Data{
+				Query: queryTypePtr(1),
+				Token: stringPtr("test-token"),
+			},
+			Error: errFieldRequired.WithAttributes("field", serverURLField),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateData(tc.MergedData)
+			a.So(err, should.EqualErrorOrDefinition, tc.Error)
+		})
+	}
 }

--- a/pkg/applicationserver/io/packages/loragls/v3/package.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/package.go
@@ -30,7 +30,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/jsonpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
-	urlutil "go.thethings.network/lorawan-stack/v3/pkg/util/url"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -80,7 +79,7 @@ func (p *GeolocationPackage) HandleUp(
 		}
 	}()
 
-	data, err := p.mergePackageData(def, assoc)
+	data, err := p.mergeAndValidatePackageData(def, assoc)
 	if err != nil {
 		return err
 	}
@@ -183,14 +182,14 @@ func (p *GeolocationPackage) pushUplink(
 	up *ttnpb.ApplicationUplink,
 	data *Data,
 ) error {
-	windowSize := constrainedWindowSize(data.MultiFrameWindowSize)
+	windowSize := constrainedWindowSize(data.GetMultiFrameWindowSize())
 
 	setter := func(assoc *ttnpb.ApplicationPackageAssociation) (*ttnpb.ApplicationPackageAssociation, []string, error) {
 		assocData := &Data{}
 		fieldMask := []string{"data"}
 
 		if assoc == nil {
-			if !data.MultiFrame {
+			if !data.GetMultiFrame() {
 				return nil, nil, nil
 			}
 
@@ -205,7 +204,7 @@ func (p *GeolocationPackage) pushUplink(
 			}
 		}
 
-		if data.MultiFrame {
+		if data.GetMultiFrame() {
 			if len(assocData.RecentMetadata) >= windowSize {
 				assocData.RecentMetadata = assocData.RecentMetadata[1:]
 			}
@@ -221,6 +220,9 @@ func (p *GeolocationPackage) pushUplink(
 		data.RecentMetadata = assocData.RecentMetadata
 
 		st, err := assocData.Struct()
+		if errors.Is(err, ErrEmptyData) {
+			return nil, nil, nil
+		}
 		if err != nil {
 			return nil, nil, err
 		}
@@ -240,13 +242,13 @@ func (*GeolocationPackage) multiFrameQuery(
 	data *Data,
 	client *api.Client,
 ) (api.AbstractLocationSolverResponse, error) {
-	windowSize := constrainedWindowSize(data.MultiFrameWindowSize)
+	windowSize := constrainedWindowSize(data.GetMultiFrameWindowSize())
 
 	now := time.Now()
 	mds := make([][]*api.RxMetadata, 0, windowSize)
 
 	for _, md := range data.RecentMetadata {
-		if now.Sub(md.ReceivedAt) > data.MultiFrameWindowAge {
+		if now.Sub(md.ReceivedAt) > data.GetMultiFrameWindowAge() {
 			continue
 		}
 
@@ -311,9 +313,9 @@ func (p *GeolocationPackage) wifiQuery(ctx context.Context, ids *ttnpb.EndDevice
 
 func (p *GeolocationPackage) sendQuery(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, up *ttnpb.ApplicationUplink, data *Data) error {
 	var runQuery func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.ApplicationUplink, *Data, *api.Client) (api.AbstractLocationSolverResponse, error)
-	switch data.Query {
+	switch *data.Query {
 	case QUERY_TOARSSI:
-		if data.MultiFrame {
+		if data.GetMultiFrame() {
 			runQuery = p.multiFrameQuery
 		} else {
 			runQuery = p.singleFrameQuery
@@ -330,7 +332,7 @@ func (p *GeolocationPackage) sendQuery(ctx context.Context, ids *ttnpb.EndDevice
 	if err != nil {
 		return err
 	}
-	client, err := api.New(httpClient, api.WithToken(data.Token), api.WithBaseURL(data.ServerURL))
+	client, err := api.New(httpClient, api.WithToken(*data.Token), api.WithBaseURL(data.ServerURL))
 	if err != nil {
 		return err
 	}
@@ -401,7 +403,7 @@ func (p *GeolocationPackage) sendLocationSolved(ctx context.Context, ids *ttnpb.
 	})
 }
 
-func (*GeolocationPackage) mergePackageData(
+func (*GeolocationPackage) mergeAndValidatePackageData(
 	def *ttnpb.ApplicationPackageDefaultAssociation,
 	assoc *ttnpb.ApplicationPackageAssociation,
 ) (*Data, error) {
@@ -417,32 +419,11 @@ func (*GeolocationPackage) mergePackageData(
 		}
 	}
 
-	merged := Data{
-		Query:                defaultData.Query,
-		MultiFrame:           defaultData.MultiFrame,
-		MultiFrameWindowSize: defaultData.MultiFrameWindowSize,
-		MultiFrameWindowAge:  defaultData.MultiFrameWindowAge,
-		ServerURL:            defaultData.ServerURL,
-		Token:                defaultData.Token,
-		RecentMetadata:       defaultData.RecentMetadata,
+	merged := mergeData(defaultData, associationData)
+	if err := validateData(merged); err != nil {
+		return nil, err
 	}
-
-	if associationData.Query != 0 {
-		merged.Query = associationData.Query
-	}
-	if associationData.ServerURL != nil {
-		merged.ServerURL = urlutil.CloneURL(associationData.ServerURL)
-	}
-	if associationData.Token != "" {
-		merged.Token = associationData.Token
-	}
-	if len(associationData.RecentMetadata) > 0 {
-		merged.RecentMetadata = associationData.RecentMetadata
-	}
-	if merged.ServerURL == nil {
-		merged.ServerURL = urlutil.CloneURL(api.DefaultServerURL)
-	}
-	return &merged, nil
+	return merged, nil
 }
 
 func toStruct(i any) (*structpb.Struct, error) {

--- a/pkg/applicationserver/io/packages/loragls/v3/package.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/package.go
@@ -220,10 +220,7 @@ func (p *GeolocationPackage) pushUplink(
 		data.RecentMetadata = assocData.RecentMetadata
 
 		st, err := assocData.Struct()
-		if errors.Is(err, ErrEmptyData) {
-			return nil, nil, nil
-		}
-		if err != nil {
+		if st == nil || err != nil {
 			return nil, nil, err
 		}
 		assoc.Data = st


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
Reduce the number of stored fields in the package data associations by allowing nil fields. Remove the package data association if the data is empty.

Closes #6342 

#### Changes
- Made the data fields in the LoRa Cloud GLS integration `nil`-able
- Split the data merging logic from the validation
- Added unit tests

#### Testing
- Manual using the `simulate` command
- Unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
