### PR TITLE
Improve entity deletion logic in Console

### DIFF
--- a/pkg/webui/components/select/index.js
+++ b/pkg/webui/components/select/index.js
@@ -171,7 +171,7 @@ Select.propTypes = {
   ),
   placeholder: PropTypes.message,
   showOptionIcon: PropTypes.bool,
-  value: PropTypes.oneOf([PropTypes.string, PropTypes.shape({})]),
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),
   warning: PropTypes.bool,
 }
 

--- a/pkg/webui/components/select/select.styl
+++ b/pkg/webui/components/select/select.styl
@@ -39,6 +39,8 @@
   :global(.select__value-container)
     padding: 0 8px
     white-space: nowrap
+  :global(.select__clear-indicator)
+    cursor: pointer
 
     div:last-child
       padding:0 !important

--- a/pkg/webui/console/containers/account-select/index.js
+++ b/pkg/webui/console/containers/account-select/index.js
@@ -24,7 +24,7 @@ import Icon from '@ttn-lw/components/icon'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import attachPromise from '@ttn-lw/lib/store/actions/attach-promise'
 import { searchAccounts } from '@ttn-lw/lib/store/actions/search-accounts'
-import { selectSearchResults } from '@ttn-lw/lib/store/selectors/search-accounts'
+import { selectSearchResultAccountIds } from '@ttn-lw/lib/store/selectors/search-accounts'
 
 import styles from './account-select.styl'
 
@@ -51,7 +51,7 @@ const m = defineMessages({
 
 const Suggest = ({ entity, ...rest }) => {
   const dispatch = useDispatch()
-  const searchResults = useSelector(selectSearchResults)
+  const searchResults = useSelector(selectSearchResultAccountIds)
   const searchResultsRef = useRef()
   searchResultsRef.current = searchResults
   const { formatMessage } = useIntl()

--- a/pkg/webui/console/store/selectors/pubsubs.js
+++ b/pkg/webui/console/store/selectors/pubsubs.js
@@ -21,6 +21,7 @@ const selectPubsubStore = state => state.pubsubs
 
 // Pubsub.
 export const selectPubsubEntityStore = state => selectPubsubStore(state).entities
+export const selectPubsubById = (state, id) => selectPubsubEntityStore(state)[id]
 export const selectSelectedPubsubId = state => selectPubsubStore(state).selectedPubsub
 export const selectSelectedPubsub = state =>
   selectPubsubEntityStore(state)[selectSelectedPubsubId(state)]

--- a/pkg/webui/console/views/application-api-key-edit/index.js
+++ b/pkg/webui/console/views/application-api-key-edit/index.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import { Container, Col, Row } from 'react-grid-system'
 import { useParams } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 
 import { APPLICATION } from '@console/constants/entities'
 
@@ -29,6 +30,8 @@ import { ApiKeyEditForm } from '@console/containers/api-key-form'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
 import { getApiKey } from '@console/store/actions/api-keys'
+
+import { selectApiKeyById } from '@console/store/selectors/api-keys'
 
 const ApplicationApiKeyEditInner = () => {
   const { apiKeyId, appId } = useParams()
@@ -56,9 +59,13 @@ const ApplicationApiKeyEditInner = () => {
 const ApplicationApiKeyEdit = () => {
   const { apiKeyId, appId } = useParams()
 
+  // Check if API key still exists after possibly being deleted.
+  const apiKey = useSelector(state => selectApiKeyById(state, apiKeyId))
+  const hasApiKey = Boolean(apiKey)
+
   return (
     <RequireRequest requestAction={getApiKey('application', appId, apiKeyId)}>
-      <ApplicationApiKeyEditInner />
+      {hasApiKey && <ApplicationApiKeyEditInner />}
     </RequireRequest>
   )
 }

--- a/pkg/webui/console/views/application-collaborator-edit/index.js
+++ b/pkg/webui/console/views/application-collaborator-edit/index.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import { Container, Col, Row } from 'react-grid-system'
 import { useParams } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 
 import { APPLICATION } from '@console/constants/entities'
 
@@ -27,6 +28,7 @@ import ConsoleCollaboratorsForm from '@console/containers/collaborators-form'
 
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import { getCollaborator, getCollaboratorsList } from '@ttn-lw/lib/store/actions/collaborators'
+import { selectCollaboratorById } from '@ttn-lw/lib/store/selectors/collaborators'
 
 const ApplicationCollaboratorEditInner = () => {
   const { appId, collaboratorId } = useParams()
@@ -52,6 +54,10 @@ const ApplicationCollaboratorEditInner = () => {
 const ApplicationCollaboratorEdit = () => {
   const { appId, collaboratorId, collaboratorType } = useParams()
 
+  // Check if collaborator still exists after being possibly deleted.
+  const collaborator = useSelector(state => selectCollaboratorById(state, collaboratorId))
+  const hasCollaborator = Boolean(collaborator)
+
   if (collaboratorType !== 'user' && collaboratorType !== 'organization') {
     return <GenericNotFound />
   }
@@ -63,7 +69,7 @@ const ApplicationCollaboratorEdit = () => {
         getCollaboratorsList('application', appId),
       ]}
     >
-      <ApplicationCollaboratorEditInner />
+      {hasCollaborator && <ApplicationCollaboratorEditInner />}
     </RequireRequest>
   )
 }

--- a/pkg/webui/console/views/application-integrations-pubsub-edit/index.js
+++ b/pkg/webui/console/views/application-integrations-pubsub-edit/index.js
@@ -36,7 +36,7 @@ import {
   selectMqttProviderDisabled,
   selectNatsProviderDisabled,
 } from '@console/store/selectors/application-server'
-import { selectSelectedPubsub } from '@console/store/selectors/pubsubs'
+import { selectPubsubById, selectSelectedPubsub } from '@console/store/selectors/pubsubs'
 
 const pubsubEntitySelector = [
   'base_topic',
@@ -127,9 +127,13 @@ const EditPubsubInner = () => {
 const EditPubsub = () => {
   const { appId, pubsubId } = useParams()
 
+  // Check if the pubsub exists after it was possibly deleted.
+  const pubsub = useSelector(state => selectPubsubById(state, pubsubId))
+  const hasPubsub = Boolean(pubsub)
+
   return (
     <RequireRequest requestAction={getPubsub(appId, pubsubId, pubsubEntitySelector)}>
-      <EditPubsubInner />
+      {hasPubsub && <EditPubsubInner />}
     </RequireRequest>
   )
 }

--- a/pkg/webui/console/views/gateway-api-key-edit/index.js
+++ b/pkg/webui/console/views/gateway-api-key-edit/index.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import { Container, Col, Row } from 'react-grid-system'
 import { useParams } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 
 import { GATEWAY } from '@console/constants/entities'
 
@@ -29,6 +30,8 @@ import { ApiKeyEditForm } from '@console/containers/api-key-form'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
 import { getApiKey } from '@console/store/actions/api-keys'
+
+import { selectApiKeyById } from '@console/store/selectors/api-keys'
 
 const GatewayApiKeyEditInner = () => {
   const { gtwId, apiKeyId } = useParams()
@@ -53,9 +56,13 @@ const GatewayApiKeyEditInner = () => {
 const GatewayApiKeyEdit = () => {
   const { gtwId, apiKeyId } = useParams()
 
+  // Check if API key still exists after possibly being deleted.
+  const apiKey = useSelector(state => selectApiKeyById(state, apiKeyId))
+  const hasApiKey = Boolean(apiKey)
+
   return (
     <RequireRequest requestAction={getApiKey('gateway', gtwId, apiKeyId)}>
-      <GatewayApiKeyEditInner />
+      {hasApiKey && <GatewayApiKeyEditInner />}
     </RequireRequest>
   )
 }

--- a/pkg/webui/console/views/gateway-collaborator-edit/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-edit/index.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import { Container, Col, Row } from 'react-grid-system'
 import { useParams } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 
 import { GATEWAY } from '@console/constants/entities'
 
@@ -28,6 +29,7 @@ import ConsoleCollaboratorsForm from '@console/containers/collaborators-form'
 
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import { getCollaborator, getCollaboratorsList } from '@ttn-lw/lib/store/actions/collaborators'
+import { selectCollaboratorById } from '@ttn-lw/lib/store/selectors/collaborators'
 
 const GatewayCollaboratorEditInner = () => {
   const { gtwId, collaboratorId, collaboratorType } = useParams()
@@ -63,6 +65,10 @@ const GatewayCollaboratorEdit = () => {
 
   const isUser = collaboratorType === 'user'
 
+  // Check if collaborator still exists after being possibly deleted.
+  const collaborator = useSelector(state => selectCollaboratorById(state, collaboratorId))
+  const hasCollaborator = Boolean(collaborator)
+
   return (
     <RequireRequest
       requestAction={[
@@ -70,7 +76,7 @@ const GatewayCollaboratorEdit = () => {
         getCollaboratorsList('gateway', gtwId),
       ]}
     >
-      <GatewayCollaboratorEditInner collaboratorType={collaboratorType} />
+      {hasCollaborator && <GatewayCollaboratorEditInner collaboratorType={collaboratorType} />}
     </RequireRequest>
   )
 }

--- a/pkg/webui/console/views/organization-api-key-edit/index.js
+++ b/pkg/webui/console/views/organization-api-key-edit/index.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import { Container, Col, Row } from 'react-grid-system'
 import { useParams } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 
 import { ORGANIZATION } from '@console/constants/entities'
 
@@ -29,6 +30,8 @@ import { ApiKeyEditForm } from '@console/containers/api-key-form'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
 import { getApiKey } from '@console/store/actions/api-keys'
+
+import { selectApiKeyById } from '@console/store/selectors/api-keys'
 
 const OrganizationApiKeyEditInner = () => {
   const { orgId, apiKeyId } = useParams()
@@ -56,9 +59,13 @@ const OrganizationApiKeyEditInner = () => {
 const OrganizationApiKeyEdit = () => {
   const { orgId, apiKeyId } = useParams()
 
+  // Check if API key still exists after possibly being deleted.
+  const apiKey = useSelector(state => selectApiKeyById(state, apiKeyId))
+  const hasApiKey = Boolean(apiKey)
+
   return (
     <RequireRequest requestAction={getApiKey('organization', orgId, apiKeyId)}>
-      <OrganizationApiKeyEditInner />
+      {hasApiKey && <OrganizationApiKeyEditInner />}
     </RequireRequest>
   )
 }

--- a/pkg/webui/console/views/organization-collaborator-edit/index.js
+++ b/pkg/webui/console/views/organization-collaborator-edit/index.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import { Container, Col, Row } from 'react-grid-system'
 import { useParams } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 
 import { ORGANIZATION } from '@console/constants/entities'
 
@@ -26,6 +27,7 @@ import RequireRequest from '@ttn-lw/lib/components/require-request'
 
 import ConsoleCollaboratorsForm from '@console/containers/collaborators-form'
 
+import { selectCollaboratorById } from '@ttn-lw/lib/store/selectors/collaborators'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import { getCollaborator } from '@ttn-lw/lib/store/actions/collaborators'
 
@@ -61,9 +63,13 @@ const OrganizationCollaboratorEditInner = () => {
 const OrganizationCollaboratorEdit = () => {
   const { orgId, collaboratorId } = useParams()
 
+  // Check if collaborator still exists after being possibly deleted.
+  const collaborator = useSelector(state => selectCollaboratorById(state, collaboratorId))
+  const hasCollaborator = Boolean(collaborator)
+
   return (
     <RequireRequest requestAction={getCollaborator('organization', orgId, collaboratorId, true)}>
-      <OrganizationCollaboratorEditInner />
+      {hasCollaborator && <OrganizationCollaboratorEditInner />}
     </RequireRequest>
   )
 }

--- a/pkg/webui/console/views/user-api-key-edit/index.js
+++ b/pkg/webui/console/views/user-api-key-edit/index.js
@@ -1,4 +1,4 @@
-// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import { getUsersRightsList } from '@console/store/actions/users'
 import { getApiKey } from '@console/store/actions/api-keys'
 
 import { selectUserId } from '@account/store/selectors/user'
+import { selectApiKeyById } from '@console/store/selectors/api-keys'
 
 const UserApiKeyEditInner = () => {
   const userId = useSelector(selectUserId)
@@ -58,11 +59,16 @@ const UserApiKeyEditInner = () => {
 const UserApiKeyEdit = () => {
   const userId = useSelector(selectUserId)
   const { apiKeyId } = useParams()
+
+  // Check if API key still exists after possibly being deleted.
+  const apiKey = useSelector(state => selectApiKeyById(state, apiKeyId))
+  const hasApiKey = Boolean(apiKey)
+
   return (
     <RequireRequest
       requestAction={[getUsersRightsList(userId), getApiKey('users', userId, apiKeyId)]}
     >
-      <UserApiKeyEditInner />
+      {hasApiKey && <UserApiKeyEditInner />}
     </RequireRequest>
   )
 }

--- a/pkg/webui/lib/store/reducers/search-accounts.js
+++ b/pkg/webui/lib/store/reducers/search-accounts.js
@@ -15,7 +15,10 @@
 import { SEARCH_ACCOUNTS_SUCCESS } from '@ttn-lw/lib/store/actions/search-accounts'
 
 const defaultState = {
-  searchResults: [],
+  searchResults: {
+    account_ids: [],
+  },
+  totalCount: 0,
 }
 
 const searchAccounts = (state = defaultState, { type, payload }) => {

--- a/pkg/webui/lib/store/selectors/search-accounts.js
+++ b/pkg/webui/lib/store/selectors/search-accounts.js
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export const selectSearchResultsStore = state => state.searchAccounts || []
-export const selectSearchResults = state =>
-  selectSearchResultsStore(state).searchResults?.account_ids || []
+export const selectSearchResultsStore = state => state.searchAccounts
+export const selectSearchResults = state => selectSearchResultsStore(state).searchResults
+export const selectSearchResultAccountIds = state => selectSearchResults(state).account_ids


### PR DESCRIPTION
#### Summary
This small quickfix ensures that views that rely on fetched entities will not accidentally render when the entity is manuall deleted.

#### Changes
- Add. check to ensure that reliant inner views only render if the depending entity is still there
- Fix search result selection to avoid unnecessary rerenders when using `useSelector()`
- Small styling fix of the react-select selector

#### Testing
- Manual testing

#### Notes for Reviewers
The above issue already lead to crashing CI in #6390 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
