### PR TITLE
Fix occurrences of old admin urls

### DIFF
--- a/pkg/email/notification.go
+++ b/pkg/email/notification.go
@@ -131,7 +131,7 @@ func (d *notificationTemplateData) ConsoleURL() string {
 		url = fmt.Sprintf("%s/organizations/%s", url, ids.OrganizationIds.GetOrganizationId())
 	case *ttnpb.EntityIdentifiers_UserIds:
 		if d.Receiver().GetAdmin() {
-			url = fmt.Sprintf("%s/admin/user-management/%s", url, ids.UserIds.GetUserId())
+			url = fmt.Sprintf("%s/admin-panel/user-management/%s", url, ids.UserIds.GetUserId())
 		}
 	}
 	return url

--- a/pkg/email/templates/testdata/password_changed.body.golden.html
+++ b/pkg/email/templates/testdata/password_changed.body.golden.html
@@ -127,7 +127,7 @@
                                   <tbody>
                                     <tr>
                                       <td style="width:600px;">
-                                        <a href="https://console.cloud.thethings.network/admin/user-management/foo-usr" target="_blank">
+                                        <a href="https://console.cloud.thethings.network/admin-panel/user-management/foo-usr" target="_blank">
                                           <img alt src="https://assets.cloud.thethings.network/email-header.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto">
                                         </a>
                                       </td>

--- a/pkg/email/templates/testdata/user_requested.body.golden.html
+++ b/pkg/email/templates/testdata/user_requested.body.golden.html
@@ -127,7 +127,7 @@
                                   <tbody>
                                     <tr>
                                       <td style="width:600px;">
-                                        <a href="https://console.cloud.thethings.network/admin/user-management/foo-usr" target="_blank">
+                                        <a href="https://console.cloud.thethings.network/admin-panel/user-management/foo-usr" target="_blank">
                                           <img alt src="https://assets.cloud.thethings.network/email-header.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="600" height="auto">
                                         </a>
                                       </td>
@@ -189,7 +189,7 @@ Since user registration requires admin approval, you need to approve this user b
 <b>Email Address:</b> foo@example.com
 </p>
 <p>
-You can review this user <a href="https://console.cloud.thethings.network/admin/user-management/foo-usr">in the Console</a>.
+You can review this user <a href="https://console.cloud.thethings.network/admin-panel/user-management/foo-usr">in the Console</a>.
 </p></div>
                                 </td>
                               </tr>

--- a/pkg/email/templates/testdata/user_requested.body.golden.txt
+++ b/pkg/email/templates/testdata/user_requested.body.golden.txt
@@ -8,4 +8,4 @@ Name: Foo User
 Description: Foo User Description
 Email Address: foo@example.com
 
-You can go to https://console.cloud.thethings.network/admin/user-management/foo-usr to review this user in the Console.
+You can go to https://console.cloud.thethings.network/admin-panel/user-management/foo-usr to review this user in the Console.

--- a/pkg/webui/console/containers/header/index.js
+++ b/pkg/webui/console/containers/header/index.js
@@ -189,17 +189,11 @@ Header.propTypes = {
   handleSearchRequest: PropTypes.func,
   /** A flag identifying whether the header should display the search input. */
   searchable: PropTypes.bool,
-  /**
-   * The User object, retrieved from the API. If it is `undefined`, then the
-   * guest header is rendered.
-   */
-  user: PropTypes.user,
 }
 
 Header.defaultProps = {
   handleSearchRequest: () => null,
   searchable: false,
-  user: undefined,
 }
 
 export default Header

--- a/pkg/webui/console/views/admin-packet-broker/network-routing-policy.js
+++ b/pkg/webui/console/views/admin-packet-broker/network-routing-policy.js
@@ -77,7 +77,7 @@ const NetworkRoutingPolicyViewInner = () => {
     <>
       <Breadcrumb path={'/admin-panel/packet-broker/networks'} content={m.networks} />
       <Breadcrumb
-        path={`/admin/packet-broker/networks/${netId}${tenantId ? `/${tenantId}` : ''}`}
+        path={`/admin-panel/packet-broker/networks/${netId}${tenantId ? `/${tenantId}` : ''}`}
         content={network.name || displayId}
       />
     </>,

--- a/pkg/webui/console/views/admin-user-management-add/index.js
+++ b/pkg/webui/console/views/admin-user-management-add/index.js
@@ -40,7 +40,7 @@ const UserManagementAddInner = () => {
   const createUserAction = useCallback(values => dispatch(createUser(values)), [dispatch])
 
   const onSubmit = useCallback(values => createUserAction(values), [createUserAction])
-  const onSubmitSuccess = useCallback(() => navigate('/admin/user-management'), [navigate])
+  const onSubmitSuccess = useCallback(() => navigate('/admin-panel/user-management'), [navigate])
 
   return (
     <Container>
@@ -61,7 +61,7 @@ const UserManagementAddInner = () => {
 const UserManagementAdd = () => {
   useBreadcrumbs(
     'admin-panel.user-management.add',
-    <Breadcrumb path={`/admin/user-management/add`} content={sharedMessages.add} />,
+    <Breadcrumb path={`/admin-panel/user-management/add`} content={sharedMessages.add} />,
   )
 
   return (

--- a/pkg/webui/console/views/admin-user-management/index.js
+++ b/pkg/webui/console/views/admin-user-management/index.js
@@ -37,8 +37,8 @@ import UserManagement from './admin-user-management'
 
 const UserManagementRouter = () => {
   useBreadcrumbs(
-    'admin.user-management',
-    <Breadcrumb path="/admin/user-management" content={sharedMessages.userManagement} />,
+    'admin-panel.user-management',
+    <Breadcrumb path="/admin-panel/user-management" content={sharedMessages.userManagement} />,
   )
   return (
     <Require featureCheck={mayManageUsers} otherwise={{ redirect: '/' }}>


### PR DESCRIPTION
#### Summary
This quickfix PR corrects the url for user management in the user activation email.

#### Changes
<!-- What are the changes made in this pull request? -->

- Update urls from `/admin/*` to `/admin-panel/*`
- Update test email html/txt

#### Testing

Manual testing

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
