### PR TITLE
Subscribe to all DevAddr prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For details about compatibility between different releases, see the **Commitment
 - The Application Server configuration has the `as.downlinks.confirmation.default-retry-attempts` and `as.downlinks.confirmation.max-retry-attempts` fields that configure the allowed number of retries for application downlinks. The default values are `8` for the `as.downlinks.confirmation.default-retry-attempts` and `32` for the `as.downlinks.confirmation.max-retry-attempts`.
 - The `as.downlinks.confirmation.default-retry-attempts` field is used for all application downlinks that were scheduled before this change and for every application downlink that does not have the `max_attempts` field set. On the other hand, the `as.downlinks.confirmation.max-retry-attempts` field ensures that the `max_attempts` field's upper bound is contained and does not exceed its value.
 - The number of historical frames considered for the multi-frame query window size in the LoRa Geolocation Services integration. The window size is now limited between 1 and 16 frames with 16 being the default value.
+- Packet Broker Agent now subscribes as Home Network to all DevAddr prefixes. This is to support NetID delegation where DevAddr blocks of other NetIDs should be routed to the cluster of a different NetID.
 
 ### Deprecated
 

--- a/cmd/internal/shared/packetbrokeragent/config.go
+++ b/cmd/internal/shared/packetbrokeragent/config.go
@@ -16,6 +16,7 @@ package shared
 
 import (
 	"go.thethings.network/lorawan-stack/v3/pkg/packetbrokeragent"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
 )
 
 // DefaultPacketBrokerAgentConfig is the default configuration for the Packet Broker Agent.
@@ -34,7 +35,8 @@ var DefaultPacketBrokerAgentConfig = packetbrokeragent.Config{
 		WorkerPool: packetbrokeragent.WorkerPoolConfig{
 			Limit: 4096,
 		},
-		IncludeHops: false,
+		IncludeHops:     false,
+		DevAddrPrefixes: []types.DevAddrPrefix{{}}, // Subscribe to all DevAddr prefixes.
 	},
 	Forwarder: packetbrokeragent.ForwarderConfig{
 		WorkerPool: packetbrokeragent.WorkerPoolConfig{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Subscribe PBA as home network to all DevAddr prefixes.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `00000000/0` as default DevAddr prefix in `pba.home-network.dev-addr-prefixes`

#### Testing

<!-- How did you verify that this change works? -->

Local integration testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
