### PR TITLE
Run the CLI telemetry submission asynchronously

### DIFF
--- a/pkg/telemetry/exporter/cli/cli.go
+++ b/pkg/telemetry/exporter/cli/cli.go
@@ -173,7 +173,7 @@ func (ct *cliTask) Run(ctx context.Context) {
 		if statePath, err := cliStatePath(); err != nil {
 			logger.WithError(err).Debug("Failed to retrieve telemetry state file path")
 		} else {
-			// If no error fetching the state file path, update the LastSeen field.
+			// If no error fetching the state file path, update the last sent timestamp.
 			state.Write(statePath) //nolint:errcheck
 		}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/6081

#### Changes
<!-- What are the changes made in this pull request? -->

- Start the telemetry submission in the command pre run, and only wait in the post run.

#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A, but may be susceptible to lambda slow starts. I think that for now this is an acceptable trade of, given that we don't want to slow down the CLI excessively. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
