### PR TITLE
Avoid watching empty sets of keys

### DIFF
--- a/pkg/applicationserver/redis/registry.go
+++ b/pkg/applicationserver/redis/registry.go
@@ -505,8 +505,13 @@ func (r *DeviceRegistry) BatchDelete(
 				}
 			}
 		}
-		if err := tx.Watch(ctx, euiKeys...).Err(); err != nil {
-			return err
+		// If the provided end device identifiers are not registered, it is possible
+		// that the `euiKeys` set will be empty. `WATCH` does not allow an empty set
+		// of keys to be provided, and as such must be manually skipped.
+		if len(euiKeys) > 0 {
+			if err := tx.Watch(ctx, euiKeys...).Err(); err != nil {
+				return err
+			}
 		}
 		if _, err := tx.TxPipelined(ctx, func(p redis.Pipeliner) error {
 			p.Del(ctx, append(uidKeys, euiKeys...)...)

--- a/pkg/joinserver/redis/registry.go
+++ b/pkg/joinserver/redis/registry.go
@@ -879,8 +879,13 @@ func (r *DeviceRegistry) BatchDelete(
 				}
 			}
 		}
-		if err := tx.Watch(ctx, keys...).Err(); err != nil {
-			return err
+		// If the provided end device identifiers are not registered, it is possible
+		// that the `keys` set will be empty. `WATCH` does not allow an empty set of
+		// keys to be provided, and as such must be manually skipped.
+		if len(keys) > 0 {
+			if err := tx.Watch(ctx, keys...).Err(); err != nil {
+				return err
+			}
 		}
 		if _, err := tx.TxPipelined(ctx, func(p redis.Pipeliner) error {
 			p.Del(ctx, append(uidKeys, keys...)...)

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -1024,8 +1024,13 @@ func (r *DeviceRegistry) BatchDelete(
 				}
 			}
 		}
-		if err := tx.Watch(ctx, euiKeys...).Err(); err != nil {
-			return err
+		// If the provided end device identifiers are not registered, it is possible
+		// that the `euiKeys` set will be empty. `WATCH` does not allow an empty set
+		// of keys to be provided, and as such must be manually skipped.
+		if len(euiKeys) > 0 {
+			if err := tx.Watch(ctx, euiKeys...).Err(); err != nil {
+				return err
+			}
 		}
 		if _, err := tx.TxPipelined(ctx, func(p redis.Pipeliner) error {
 			p.Del(ctx, append(uidKeys, euiKeys...)...)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes https://the-things-industries.sentry.io/issues/4338176452
References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/974#issuecomment-1649854784

#### Changes
<!-- What are the changes made in this pull request? -->

- Avoid doing `WATCH` with an empty set of keys.


#### Testing

<!-- How did you verify that this change works? -->

Local testing by deleting a set of non-existing end devices.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This fixes a regression in itself - `WATCH` requires at least one key to be present, but we may have an empty set of keys to watch if all of the end devices are not registered.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@johanstokking please take a look. This will be backported.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
