### PR TITLE
Fix batch end device delete event name

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -9620,6 +9620,15 @@
       "file": "client_registry.go"
     }
   },
+  "event:end_device.batch.delete": {
+    "translations": {
+      "en": "batch delete end devices"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "end_device_registry.go"
+    }
+  },
   "event:end_device.create": {
     "translations": {
       "en": "create end device"
@@ -9924,15 +9933,6 @@
     "description": {
       "package": "pkg/identityserver",
       "file": "invitation_registry.go"
-    }
-  },
-  "event:is.end_device.batch.delete": {
-    "translations": {
-      "en": "batch delete end devices"
-    },
-    "description": {
-      "package": "pkg/identityserver",
-      "file": "end_device_registry.go"
     }
   },
   "event:js.end_device.batch.delete": {

--- a/pkg/identityserver/end_device_registry.go
+++ b/pkg/identityserver/end_device_registry.go
@@ -59,7 +59,7 @@ var (
 		events.WithPropagateToParent(),
 	)
 	evtBatchDeleteEndDevices = events.Define(
-		"is.end_device.batch.delete", "batch delete end devices",
+		"end_device.batch.delete", "batch delete end devices",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ),
 		events.WithDataType(&ttnpb.EndDeviceIdentifiersList{}),
 		events.WithAuthFromContext(),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/974

This PR fixes the name of the end device deletion event in the Identity Server, in order to have it be visible without verbose events enabled in the Console.

#### Changes
<!-- What are the changes made in this pull request? -->

- Rename the IS event to `end_device.batch.delete`, such that `end_device.*` filter matches it.


#### Testing

<!-- How did you verify that this change works? -->

Local.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@kschiffer please take a look.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
