### PR TITLE
Enable telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 - Add support for `administrative_contact` and `technical_contact` in the Console.
 - Reimplement move away prompt in payload formatter views in the Console.
+- Add telemetry collection for the CLI. A background process was added to the CLI in order to send the following information: Operating System, Architecture, Binary version and Golang version. The message is sent every 24 hours and it contains an unique random number as an identifier. It is enabled by default and in order to disable it, set `telemetry.enable` to false in the CLI configuration. For more information, consult the documentation [here](https://www.thethingsindustries.com/docs/reference/telemetry/cli).
+- Add telemetry collection for the IdentityServer. A background task was added in the Identity Server which is responsible for collecting information regarding the amount of each entity in the database, this has the purpose of allowing us to better understand how users are interacting with the system, an example being if tenants are using Organizations or just Users. All information is sent every 24 hours and it contains an identifier composed of the URLs present in the following configuration fields `console.ui.[is|gs|ns|as|js].base-url`. It is enabled by default and in order to disable it, set `telemetry.enable` to false in the Stack configuration. For more information, consult the documentation [here](https://www.thethingsindustries.com/docs/reference/telemetry/identity_server).
 
 ### Changed
 

--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -158,13 +158,11 @@ var DefaultTracingConfig = tracing.Config{
 
 // DefaultTelemetryConfig  is the default config for telemetry.
 var DefaultTelemetryConfig = telemetry.Config{
-	// TODO: After (https://github.com/TheThingsNetwork/lorawan-stack/issues/6081) is no longer blocked.
-	// Enable the telemetry and define the target.
-	Enable:       false,
-	Target:       "",
+	Enable:       true,
+	Target:       "https://telemetry.thethingsstack.io/collect",
 	NumConsumers: 1,
 	EntityCountTelemetry: telemetry.EntityCountTelemetry{
-		Enable:   false,
+		Enable:   true,
 		Interval: 24 * time.Hour,
 	},
 }

--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -35,10 +35,8 @@ var (
 		EnableMetadata: true,
 	}
 	defaultTelemetryConfig = telemetry.CLI{
-		// TODO: After (https://github.com/TheThingsNetwork/lorawan-stack/issues/6081) is no longer blocked.
-		// Enable the telemetry and define the target.
-		Enable: false,
-		Target: "",
+		Enable: true,
+		Target: "https://telemetry.thethingsstack.io/collect",
 	}
 )
 

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -174,6 +174,9 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 		// The result is waited in the post run.
 		telemetrySubmission = make(chan struct{})
 		if config.Telemetry.Enable {
+			logger.
+				WithField("documentation_url", "https://www.thethingsindustries.com/docs/reference/telemetry/cli").
+				Info("Telemetry is enabled. Check the documentation for more information on what is collected and how to disable it") // nolint:lll
 			go func(ctx context.Context) {
 				defer close(telemetrySubmission)
 				cli.NewCLITelemetry(

--- a/pkg/identityserver/telemetry.go
+++ b/pkg/identityserver/telemetry.go
@@ -37,6 +37,9 @@ func (is *IdentityServer) initializeTelemetryTasks(ctx context.Context) error {
 	if tq == nil || !tmCfg.Enable {
 		return nil
 	}
+	logger.
+		WithField("documentation_url", "https://www.thethingsindustries.com/docs/reference/telemetry/identity_server").
+		Info("Identity Server telemetry is enabled. Check the documentation for more information on what is collected and how to disable it") // nolint:lll
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/pkg/telemetry/exporter/cli/cli.go
+++ b/pkg/telemetry/exporter/cli/cli.go
@@ -26,7 +26,7 @@ import (
 	"path"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	telemetry "go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter"
 	"go.thethings.network/lorawan-stack/v3/pkg/telemetry/exporter/models"
@@ -106,7 +106,7 @@ func getCLIState() (*cliStateTelemetry, bool, error) {
 			return nil, false, err
 		}
 
-		cliState.UID = uuid.NewV4().String()
+		cliState.UID = uuid.NewString()
 		cliState.LastSent = time.Now()
 		return cliState, true, nil
 	}

--- a/pkg/telemetry/exporter/config.go
+++ b/pkg/telemetry/exporter/config.go
@@ -32,10 +32,9 @@ type EntityCountTelemetry struct {
 
 // Config contains information regarding the telemetry collection.
 type Config struct {
-	Enable bool `name:"enable" description:"Enables telemetry collection"`
-	// UIDElements is a list of elements that will be used to generate the UID.
-	UIDElements          []string             `name:"-"`
+	Enable               bool                 `name:"enable" description:"Enables telemetry collection"`
 	Target               string               `name:"target" description:"Target to which the information will be sent to"`                                 // nolint:lll
+	UIDElements          []string             `name:"uid-elements" description:"Elements that will be used to generate the UID"`                            // nolint:lll
 	NumConsumers         uint64               `name:"num-consumers" description:"Number of consumers that will be used to monitor telemetry related tasks"` // nolint:lll
 	EntityCountTelemetry EntityCountTelemetry `name:"entity-count-telemetry"`
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #6081

Enables telemetry for the Stack and the CLI, this sets the default value to `true` and it defines the value of the `target` at which the telemetry information is sent.  

The main points of this PR are:
- the `changelog` message
- the documentation PR linked
- the log messages contents
  - one for CLI
  - one for IS

#### Changes

<!-- What are the changes made in this pull request? -->

- Change the pkg used for generating the `uuid` for telemetry/cli. Has the same effect since both use the RFC 4122 but Google's package should be one used on my opinion.
- Add log `INFO` messages for when telemetry is enable on CLI and/or IS.
- Add Changelog.md message introducing telemetry to users.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

- Manual tests for the log messages
- I validated with the already deployed collector that the messages sent by CLI and IS are being received and plotted on Grafana.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

As this is a new feature, there aren't any regressions that I can imagine but this is the last change to have breaking changes.

For example the current message structure works around the concept that each field on the main json body represents a data collected in general, it might be interesting to encapsulate a bit more since we plan to add telemetry in other places, for example:

- Current:
<details open>

```json
{
  "message": {
    "uid": "",
    "os": {
      "operating_system": "linux",
      "arch": "amd64",
      "binary_version": "3.27.0-dev",
      "golang_version": " go1.20.7"
    },
    "cli": null,
    "entities_count": { 
      // ... 
    }
  }
}
```
</details>

- A bit more encapsulated:
<details open>

```json
{
  "message": {
    "uid": "",
    "os": {
      "operating_system": "linux",
      "arch": "amd64",
      "binary_version": "3.27.0-dev",
      "golang_version": " go1.20.7"
    },
    "cli": null,
    "is": {
      "entities_count": { // ... },
      // ...
    }
  }
} 
```
</details>

Might be a bit late for that but since its not a breaking change yet and only implies in small changes in here and in the lambda code its worth considering. @adriansmares @KrishnaIyer 

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

1. Documentation PR can be found in [here](https://github.com/TheThingsIndustries/lorawan-stack-docs/pull/1153).
2. In regards to the steps to tests this feature I believe its more productive to write them after the discussion around the point made in the regressions section.
3. Regarding the changes made on: 
https://github.com/TheThingsNetwork/lorawan-stack/blob/44951feb61b30fd4eea2ed79999a4fff58652739/pkg/telemetry/exporter/config.go#L37
This allows users to set their own values used to generate the hash, allowing them to disassociate their console URLs and still contribute telemetry data. 

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
