### PR TITLE
Admins no longer triggers client creation notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- OAuth clients created by an admin no longer trigger an email requesting approval from one of the tenant's admins.
+
 ### Security
 
 ## [3.27.0] - 2023-07-31

--- a/pkg/identityserver/client_registry.go
+++ b/pkg/identityserver/client_registry.go
@@ -159,7 +159,7 @@ func (is *IdentityServer) createClient( //nolint:gocyclo
 		return nil, err
 	}
 	apikey := authInfo.GetApiKey().GetApiKey()
-	if cli.State == ttnpb.State_STATE_REQUESTED {
+	if !createdByAdmin && cli.State == ttnpb.State_STATE_REQUESTED {
 		go is.notifyAdminsInternal(ctx, &ttnpb.CreateNotificationRequest{
 			EntityIds:        req.GetClient().GetIds().GetEntityIdentifiers(),
 			NotificationType: "client_requested",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This small PR fixes the bug found where a Client created by an admin where its not specified its state during its creation, will trigger the request to be approved by one of the tenant's admins. This is not the expected behavior since the user who created the Client is an admin himself.

#### Changes

<!-- What are the changes made in this pull request? -->

- Add admin check in the email notification conditional.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Local test. 

In regards to tests that catch this sort of behavior, from what I checked (other unit tests and the integration test) we don't have tests that validate the contents of the emails generated by registry operations. Since this is something interesting to have, I'll create an issue to add those validations on the clicrud integrations test that we have (will add the triage label just to check before working on it). 

Steps for manually testing this bug fix:
- Create an OAuth Client with an admin account
  - Do not specify its state during its creation, simply giving it a name and nothing else.
- Validate if any emails requesting for an admin's approval were sent (there should be none)
- Validate the state of the created client (it should be approved)


##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

This is a bug fix.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Didn't do the tests but in the Test section of this PR there is a step to remedy the lack of tests in this regard

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
