### PR TITLE
Ensure complete identifiers are available in downlink events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - OAuth clients created by an admin no longer trigger an email requesting approval from one of the tenant's admins.
 - Broken network routing policy links in the Packet Broker panel of the admin panel in the Console.
+- Application Server downlink related events now contain the complete set of end device identifiers, and the received at timestamp is now provided at all times.
 
 ### Security
 

--- a/pkg/applicationserver/observability.go
+++ b/pkg/applicationserver/observability.go
@@ -24,6 +24,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/metrics"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -360,7 +361,13 @@ func registerDropDownlink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, 
 	}
 }
 
-func (as *ApplicationServer) registerDropDownlinks(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, items []*ttnpb.ApplicationDownlink, err error) {
+func (as *ApplicationServer) registerDropDownlinks(
+	ctx context.Context,
+	ids *ttnpb.EndDeviceIdentifiers,
+	items []*ttnpb.ApplicationDownlink,
+	receivedAt *timestamppb.Timestamp,
+	err error,
+) {
 	var (
 		errorDetails   errors.ErrorDetails
 		pbErrorDetails *ttnpb.ErrorDetails
@@ -372,6 +379,7 @@ func (as *ApplicationServer) registerDropDownlinks(ctx context.Context, ids *ttn
 		if err := as.publishUp(ctx, &ttnpb.ApplicationUp{
 			EndDeviceIds:   ids,
 			CorrelationIds: item.CorrelationIds,
+			ReceivedAt:     receivedAt,
 			Up: &ttnpb.ApplicationUp_DownlinkFailed{
 				DownlinkFailed: &ttnpb.ApplicationDownlinkFailed{
 					Downlink: item,
@@ -386,12 +394,16 @@ func (as *ApplicationServer) registerDropDownlinks(ctx context.Context, ids *ttn
 }
 
 func (as *ApplicationServer) registerForwardDownlinks(
-	ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, decrypted, encrypted []*ttnpb.ApplicationDownlink,
+	ctx context.Context,
+	ids *ttnpb.EndDeviceIdentifiers,
+	decrypted, encrypted []*ttnpb.ApplicationDownlink,
+	receivedAt *timestamppb.Timestamp,
 ) {
 	for _, item := range decrypted {
 		if err := as.publishUp(ctx, &ttnpb.ApplicationUp{
 			EndDeviceIds:   ids,
 			CorrelationIds: item.CorrelationIds,
+			ReceivedAt:     receivedAt,
 			Up: &ttnpb.ApplicationUp_DownlinkQueued{
 				DownlinkQueued: item,
 			},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR addresses a bug in which the `ttnpb.ApplicationUp` generated in the downlink queued / acked / nacked / failed / sent events did not contain the full set of end device identifiers or the received at timestamp.

#### Changes

<!-- What are the changes made in this pull request? -->

- Use the registry identifiers instead of the caller provided identifiers while registering events and generating uplinks.
- Propagate the received at timestamp.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Local testing. The feature can be tested further by attempting to push/replace the downlink queue and observing that the `received_at` is available, and that the EUIs are part of the `ids`.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

N/A. This fixes an inconsistency in our message filling behavior, but does not change the existing logic significantly.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
