### PR TITLE
Fix packet broker network routing policy links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - OAuth clients created by an admin no longer trigger an email requesting approval from one of the tenant's admins.
+- Broken network routing policy links in the Packet Broker panel of the admin panel in the Console.
 
 ### Security
 

--- a/pkg/webui/console/views/admin-packet-broker/admin-packet-broker.js
+++ b/pkg/webui/console/views/admin-packet-broker/admin-packet-broker.js
@@ -283,7 +283,7 @@ const PacketBroker = () => {
               </PortalledModal>
               <hr className={style.hRule} />
             </Col>
-            <Col md={12}>
+            <Col md={12} style={{ position: 'relative' }}>
               <Tabs tabs={tabs} active={activeTab} onTabChange={setActiveTab} divider />
               <RequireRequest
                 requestAction={[
@@ -291,6 +291,7 @@ const PacketBroker = () => {
                   getHomeNetworkDefaultGatewayVisibility(),
                 ]}
                 errorRenderFunction={SubViewErrorComponent}
+                spinnerProps={{ inline: true, center: true, className: 'mt-ls-s' }}
               >
                 <Routes>
                   <Route index Component={DefaultRoutingPolicyView} />


### PR DESCRIPTION
#### Summary
This quickfix resolves faulty links for individual network routing policies in the packet broker settings panel.
This is a regression introduced via #6313 

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/984

#### Changes

- Fix URL relativity
- Convert PB table to functional component
- Rewrite `baseDataSelector` using `createSelector()` to fix warnings
- Fix minor display bug related to the loading spinner in the PB panel

#### Testing

Manual testing on staging environment.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
