### PR TITLE
Pick device address prefixes in a weighted manner

### DIFF
--- a/pkg/networkserver/grpc.go
+++ b/pkg/networkserver/grpc.go
@@ -29,7 +29,7 @@ import (
 // GenerateDevAddr returns a device address assignment in the device address
 // range of the network server.
 func (ns *NetworkServer) GenerateDevAddr(ctx context.Context, req *emptypb.Empty) (*ttnpb.GenerateDevAddrResponse, error) {
-	devAddr := ns.newDevAddr(ctx, nil)
+	devAddr := ns.newDevAddr(ctx)
 	return &ttnpb.GenerateDevAddrResponse{DevAddr: devAddr.Bytes()}, nil
 }
 

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1248,10 +1248,10 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 		"device_channel_index", chIdx,
 	)
 
-	devAddr := ns.newDevAddr(ctx, matched)
+	devAddr := ns.newDevAddr(ctx)
 	const maxDevAddrGenerationRetries = 5
 	for i := 0; i < maxDevAddrGenerationRetries && matched.Session != nil && devAddr.Equal(types.MustDevAddr(matched.Session.DevAddr).OrZero()); i++ {
-		devAddr = ns.newDevAddr(ctx, matched)
+		devAddr = ns.newDevAddr(ctx)
 	}
 	ctx = log.NewContextWithField(ctx, "dev_addr", devAddr)
 	if matched.Session != nil && devAddr.Equal(types.MustDevAddr(matched.Session.DevAddr).OrZero()) {

--- a/pkg/networkserver/networkserver_internal_test.go
+++ b/pkg/networkserver/networkserver_internal_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestNewDevAddr(t *testing.T) {
+	t.Parallel()
+
 	test.RunSubtest(t, test.SubtestConfig{
 		Name:     "From NetID",
 		Parallel: true,
@@ -101,20 +103,22 @@ func TestNewDevAddr(t *testing.T) {
 			)
 			defer stop()
 
-			seen := map[types.DevAddrPrefix]int{}
-			for i := 0; i < 100000; i++ {
+			seen, total := map[types.DevAddrPrefix]float64{}, float64(0)
+			for i := 0; i < 10000; i++ {
 				devAddr := ns.newDevAddr(ctx)
 				for _, p := range ps {
 					if devAddr.HasPrefix(p) {
 						seen[p]++
+						total++
 						break
 					}
 				}
 			}
 
-			a.So(seen[ps[0]], should.BeGreaterThan, 0)
-			a.So(seen[ps[1]], should.BeGreaterThan, 0)
-			a.So(seen[ps[2]], should.BeGreaterThan, 0)
+			totalAddresses := (65536.0 + 256.0 + 16777216.0)
+			a.So(seen[ps[0]]/total, should.AlmostEqual, 65536.0/totalAddresses, 1e-2)
+			a.So(seen[ps[1]]/total, should.AlmostEqual, 256.0/totalAddresses, 1e-2)
+			a.So(seen[ps[2]]/total, should.AlmostEqual, 16777216.0/totalAddresses, 1e-2)
 		},
 	})
 }
@@ -226,7 +230,7 @@ func TestMakeNewDevAddrFunc(t *testing.T) {
 			a, ctx := test.New(t)
 			newF := makeNewDevAddrFunc(tc.Prefixes...)
 			weights, total := make([]int, len(tc.Prefixes)), 0
-			for i := 0; i < 100000; i++ {
+			for i := 0; i < 10000; i++ {
 				devAddr := newF(ctx)
 				found := false
 				for j, prefix := range tc.Prefixes {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes the device address generation take into account the number of bits assigned for the actual device address. This ensures that when blocks of different sizes are used, the size of the block is used as a weight for the chosen block.

#### Changes

<!-- What are the changes made in this pull request? -->

- Use a weighted random algorithm for the device address prefix selection.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Unit testing.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

N/A.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
