### PR TITLE
Wait for secondary gateway disconnection

### DIFF
--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -2111,7 +2111,7 @@ func TestBatchGetStatus(t *testing.T) {
 				defer statsRedisClient.Close()
 				registry := &gsredis.GatewayConnectionStatsRegistry{
 					Redis:   statsRedisClient,
-					LockTTL: 5 * test.Delay,
+					LockTTL: timeout,
 				}
 				if err := registry.Init(ctx); err != nil {
 					t.Fatalf("Failed to setup stats registry :%v", err)
@@ -2258,6 +2258,7 @@ func TestBatchGetStatus(t *testing.T) {
 
 			// Disconnect second gateway.
 			gtwConnCancel()
+			time.Sleep(timeout) // Wait for connection to be closed.
 
 			cfg, err := gs.GetConfig(ctx)
 			if !a.So(err, should.BeNil) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/actions/runs/5443202416/job/14734441018

#### Changes

<!-- What are the changes made in this pull request? -->

- Ensure that we actually wait for the secondary gateway to disconnect, in order to ensure that we don't count it during the batch gateway stats retrieval when no registry is used.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

`go test -tags tti -count 30 -failfast -run TestBatchGetStatus`

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

N/A. This affects strictly test code.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
