### PR TITLE
Refactor ping pong tests

### DIFF
--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -129,6 +129,7 @@ func TestGatewayServer(t *testing.T) {
 						Listen: ":1887",
 						Config: ws.Config{
 							WSPingInterval:       wsPingInterval,
+							MissedPongThreshold:  2,
 							AllowUnauthenticated: true,
 						},
 					},

--- a/pkg/gatewayserver/io/ws/ws.go
+++ b/pkg/gatewayserver/io/ws/ws.go
@@ -321,7 +321,7 @@ func (s *srv) handleTraffic(w http.ResponseWriter, r *http.Request) (err error) 
 			case <-conn.Context().Done():
 				return
 			case <-pingTicker.C:
-				if err := ws.WriteMessage(websocket.PingMessage, nil); err != nil {
+				if err := ws.WriteControl(websocket.PingMessage, nil, time.Time{}); err != nil {
 					logger.WithError(err).Warn("Failed to send ping message")
 					return err
 				}
@@ -334,7 +334,7 @@ func (s *srv) handleTraffic(w http.ResponseWriter, r *http.Request) (err error) 
 					return err
 				}
 			case data := <-pongCh:
-				if err := ws.WriteMessage(websocket.PongMessage, data); err != nil {
+				if err := ws.WriteControl(websocket.PongMessage, data, time.Time{}); err != nil {
 					logger.WithError(err).Warn("Failed to send pong")
 					return err
 				}

--- a/pkg/gatewayserver/io/ws/ws.go
+++ b/pkg/gatewayserver/io/ws/ws.go
@@ -336,7 +336,7 @@ func (s *srv) handleTraffic(w http.ResponseWriter, r *http.Request) (err error) 
 				return
 			case <-pingTicker.C:
 				if atomic.LoadInt64(&pongCount) > 0 {
-					if atomic.AddInt64(&missingPongs, 1) == int64(s.cfg.MissedPongThreshold) {
+					if atomic.AddInt64(&missingPongs, 1)-1 == int64(s.cfg.MissedPongThreshold) {
 						err := errMissedTooManyPongs.New()
 						logger.WithError(err).Warn("Disconnect gateway")
 						return err

--- a/pkg/gatewayserver/io/ws/ws_test.go
+++ b/pkg/gatewayserver/io/ws/ws_test.go
@@ -1785,7 +1785,7 @@ func TestPingPong(t *testing.T) {
 			defer cancel()
 
 			web, err := New(ctx, gs, lbslns.NewFormatter(maxValidRoundTripDelay), Config{
-				WSPingInterval:       (1 << 5) * test.Delay,
+				WSPingInterval:       (1 << 4) * test.Delay,
 				AllowUnauthenticated: true,
 				UseTrafficTLSAddress: false,
 				MissedPongThreshold:  2,
@@ -1830,7 +1830,7 @@ func TestPingPong(t *testing.T) {
 			}()
 
 			// Wait for connection to setup
-			time.After(1 << 8 * test.Delay)
+			time.After(timeout)
 
 			select {
 			case <-ctx.Done():

--- a/pkg/gatewayserver/io/ws/ws_util_test.go
+++ b/pkg/gatewayserver/io/ws/ws_util_test.go
@@ -121,9 +121,7 @@ func withServer(t *testing.T, wsConfig ws.Config, rateLimitConf config.RateLimit
 		t.FailNow()
 	}
 	defer lis.Close()
-	go func() error {
-		return http.Serve(lis, web)
-	}()
+	go http.Serve(lis, web) // nolint:errcheck,gosec
 	servAddr := fmt.Sprintf("ws://%s", lis.Addr().String())
 
 	f(t, is, servAddr)
@@ -157,7 +155,7 @@ func (h *PingPongHandler) HandlePing(data string) error {
 	}
 	h.wsConnMu.Lock()
 	defer h.wsConnMu.Unlock()
-	if err := h.wsConn.WriteMessage(websocket.PongMessage, nil); err != nil {
+	if err := h.wsConn.WriteControl(websocket.PongMessage, []byte(data), time.Time{}); err != nil {
 		h.errCh <- err
 	}
 	h.numberOfPongs--


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/actions/runs/5388909842/job/14586179127?pr=3745

#### Changes

<!-- What are the changes made in this pull request? -->

- Refactor the flow used to detect that the client has missed responding to a PING. See inline comment for details.
- Use `WriteControl` instead of `WriteMessage` for ping and pong messages. This is how these messages are supposed to be sent.
- Simplify how we start HTTP servers.
- Remove superfluous `break`s.
- Ensure that we cancel contexts when test cases end.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

`go test -tags tti -count 3000 -failfast -v -run TestPingPong`

I warn you, it will take a lot of time. But it was worth it as we waste 15 minutes on every single time this damn flake is triggered.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

This touches the code used to detect missing `PONG`s, but the unit tests should cover this issue. The race condition is virtually impossible to reproduce by hand, and requires thousands of tests until it occurs.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
