### PR TITLE
Fix wording and styling of CH upgrade notification

### DIFF
--- a/pkg/webui/components/notification/index.js
+++ b/pkg/webui/components/notification/index.js
@@ -61,7 +61,7 @@ const Notification = ({
         <Icon className={style.icon} icon={icon} large={!small} />
         <div className={style.content}>
           {title && <Message className={style.title} content={title} component="h4" />}
-          <div>
+          <div className={style.message}>
             <Message content={content} values={messageValues} firstToUpper />
             {children}
           </div>

--- a/pkg/webui/components/notification/notification.styl
+++ b/pkg/webui/components/notification/notification.styl
@@ -59,6 +59,12 @@ left-border($color)
     left-border($c-success)
     color: $c-success
 
+  .message
+    display: flex
+    align-items: flex-start
+    flex-direction: column
+    gap: $cs.xs
+
   .title
     text-margin-bottom($cs.s)
     margin-top: 0

--- a/pkg/webui/console/containers/network-information-container/index.js
+++ b/pkg/webui/console/containers/network-information-container/index.js
@@ -23,7 +23,7 @@ import RegistryTotals from './registry-totals'
 const m = defineMessages({
   openSourceInfo:
     'You are currently using The Things Stack Open Source. More features can be unlocked by using The Things Stack Cloud.',
-  plansButton: 'Get started with The things Stack Cloud',
+  plansButton: 'Get started with The Things Stack Cloud',
 })
 
 const NetworkInformationContainer = () => (
@@ -39,7 +39,6 @@ const NetworkInformationContainer = () => (
           message={m.plansButton}
           target="_blank"
           external
-          className="mt-cs-s"
         />
       }
       className="mt-cs-l"

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -647,7 +647,7 @@
   "console.containers.move-away-modal.move-away-modal.modalTitle": "Confirm navigation",
   "console.containers.move-away-modal.move-away-modal.modalMessage": "Are you sure you want to leave this page? Your current changes have not been saved yet.",
   "console.containers.network-information-container.index.openSourceInfo": "You are currently using The Things Stack Open Source. More features can be unlocked by using The Things Stack Cloud.",
-  "console.containers.network-information-container.index.plansButton": "Get started with The things Stack Cloud",
+  "console.containers.network-information-container.index.plansButton": "Get started with The Things Stack Cloud",
   "console.containers.network-information-container.registry-totals.applicationsUsed": "Total applications",
   "console.containers.network-information-container.registry-totals.gatewaysUsed": "Total gateways",
   "console.containers.network-information-container.registry-totals.registeredUsers": "Registered users",


### PR DESCRIPTION
#### Summary
Quickfix to fix styling and wording of the notification that nudges to update to CH in the OS admin panel.

#### Changes
- Fix notification styling
- Fix message typo

#### Testing

No tests required, only visual changes.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
