### PR TITLE
Fix PB network policy selectors

### DIFF
--- a/pkg/webui/console/containers/packet-broker-networks-table/index.js
+++ b/pkg/webui/console/containers/packet-broker-networks-table/index.js
@@ -30,10 +30,10 @@ import { getPacketBrokerNetworksList } from '@console/store/actions/packet-broke
 import {
   selectPacketBrokerNetworks,
   selectPacketBrokerNetworksTotalCount,
-  selectPacketBrokerForwarderPolicyById,
-  selectPacketBrokerHomeNetworkPolicyById,
   selectPacketBrokerOwnCombinedId,
   selectHomeNetworkDefaultRoutingPolicy,
+  selectPacketBrokerHomeNetworkPoliciesStore,
+  selectPacketBrokerForwarderPoliciesStore,
 } from '@console/store/selectors/packet-broker'
 
 const m = defineMessages({
@@ -104,17 +104,17 @@ const PacketBrokerNetworksTable = () => {
       selectPacketBrokerOwnCombinedId,
       selectPacketBrokerNetworks,
       selectHomeNetworkDefaultRoutingPolicy,
-      selectPacketBrokerForwarderPolicyById,
-      selectPacketBrokerHomeNetworkPolicyById,
       selectPacketBrokerNetworksTotalCount,
+      selectPacketBrokerHomeNetworkPoliciesStore,
+      selectPacketBrokerForwarderPoliciesStore,
     ],
     (
       ownCombinedId,
       networks,
       defaultHomeNetworkRoutingPolicy,
-      forwarderPolicy,
-      homeNetworkPolicy,
       totalCount,
+      homeNetworkPolicies,
+      forwarderPolicies,
     ) => {
       const decoratedNetworks = []
       for (const network of networks) {
@@ -122,6 +122,9 @@ const PacketBrokerNetworksTable = () => {
         if (combinedId === ownCombinedId) {
           continue
         }
+
+        const homeNetworkPolicy = homeNetworkPolicies[combinedId]
+        const forwarderPolicy = forwarderPolicies[combinedId]
 
         const decoratedNetwork = { ...network }
         decoratedNetwork._forwarderPolicy = forwarderPolicy || {


### PR DESCRIPTION
#### Summary
Quickfix to resolve faulty display of network policies in the network policy table of the packet broker panel in the Console.

#### Changes

- Fix the `baseDataSelector` of the policy table (after an earlier refactor to use `createSelector`)

#### Testing

- Check whether the policy matrix (the green dots) in the network policy table of the packet broker panel display the correct policy schemes, as set for the respective network.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
