### PR TITLE
Fix order of breadcrumbs for device pages in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For details about compatibility between different releases, see the **Commitment
 - OAuth clients created by an admin no longer trigger an email requesting approval from one of the tenant's admins.
 - Broken network routing policy links in the Packet Broker panel of the admin panel in the Console.
 - Application Server downlink related events now contain the complete set of end device identifiers, and the received at timestamp is now provided at all times.
+- Wrong order of breadcrumbs in the device views of the Console.
 
 ### Security
 

--- a/pkg/webui/console/views/device/device.js
+++ b/pkg/webui/console/views/device/device.js
@@ -79,7 +79,7 @@ const Device = () => {
     : 'messaging'
 
   useBreadcrumbs(
-    'device.single',
+    'apps.single.devices.single',
     <Breadcrumb path={`/applications/${appId}/devices/${devId}`} content={name || devId} />,
   )
 

--- a/pkg/webui/console/views/devices/index.js
+++ b/pkg/webui/console/views/devices/index.js
@@ -40,7 +40,7 @@ const Devices = () => {
   const appId = useSelector(selectSelectedApplicationId)
 
   useBreadcrumbs(
-    'devices',
+    'apps.single.devices',
     <Breadcrumb path={`/applications/${appId}/devices`} content={sharedMessages.devices} />,
   )
 

--- a/pkg/webui/console/views/gateway-api-keys/index.js
+++ b/pkg/webui/console/views/gateway-api-keys/index.js
@@ -38,7 +38,7 @@ const GatewayApiKeys = () => {
   const { gtwId } = useParams()
 
   useBreadcrumbs(
-    'gateways.single.api-keys',
+    'gtws.single.api-keys',
     <Breadcrumb path={`/gateways/${gtwId}/api-keys`} content={sharedMessages.apiKeys} />,
   )
 

--- a/pkg/webui/console/views/gateway-data/index.js
+++ b/pkg/webui/console/views/gateway-data/index.js
@@ -40,7 +40,7 @@ const GatewayData = () => {
   const { gtwId } = useParams()
 
   useBreadcrumbs(
-    'gateways.single.data',
+    'gtws.single.data',
     <Breadcrumb path={`/gateways/${gtwId}/data`} content={sharedMessages.liveData} />,
   )
 

--- a/pkg/webui/console/views/gateway-general-settings/index.js
+++ b/pkg/webui/console/views/gateway-general-settings/index.js
@@ -182,7 +182,7 @@ const GatewaySettings = () => {
   )
 
   useBreadcrumbs(
-    'gateways.single.general-settings',
+    'gtws.single.general-settings',
     <Breadcrumb
       path={`/gateways/${gtwId}/general-settings`}
       content={sharedMessages.generalSettings}

--- a/pkg/webui/console/views/gateway/index.js
+++ b/pkg/webui/console/views/gateway/index.js
@@ -108,10 +108,7 @@ const GatewayInner = () => {
 
   const gatewayName = gateway?.name || gtwId
 
-  useBreadcrumbs(
-    'gateways.single',
-    <Breadcrumb path={`/gateways/${gtwId}`} content={gatewayName} />,
-  )
+  useBreadcrumbs('gtws.single', <Breadcrumb path={`/gateways/${gtwId}`} content={gatewayName} />)
 
   return (
     <>

--- a/pkg/webui/console/views/gateways/index.js
+++ b/pkg/webui/console/views/gateways/index.js
@@ -32,7 +32,7 @@ import { pathId as pathIdRegexp } from '@ttn-lw/lib/regexp'
 import { mayViewGateways } from '@console/lib/feature-checks'
 
 const Gateways = () => {
-  useBreadcrumbs('gateways', <Breadcrumb path="/gateways" content={sharedMessages.gateways} />)
+  useBreadcrumbs('gtws', <Breadcrumb path="/gateways" content={sharedMessages.gateways} />)
   return (
     <Require featureCheck={mayViewGateways} otherwise={{ redirect: '/' }}>
       <Routes>


### PR DESCRIPTION
#### Summary
Closes #6441

#### Changes

- Fix the breadcrumb IDs so that they will be ordered correctly

#### Testing

- Navigate to all device subpages and check whether the breadcrumbs are displayed in the right order.

#### Notes for Reviewers

I've recently changed the logic for how the breadcrumbs determine their order from formerly being determined by render order, to determine the order by the breadcrumb IDs (alphabetically). This is better because the render order does not always correspond to the navigation structure.
To make this work though, all the breadcrumb IDs need to be named hierarchically correctly, which was not the case and caused this bug.

Compare:
```
apps
apps.single
device.single
devices
```
with the corrected:
```
apps
apps.single
apps.single.devices
apps.single.devices.single
```

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
