### PR TITLE
Account for flaky invocationDetails presence in Cypress tests

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -29,7 +29,15 @@ afterEach(function () {
   // Enable fail-early, if set.:
   if (this.currentTest.state === 'failed' && Cypress.env('FAIL_FAST')) {
     cy.log('Skipping rest of run due to test failure (fail fast)')
-    const file = this.currentTest.invocationDetails.relativeFile
+    const file = this.currentTest?.invocationDetails?.relativeFile
+    // Sometimes `invocationDetails` is not set, see:
+    // https://github.com/cypress-io/cypress/issues/3090#issuecomment-1068059581
+    // In that case, we should just skip the fail fast logic and run the
+    // remaining tests as usual.
+    if (!file) {
+      cy.log('Skipping fail fast logic due to missing `invocationDetails`')
+      return
+    }
     // The file will be relative to the `./config` directory, so we need to
     // remove the `../` prefix.
     const relativeFile = file.replace(/^\.\.\//, '')


### PR DESCRIPTION
#### Summary

This quickfix PR will ensure that the fail fast logic of the cypress tests does not result in further crashes.

#### Changes

- Account for `invocationDetails` not being in the context which can sometimes be the case

#### Testing

- Manual testing, this is a pure dev tooling change

#### Notes for Reviewers

It appears as though the `invocationDetails` can sometimes be missing from the context. More info on that here:
https://github.com/cypress-io/cypress/issues/3090#issuecomment-1068059581

So I believe it's best to add a check for it and just run the remaining tests anyway if necessary. It should be noted that this bit of the fail-fast logic only fires when the connected test already failed organically. So typically the logic should not result in a test failure in itself, but it can obfuscate the actual failure of the underlying test.

cc @adriansmares 

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
