### PR TITLE
Fix double fetching of fetch table

### DIFF
--- a/pkg/webui/containers/fetch-table/index.js
+++ b/pkg/webui/containers/fetch-table/index.js
@@ -147,9 +147,7 @@ const FetchTable = props => {
         }
         await dispatch(attachPromise(getItemsAction(f)))
         setFetching(false)
-        if (initialFetch) {
-          setInitialFetch(false)
-        }
+        setInitialFetch(false)
       } catch (error) {
         setError(error)
         setFetching(false)
@@ -162,7 +160,6 @@ const FetchTable = props => {
     defaultTab,
     dispatch,
     getItemsAction,
-    initialFetch,
     order,
     page,
     pageSize,


### PR DESCRIPTION
#### Summary

This pull request aims to fix the issue of double fetching of list endpoints within the `<FetchTable />` component.

#### Changes

- Simplified how we handle initial fetch in 'fetch-table/index.js'. The condition checking for `initialFetch` before setting it to `false` was removed. This get's rid of the `initialFetch` dependency which would otherwise cause the effect to run again.

#### Testing

To test this change:

1. Open console and go to applications table
2. Open the developer console in the "Network" tab
3. Observe that only one request to the `/applications` endpoint is launched (as opposed to two being launched before this fix)

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.