### PR TITLE
Remove unused Redis store implementations

### DIFF
--- a/pkg/networkserver/redis/registry_internal_test.go
+++ b/pkg/networkserver/redis/registry_internal_test.go
@@ -78,9 +78,6 @@ func TestMsgpackCompatibility(t *testing.T) {
 	makeLastFCntExpr := func(v uint32) string {
 		return makeNumericExpr("last_f_cnt", v)
 	}
-	makeUIDExpr := func(v string) string {
-		return makeStringExpr("uid", v)
-	}
 
 	defaultfNwkSIntKeyWrappedExpr := makeFNwkSIntWrappedKeyExpr(test.DefaultFNwkSIntKeyEnvelopeWrapped)
 	defaultfNwkSIntKeyUnwrappedExpr := makeFNwkSIntUnwrappedKeyExpr(test.DefaultFNwkSIntKey)
@@ -193,123 +190,6 @@ func TestMsgpackCompatibility(t *testing.T) {
 				makeResetsFCntExpr(true),
 				makeSupports32BitFCntExpr(false),
 				makeLastFCntExpr(42),
-			),
-		},
-
-		{
-			Value: UplinkMatchResult{
-				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelopeWrapped,
-				LoRaWANVersion: test.DefaultMACVersion,
-				UID:            "test-uid",
-			},
-			LuaExpr: makeExprWithDefaults(
-				makeUIDExpr("test-uid"),
-			),
-		},
-		{
-			Value: UplinkMatchResult{
-				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelope,
-				LoRaWANVersion: test.DefaultMACVersion,
-				UID:            "test-uid",
-			},
-			LuaExpr: makeExpr(
-				defaultfNwkSIntKeyUnwrappedExpr,
-				defaultLoRaWANVersionExpr,
-				makeUIDExpr("test-uid"),
-			),
-		},
-		{
-			Value: UplinkMatchResult{
-				FNwkSIntKey:       test.DefaultFNwkSIntKeyEnvelopeWrapped,
-				LoRaWANVersion:    test.DefaultMACVersion,
-				Supports32BitFCnt: &ttnpb.BoolValue{Value: false},
-				UID:               "test-uid",
-			},
-			LuaExpr: makeExprWithDefaults(
-				makeUIDExpr("test-uid"),
-				makeSupports32BitFCntExpr(false),
-			),
-		},
-		{
-			Value: UplinkMatchResult{
-				FNwkSIntKey:       test.DefaultFNwkSIntKeyEnvelopeWrapped,
-				LoRaWANVersion:    test.DefaultMACVersion,
-				Supports32BitFCnt: &ttnpb.BoolValue{Value: true},
-				UID:               "test-uid",
-			},
-			LuaExpr: makeExprWithDefaults(
-				makeUIDExpr("test-uid"),
-				makeSupports32BitFCntExpr(true),
-			),
-		},
-		{
-			Value: UplinkMatchResult{
-				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelopeWrapped,
-				LoRaWANVersion: test.DefaultMACVersion,
-				UID:            "test-uid",
-				ResetsFCnt:     &ttnpb.BoolValue{Value: true},
-			},
-			LuaExpr: makeExprWithDefaults(
-				makeUIDExpr("test-uid"),
-				makeResetsFCntExpr(true),
-			),
-		},
-		{
-			Value: UplinkMatchResult{
-				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelopeWrapped,
-				LoRaWANVersion: test.DefaultMACVersion,
-				UID:            "test-uid",
-				ResetsFCnt:     &ttnpb.BoolValue{Value: false},
-			},
-			LuaExpr: makeExprWithDefaults(
-				makeUIDExpr("test-uid"),
-				makeResetsFCntExpr(false),
-			),
-		},
-		{
-			Value: UplinkMatchResult{
-				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelopeWrapped,
-				LoRaWANVersion: test.DefaultMACVersion,
-				UID:            "test-uid",
-				LastFCnt:       42,
-			},
-			LuaExpr: makeExprWithDefaults(
-				makeUIDExpr("test-uid"),
-				makeLastFCntExpr(42),
-			),
-		},
-		{
-			Value: UplinkMatchResult{
-				FNwkSIntKey:       test.DefaultFNwkSIntKeyEnvelopeWrapped,
-				LoRaWANVersion:    test.DefaultMACVersion,
-				UID:               "test-uid",
-				ResetsFCnt:        &ttnpb.BoolValue{Value: true},
-				Supports32BitFCnt: &ttnpb.BoolValue{Value: false},
-				LastFCnt:          42,
-			},
-			LuaExpr: makeExprWithDefaults(
-				makeUIDExpr("test-uid"),
-				makeResetsFCntExpr(true),
-				makeSupports32BitFCntExpr(false),
-				makeLastFCntExpr(42),
-			),
-		},
-		{
-			Value: UplinkMatchResult{
-				FNwkSIntKey:       test.DefaultFNwkSIntKeyEnvelopeWrapped,
-				LoRaWANVersion:    test.DefaultMACVersion,
-				UID:               "test-uid",
-				ResetsFCnt:        &ttnpb.BoolValue{Value: true},
-				Supports32BitFCnt: &ttnpb.BoolValue{Value: false},
-				LastFCnt:          42,
-				IsPending:         true,
-			},
-			LuaExpr: makeExprWithDefaults(
-				makeUIDExpr("test-uid"),
-				makeResetsFCntExpr(true),
-				makeSupports32BitFCntExpr(false),
-				makeLastFCntExpr(42),
-				`x.is_pending`,
 			),
 		},
 	} {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR removes some dead code from the Network Server's Redis store implementation. These parts have been dead since we've removed stateful matching.

#### Changes

<!-- What are the changes made in this pull request? -->

- Remove unused Redis store definitions.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

CI.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

This is dead code. It has no effects that could regress.

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

No need to review.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
