### PR TITLE
Fix for `WithSoftDelete` failing some specific operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Providing fixed downlink paths to the `ttn-lw-cli devices downlink {push|replace}` commands using the `-class-b-c.gateways` parameter. The gateways IDs are comma separated, and the antenna index `i` can be provided by suffixing the ID with `:i` (i.e. `my-gateway:0` for antenna index 0). The group index `j` can be provided by suffixing the ID with `:j` (i.e. `my-gateway:0:1` for antenna index 0 and group index 1). The antenna index is mandatory if a group index is to be provided, but optional otherwise.
 - Gateway registration without gateway EUI not working.
+- Listing deleted entities is now fixed for both admin and standard users, which previously returned an `account_not_found` error.
 
 ### Security
 

--- a/pkg/identityserver/bunstore/membership_store.go
+++ b/pkg/identityserver/bunstore/membership_store.go
@@ -105,7 +105,7 @@ func (s *membershipStore) selectWithUUIDsInMemberships(
 		}
 	}
 
-	account, err := s.getAccountModel(ctx, accountID.EntityType(), accountID.IDString())
+	account, err := s.getAccountModel(store.WithSoftDeleted(ctx, false), accountID.EntityType(), accountID.IDString())
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (s *membershipStore) selectWithUUIDsInMemberships(
 func (s *membershipStore) CountMemberships(
 	ctx context.Context, accountID *ttnpb.OrganizationOrUserIdentifiers, entityType string,
 ) (uint64, error) {
-	account, err := s.getAccountModel(ctx, accountID.EntityType(), accountID.IDString())
+	account, err := s.getAccountModel(store.WithSoftDeleted(ctx, false), accountID.EntityType(), accountID.IDString())
 	if err != nil {
 		return 0, err
 	}
@@ -227,7 +227,7 @@ func (s *membershipStore) FindAccountMembershipChains(
 	))
 	defer span.End()
 
-	account, err := s.getAccountModel(ctx, accountID.EntityType(), accountID.IDString())
+	account, err := s.getAccountModel(store.WithSoftDeleted(ctx, false), accountID.EntityType(), accountID.IDString())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/identityserver/registry_search_test.go
+++ b/pkg/identityserver/registry_search_test.go
@@ -17,6 +17,7 @@ package identityserver
 import (
 	"testing"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/storetest"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
@@ -124,5 +125,201 @@ func TestRegistrySearch(t *testing.T) {
 		if a.So(usrs, should.NotBeNil) {
 			a.So(usrs.Users, should.HaveLength, 5)
 		}
+	}, withPrivateTestDatabase(p))
+}
+
+// TestRegistrySearchDeletedEntities validates that deleted entities are listed properly when providing the adequate
+// values on the request body.
+func TestRegistrySearchDeletedEntities(t *testing.T) { // nolint:gocyclo
+	t.Parallel()
+
+	p := &storetest.Population{}
+
+	usr := p.NewUser()
+	usrKey, _ := p.NewAPIKey(usr.GetEntityIdentifiers(), ttnpb.Right_RIGHT_ALL)
+	usrCreds := rpcCreds(usrKey)
+
+	adminUsr := p.NewUser()
+	adminUsr.Admin = true
+	adminUsrKey, _ := p.NewAPIKey(adminUsr.GetEntityIdentifiers(), ttnpb.Right_RIGHT_ALL)
+	adminUsrCreds := rpcCreds(adminUsrKey)
+
+	const (
+		notDeletedAmount = 6
+		deletedAmount    = 4
+	)
+
+	apps := make([]*ttnpb.Application, 10)
+	clis := make([]*ttnpb.Client, 10)
+	gtws := make([]*ttnpb.Gateway, 10)
+	orgs := make([]*ttnpb.Organization, 10)
+	usrs := make([]*ttnpb.User, 10)
+
+	// Making an uneven number of deleted entities just to avoid having a flaky tests.
+	for i := 0; i < 10; i++ {
+		apps[i] = p.NewApplication(usr.GetOrganizationOrUserIdentifiers())
+		clis[i] = p.NewClient(usr.GetOrganizationOrUserIdentifiers())
+		gtws[i] = p.NewGateway(usr.GetOrganizationOrUserIdentifiers())
+		orgs[i] = p.NewOrganization(usr.GetOrganizationOrUserIdentifiers())
+		usrs[i] = p.NewUser()
+	}
+
+	noOwnerApp := p.NewApplication(nil)
+	noOwnerClient := p.NewClient(nil)
+	noOwnerGtw := p.NewGateway(nil)
+	noOwnerOrg := p.NewOrganization(nil)
+
+	testWithIdentityServer(t, func(_ *IdentityServer, cc *grpc.ClientConn) {
+		cli := ttnpb.NewEntityRegistrySearchClient(cc)
+		appReg := ttnpb.NewApplicationRegistryClient(cc)
+		cliReg := ttnpb.NewClientRegistryClient(cc)
+		gtwReg := ttnpb.NewGatewayRegistryClient(cc)
+		orgReg := ttnpb.NewOrganizationRegistryClient(cc)
+
+		a, ctx := test.New(t)
+
+		// Delete some entities associated with the non admin user.
+		for i := 0; i < deletedAmount; i++ {
+			_, err := appReg.Delete(ctx, apps[i].Ids, usrCreds)
+			a.So(err, should.BeNil)
+			_, err = cliReg.Delete(ctx, clis[i].Ids, usrCreds)
+			a.So(err, should.BeNil)
+			_, err = gtwReg.Delete(ctx, gtws[i].Ids, usrCreds)
+			a.So(err, should.BeNil)
+			_, err = orgReg.Delete(ctx, orgs[i].Ids, usrCreds)
+			a.So(err, should.BeNil)
+		}
+		// Delete some entities not associated with `usr`, this should not reflect on the results of the test below.
+		_, err := appReg.Delete(ctx, noOwnerApp.Ids, adminUsrCreds)
+		a.So(err, should.BeNil)
+		_, err = cliReg.Delete(ctx, noOwnerClient.Ids, adminUsrCreds)
+		a.So(err, should.BeNil)
+		_, err = gtwReg.Delete(ctx, noOwnerGtw.Ids, adminUsrCreds)
+		a.So(err, should.BeNil)
+		_, err = orgReg.Delete(ctx, noOwnerOrg.Ids, adminUsrCreds)
+		a.So(err, should.BeNil)
+
+		t.Run("Applications", func(t *testing.T) { // nolint:paralleltest
+			t.Run("Not Deleted", func(t *testing.T) { // nolint:paralleltest
+				a, ctx := test.New(t)
+				got, err := cli.SearchApplications(ctx, &ttnpb.SearchApplicationsRequest{
+					FieldMask: ttnpb.FieldMask("ids"),
+				}, usrCreds)
+				if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+					a.So(got.Applications, should.HaveLength, notDeletedAmount)
+				}
+			})
+			t.Run("Deleted", func(t *testing.T) { // nolint:paralleltest
+				a, ctx := test.New(t)
+				got, err := cli.SearchApplications(ctx, &ttnpb.SearchApplicationsRequest{
+					Deleted:   true,
+					FieldMask: ttnpb.FieldMask("ids"),
+				}, usrCreds)
+				if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+					a.So(got.Applications, should.HaveLength, deletedAmount)
+				}
+			})
+		})
+		t.Run("Clients", func(t *testing.T) { // nolint:paralleltest
+			t.Run("Not Deleted", func(t *testing.T) { // nolint:paralleltest
+				a, ctx := test.New(t)
+				got, err := cli.SearchClients(ctx, &ttnpb.SearchClientsRequest{
+					FieldMask: ttnpb.FieldMask("ids"),
+				}, usrCreds)
+				if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+					a.So(got.Clients, should.HaveLength, notDeletedAmount)
+				}
+			})
+			t.Run("Deleted", func(t *testing.T) { // nolint:paralleltest
+				a, ctx := test.New(t)
+				got, err := cli.SearchClients(ctx, &ttnpb.SearchClientsRequest{
+					Deleted:   true,
+					FieldMask: ttnpb.FieldMask("ids"),
+				}, usrCreds)
+				if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+					a.So(got.Clients, should.HaveLength, deletedAmount)
+				}
+			})
+		})
+		t.Run("Gateways", func(t *testing.T) { // nolint:paralleltest
+			t.Run("Not Deleted", func(t *testing.T) { // nolint:paralleltest
+				a, ctx := test.New(t)
+				got, err := cli.SearchGateways(ctx, &ttnpb.SearchGatewaysRequest{
+					FieldMask: ttnpb.FieldMask("ids"),
+				}, usrCreds)
+				if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+					a.So(got.Gateways, should.HaveLength, notDeletedAmount)
+				}
+			})
+			t.Run("Deleted", func(t *testing.T) { // nolint:paralleltest
+				a, ctx := test.New(t)
+				got, err := cli.SearchGateways(ctx, &ttnpb.SearchGatewaysRequest{
+					Deleted:   true,
+					FieldMask: ttnpb.FieldMask("ids"),
+				}, usrCreds)
+				if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+					a.So(got.Gateways, should.HaveLength, deletedAmount)
+				}
+			})
+		})
+		t.Run("Organizations", func(t *testing.T) { // nolint:paralleltest
+			t.Run("Not Deleted", func(t *testing.T) { // nolint:paralleltest
+				a, ctx := test.New(t)
+				got, err := cli.SearchOrganizations(ctx, &ttnpb.SearchOrganizationsRequest{
+					FieldMask: ttnpb.FieldMask("ids"),
+				}, usrCreds)
+				if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+					a.So(got.Organizations, should.HaveLength, notDeletedAmount)
+				}
+			})
+			t.Run("Deleted", func(t *testing.T) { // nolint:paralleltest
+				a, ctx := test.New(t)
+				got, err := cli.SearchOrganizations(ctx, &ttnpb.SearchOrganizationsRequest{
+					Deleted:   true,
+					FieldMask: ttnpb.FieldMask("ids"),
+				}, usrCreds)
+				if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+					a.So(got.Organizations, should.HaveLength, deletedAmount)
+				}
+			})
+		})
+
+		// Admin only operations
+		usrReg := ttnpb.NewUserRegistryClient(cc)
+		// Delete some users.
+		for i := 0; i < deletedAmount; i++ {
+			_, err := usrReg.Delete(ctx, usrs[i].Ids, adminUsrCreds)
+			a.So(err, should.BeNil)
+		}
+		t.Run("Users", func(t *testing.T) { // nolint: paralleltest
+			t.Run("Not Deleted", func(t *testing.T) { // nolint:paralleltest
+				a, ctx := test.New(t)
+				got, err := cli.SearchUsers(ctx, &ttnpb.SearchUsersRequest{}, usrCreds)
+				a.So(got, should.BeNil)
+				a.So(errors.IsPermissionDenied(err), should.BeTrue)
+
+				got, err = cli.SearchUsers(ctx, &ttnpb.SearchUsersRequest{
+					FieldMask: ttnpb.FieldMask("ids"),
+				}, adminUsrCreds)
+				if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+					// The `+2` refers to the two non-deleted users created at the beginning of the test.
+					a.So(got.Users, should.HaveLength, (notDeletedAmount + 2))
+				}
+			})
+			t.Run("Deleted", func(t *testing.T) { // nolint:paralleltest
+				a, ctx := test.New(t)
+				got, err := cli.SearchUsers(ctx, &ttnpb.SearchUsersRequest{Deleted: true}, usrCreds)
+				a.So(got, should.BeNil)
+				a.So(errors.IsPermissionDenied(err), should.BeTrue)
+
+				got, err = cli.SearchUsers(ctx, &ttnpb.SearchUsersRequest{
+					Deleted:   true,
+					FieldMask: ttnpb.FieldMask("ids"),
+				}, adminUsrCreds)
+				if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+					a.So(got.Users, should.HaveLength, deletedAmount)
+				}
+			})
+		})
 	}, withPrivateTestDatabase(p))
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #6573

The issue revolves around two things:
1. Operations of `search` were failing for non admin users.
2. Operations of `list` were failing for both admin and non admin users.

The reason being that the `WithSoftDeleted` impacts the account search that is done on the membership store, resulting in the following error:
```
error:pkg/identityserver/store:account_not_found (user account with id `admin` not found)
    account_type=user
    account_id=admin
    correlation_id=8ca168ed8379438cbe6066d5cbcbe6dc
exit status 255
``` 

#### Changes

<!-- What are the changes made in this pull request? -->

- FindAccount operations on membership_store search within both deleted and non deleted users, regardless of `DeletedOptions` being propagated in the context.
  - Means that `ttn-lw-cli (app|gtw|org|client) list --deleted` now works, was previously broken.
  - Search method that includes `Deleted: true` now is fixed, was broken to non admin users. 

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Unit tests and manual testing
Steps to test the feature

<details><summary>Test Steps</summary>
For a more robust test you can create a new non admin user and from there create an entity and delete it, it should not
show up in the following tests' results.

###### List deleted entities as admin

1. Login as an admin user
2. Create an app
3. Delete the app
4. Use the CLI to execute `ttn-lw-cli app list --deleted`
  4.1. This previously returned an `account_not_found` error.
  4.2. It should now be a list of only deleted applications belonging to the user.

```bash
# commands for the steps mentioned above
ttn-lw-cli app create --application-id <app_id> --user-id admin
ttn-lw-cli app delete <app_id>
ttn-lw-cli app list --deleted

# Expected output of last command
# [{
#   "ids": {
#     "application_id": "<app_id>"
#   },
#   "created_at": "2023-09-27T10:33:07.097761Z",
#   "updated_at": "2023-09-27T10:33:07.097761Z",
#   "deleted_at": "2023-09-27T10:33:13.442904Z"
# }]
```

###### Search deleted entities as admin

Previously it already worked but should remain working.

1. Login as an admin user
2. Create an app
3. Delete the app
4. Use the CLI to execute `ttn-lw-cli app search --deleted`

```bash
# commands for the steps mentioned above
ttn-lw-cli app create --application-id <app_id> --user-id admin
ttn-lw-cli app delete <app_id>
ttn-lw-cli app search --deleted
```

```
# Expected output of last command
# [{
#   "ids": {
#     "application_id": "<app_id>"
#   },
#   "created_at": "2023-09-27T10:33:07.097761Z",
#   "updated_at": "2023-09-27T10:33:07.097761Z",
#   "deleted_at": "2023-09-27T10:33:13.442904Z"
# }]
```

###### Search deleted entities as non admin user
1. Login as a **non** admin user
2. Create an app
3. Delete the app
4. Use the CLI to execute `ttn-lw-cli app search --deleted`
  4.1. This previously returned an `account_not_found` error.
  4.2. It should now be a list of only deleted applications belonging to the user.

```bash
# commands for the steps mentioned above
ttn-lw-cli app create --application-id <app_id> --user-id <user_id>
ttn-lw-cli app delete <app_id>
ttn-lw-cli app search --deleted
```

```
# Expected output of last command
# [{
#   "ids": {
#     "application_id": "<app_id>"
#   },
#   "created_at": "2023-09-27T10:33:07.097761Z",
#   "updated_at": "2023-09-27T10:33:07.097761Z",
#   "deleted_at": "2023-09-27T10:33:13.442904Z"
# }]
```
</details>

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

From what I can think off there is no regression since we are only doing the overwrite on the account fetching in the membership operations that are related to fetching memberships between an user an another entity. Will think of this for a second time before marking the PR as ready.

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Leaving this as a draft in order to have the discussion, I took the chance that the PR isn't that big in order to make the point of what was the proposed changed a bit more clearer on the original issue and this should hopefully clarify the conversation there. Will update the CHANGELOG and  make the PR ready after the confirmation that the issue itself is more clearly defined.
 

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
