### PR TITLE
Fix gateway registration without gateway EUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Providing fixed downlink paths to the `ttn-lw-cli devices downlink {push|replace}` commands using the `-class-b-c.gateways` parameter. The gateways IDs are comma separated, and the antenna index `i` can be provided by suffixing the ID with `:i` (i.e. `my-gateway:0` for antenna index 0). The group index `j` can be provided by suffixing the ID with `:j` (i.e. `my-gateway:0:1` for antenna index 0 and group index 1). The antenna index is mandatory if a group index is to be provided, but optional otherwise.
+- Gateway registration without gateway EUI not working.
 
 ### Security
 

--- a/pkg/webui/console/containers/gateway-onboarding-form/gateway-provisioning-form/gateway-registration-form-section/validation-schema.js
+++ b/pkg/webui/console/containers/gateway-onboarding-form/gateway-provisioning-form/gateway-registration-form-section/validation-schema.js
@@ -28,14 +28,14 @@ const validationSchema = Yup.object().shape({
       .required(sharedMessages.validateRequired),
     eui: Yup.string()
       .test(
-        'has 16 or 12 characters',
+        'has 16, 12 or 0 characters',
         Yup.passValues(sharedMessages.validateLength)({ length: 16 }),
-        value => value && (value.length === 12 || value.length === 16),
+        value => value === undefined || value.length === 12 || value.length === 16,
       )
       .test(
         "doesn't have 12 characters",
         Yup.passValues(sharedMessages.validateMacAddressEntered),
-        value => value && value.length !== 12,
+        value => value?.length !== 12,
       ),
   }),
   name: Yup.string()


### PR DESCRIPTION
#### Summary

This quickfix will resolve an issue that lead to gateway registration without gateway EUI not working as it should.

#### Changes

- Allow empty gateway EUIs in the validation schema

#### Testing

1. Go to the gateway registration screen
2. Do not type in any Gateway EUI but fill out the other input fields
3. Click on `Register gateway`
4. The gateway is created and you are redirected to the gateway page

#### Notes for Reviewers

This is backporting an issue that I resolved in Enterprise already as part of the last merge PR
https://github.com/TheThingsIndustries/lorawan-stack/pull/3878

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
