### PR TITLE
Convert (some) class components to functional components

### DIFF
--- a/pkg/webui/components/navigation/side/index.js
+++ b/pkg/webui/components/navigation/side/index.js
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 import ReactDom from 'react-dom'
-import React, { Component } from 'react'
-import bind from 'autobind-decorator'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
 import classnames from 'classnames'
-import { defineMessages, injectIntl } from 'react-intl'
+import { defineMessages, useIntl } from 'react-intl'
 
 import LAYOUT from '@ttn-lw/constants/layout'
 
@@ -41,220 +40,181 @@ const m = defineMessages({
   hideSidebar: 'Hide sidebar',
 })
 
-@injectIntl
-export class SideNavigation extends Component {
-  static propTypes = {
-    appContainerId: PropTypes.string,
-    children: PropTypes.node.isRequired,
-    className: PropTypes.string,
-    /** The header for the side navigation. */
-    header: PropTypes.shape({
-      title: PropTypes.string.isRequired,
-      icon: PropTypes.string.isRequired,
-      iconAlt: PropTypes.message.isRequired,
-      to: PropTypes.string.isRequired,
-    }).isRequired,
-    intl: PropTypes.shape({
-      formatMessage: PropTypes.func,
-    }).isRequired,
-    modifyAppContainerClasses: PropTypes.bool,
-  }
+const SideNavigation = ({
+  appContainerId,
+  modifyAppContainerClasses,
+  className,
+  header,
+  children,
+}) => {
+  const [isMinimized, setIsMinimized] = useState(getViewportWidth() <= LAYOUT.BREAKPOINTS.M)
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  const [preferMinimized, setPreferMinimized] = useState(false)
+  const node = useRef()
+  const intl = useIntl()
 
-  static defaultProps = {
-    appContainerId: 'app',
-    modifyAppContainerClasses: true,
-    className: undefined,
-  }
+  const updateAppContainerClasses = useCallback(
+    (initial = false) => {
+      if (!modifyAppContainerClasses) {
+        return
+      }
+      const containerClasses = document.getElementById(appContainerId).classList
+      containerClasses.add('with-sidebar')
+      if (!initial) {
+        containerClasses.add('sidebar-transitioned')
+      }
+      if (isMinimized) {
+        containerClasses.add('sidebar-minimized')
+      } else {
+        containerClasses.remove('sidebar-minimized')
+      }
+    },
+    [modifyAppContainerClasses, appContainerId, isMinimized],
+  )
 
-  state = {
-    /** A flag specifying whether the side navigation is minimized or not. */
-    isMinimized: getViewportWidth() <= LAYOUT.BREAKPOINTS.M,
-    /** A flag specifying whether the drawer is currently open (in mobile
-     * screensizes).
-     */
-    isDrawerOpen: false,
-    /** A flag indicating whether the user has last toggled the sidebar to
-     * minimized state. */
-    preferMinimized: false,
-  }
-
-  @bind
-  updateAppContainerClasses(initial = false) {
-    const { modifyAppContainerClasses, appContainerId } = this.props
-    if (!modifyAppContainerClasses) {
-      return
-    }
-    const { isMinimized } = this.state
-    const containerClasses = document.getElementById(appContainerId).classList
-    containerClasses.add('with-sidebar')
-    if (!initial) {
-      // The transitioned class is necessary to prevent unwanted width
-      // transitions during route changes.
-      containerClasses.add('sidebar-transitioned')
-    }
-    if (isMinimized) {
-      containerClasses.add('sidebar-minimized')
-    } else {
-      containerClasses.remove('sidebar-minimized')
-    }
-  }
-
-  @bind
-  removeAppContainerClasses() {
-    const { modifyAppContainerClasses, appContainerId } = this.props
+  const removeAppContainerClasses = useCallback(() => {
     if (!modifyAppContainerClasses) {
       return
     }
     document
       .getElementById(appContainerId)
       .classList.remove('with-sidebar', 'sidebar-minimized', 'sidebar-transitioned')
-  }
+  }, [modifyAppContainerClasses, appContainerId])
 
-  componentDidMount() {
-    window.addEventListener('resize', this.setMinimizedState)
-    this.updateAppContainerClasses(true)
-  }
+  const closeDrawer = useCallback(() => {
+    setIsDrawerOpen(false)
+    document.body.classList.remove(style.scrollLock)
+  }, [])
 
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.setMinimizedState)
-    this.removeAppContainerClasses()
-  }
+  const openDrawer = useCallback(() => {
+    setIsDrawerOpen(true)
+    document.body.classList.add(style.scrollLock)
+  }, [])
 
-  @bind
-  setMinimizedState() {
-    const { isMinimized, preferMinimized } = this.state
+  useEffect(() => {
+    const onClickOutside = e => {
+      if (isDrawerOpen && node.current && !node.current.contains(e.target)) {
+        closeDrawer()
+      }
+    }
 
+    if (isDrawerOpen) {
+      document.addEventListener('mousedown', onClickOutside)
+      return () => document.removeEventListener('mousedown', onClickOutside)
+    }
+  }, [isDrawerOpen, closeDrawer])
+
+  const setMinimizedState = useCallback(() => {
     const viewportWidth = getViewportWidth()
     if (
       (!isMinimized && viewportWidth <= LAYOUT.BREAKPOINTS.M) ||
       (isMinimized && viewportWidth > LAYOUT.BREAKPOINTS.M)
     ) {
-      this.setState({ isMinimized: getViewportWidth() <= LAYOUT.BREAKPOINTS.M || preferMinimized })
-      this.updateAppContainerClasses()
+      setIsMinimized(getViewportWidth() <= LAYOUT.BREAKPOINTS.M || preferMinimized)
+      updateAppContainerClasses()
     }
-  }
+  }, [isMinimized, preferMinimized, updateAppContainerClasses])
 
-  @bind
-  async onToggle() {
-    await this.setState(prev => ({
-      isMinimized: !prev.isMinimized,
-      preferMinimized: !prev.isMinimized,
-    }))
-    this.updateAppContainerClasses()
-  }
+  useEffect(() => {
+    window.addEventListener('resize', setMinimizedState)
+    updateAppContainerClasses(true)
+    return () => {
+      window.removeEventListener('resize', setMinimizedState)
+      removeAppContainerClasses()
+    }
+  }, [removeAppContainerClasses, setMinimizedState, updateAppContainerClasses])
 
-  @bind
-  onDrawerExpandClick() {
-    const { isDrawerOpen } = this.state
+  const onToggle = useCallback(async () => {
+    setIsMinimized(prev => !prev)
+    setPreferMinimized(prev => !prev)
+    updateAppContainerClasses()
+  }, [updateAppContainerClasses])
 
+  const onDrawerExpandClick = useCallback(() => {
     if (!isDrawerOpen) {
-      this.openDrawer()
+      openDrawer()
     } else {
-      this.closeDrawer()
+      closeDrawer()
     }
-  }
+  }, [isDrawerOpen, openDrawer, closeDrawer])
 
-  @bind
-  onClickOutside(e) {
-    const { isDrawerOpen } = this.state
-    if (isDrawerOpen && this.node && !this.node.contains(e.target)) {
-      this.closeDrawer()
-    }
-  }
-
-  @bind
-  closeDrawer() {
-    this.setState({ isDrawerOpen: false })
-
-    // Enable body scrolling.
-    document.body.classList.remove(style.scrollLock)
-    document.removeEventListener('mousedown', this.onClickOutside)
-  }
-
-  @bind
-  openDrawer() {
-    // Disable body scrolling.
-    document.body.classList.add(style.scrollLock)
-
-    document.addEventListener('mousedown', this.onClickOutside)
-    this.setState({ isDrawerOpen: true })
-  }
-
-  @bind
-  onLeafItemClick() {
-    const { isDrawerOpen } = this.state
+  const onLeafItemClick = useCallback(() => {
     if (isDrawerOpen) {
-      this.onDrawerExpandClick()
+      onDrawerExpandClick()
     }
-  }
+  }, [isDrawerOpen, onDrawerExpandClick])
 
-  @bind
-  ref(node) {
-    this.node = node
-  }
+  const navigationClassNames = classnames(className, style.navigation, {
+    [style.navigationMinimized]: isMinimized,
+  })
+  const minimizeButtonClassNames = classnames(style.minimizeButton, {
+    [style.minimizeButtonMinimized]: isMinimized,
+  })
 
-  render() {
-    const { className, header, children, intl } = this.props
-    const { isMinimized, isDrawerOpen } = this.state
+  const drawerClassNames = classnames(style.drawer, { [style.drawerOpen]: isDrawerOpen })
 
-    const navigationClassNames = classnames(className, style.navigation, {
-      [style.navigationMinimized]: isMinimized,
-    })
-    const minimizeButtonClassNames = classnames(style.minimizeButton, {
-      [style.minimizeButtonMinimized]: isMinimized,
-    })
-
-    const drawerClassNames = classnames(style.drawer, { [style.drawerOpen]: isDrawerOpen })
-
-    return (
-      <>
-        <nav className={navigationClassNames} ref={this.ref} data-test-id="navigation-sidebar">
-          <div className={style.mobileHeader} onClick={this.onDrawerExpandClick}>
-            <Icon className={style.expandIcon} icon="more_vert" />
-            <img
-              className={style.icon}
-              src={header.icon}
-              alt={intl.formatMessage(header.iconAlt)}
-            />
-            <Message className={style.message} content={header.title} />
-          </div>
-          <div>
-            <div className={drawerClassNames}>
-              <Link to={header.to}>
-                <div className={style.header}>
-                  <img
-                    className={style.icon}
-                    src={header.icon}
-                    alt={intl.formatMessage(header.iconAlt)}
-                  />
-                  <Message className={style.message} content={header.title} />
-                </div>
-              </Link>
-              <SideNavigationContext.Provider
-                value={{ isMinimized, onLeafItemClick: this.onLeafItemClick }}
+  return (
+    <>
+      <nav className={navigationClassNames} ref={node} data-test-id="navigation-sidebar">
+        <div className={style.mobileHeader} onClick={onDrawerExpandClick}>
+          <Icon className={style.expandIcon} icon="more_vert" />
+          <img className={style.icon} src={header.icon} alt={intl.formatMessage(header.iconAlt)} />
+          <Message className={style.message} content={header.title} />
+        </div>
+        <div>
+          <div className={drawerClassNames}>
+            <Link to={header.to}>
+              <div className={style.header}>
+                <img
+                  className={style.icon}
+                  src={header.icon}
+                  alt={intl.formatMessage(header.iconAlt)}
+                />
+                <Message className={style.message} content={header.title} />
+              </div>
+            </Link>
+            <SideNavigationContext.Provider value={{ isMinimized, onLeafItemClick }}>
+              <SideNavigationList
+                onListClick={onDrawerExpandClick}
+                isMinimized={isMinimized}
+                className={style.navigationList}
               >
-                <SideNavigationList
-                  onListClick={this.onDrawerExpandClick}
-                  isMinimized={isMinimized}
-                  className={style.navigationList}
-                >
-                  {children}
-                </SideNavigationList>
-              </SideNavigationContext.Provider>
-            </div>
+                {children}
+              </SideNavigationList>
+            </SideNavigationContext.Provider>
           </div>
-        </nav>
-        <Button
-          unstyled
-          className={minimizeButtonClassNames}
-          icon={isMinimized ? 'keyboard_arrow_right' : 'keyboard_arrow_left'}
-          message={isMinimized ? null : m.hideSidebar}
-          onClick={this.onToggle}
-          data-hook="side-nav-hide-button"
-        />
-      </>
-    )
-  }
+        </div>
+      </nav>
+      <Button
+        unstyled
+        className={minimizeButtonClassNames}
+        icon={isMinimized ? 'keyboard_arrow_right' : 'keyboard_arrow_left'}
+        message={isMinimized ? null : m.hideSidebar}
+        onClick={onToggle}
+        data-hook="side-nav-hide-button"
+      />
+    </>
+  )
+}
+
+SideNavigation.propTypes = {
+  appContainerId: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  /** The header for the side navigation. */
+  header: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    icon: PropTypes.string.isRequired,
+    iconAlt: PropTypes.message.isRequired,
+    to: PropTypes.string.isRequired,
+  }).isRequired,
+  modifyAppContainerClasses: PropTypes.bool,
+}
+
+SideNavigation.defaultProps = {
+  appContainerId: 'app',
+  modifyAppContainerClasses: true,
+  className: undefined,
 }
 
 const PortalledSideNavigation = props =>
@@ -262,4 +222,4 @@ const PortalledSideNavigation = props =>
 
 PortalledSideNavigation.Item = SideNavigationItem
 
-export default PortalledSideNavigation
+export { PortalledSideNavigation as default, SideNavigation }

--- a/pkg/webui/lib/components/init.js
+++ b/pkg/webui/lib/components/init.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react'
-import { connect } from 'react-redux'
+import React, { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import 'focus-visible/dist/focus-visible'
 import { setConfiguration } from 'react-grid-system'
 import { defineMessages } from 'react-intl'
@@ -70,32 +70,13 @@ setConfiguration({
   gutterWidth: LAYOUT.GUTTER_WIDTH,
 })
 
-@connect(
-  state => ({
-    initialized: !selectInitFetching(state) && selectIsInitialized(state),
-    error: selectInitError(state),
-  }),
-  dispatch => ({
-    initialize: () => dispatch(initialize()),
-  }),
-)
-export default class Init extends React.PureComponent {
-  static propTypes = {
-    children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
-    error: PropTypes.error,
-    initialize: PropTypes.func.isRequired,
-    initialized: PropTypes.bool,
-  }
+const Init = ({ children }) => {
+  const initialized = useSelector(state => !selectInitFetching(state) && selectIsInitialized(state))
+  const error = useSelector(state => selectInitError(state))
+  const dispatch = useDispatch()
 
-  static defaultProps = {
-    initialized: false,
-    error: undefined,
-  }
-
-  componentDidMount() {
-    const { initialize } = this.props
-
-    initialize()
+  useEffect(() => {
+    dispatch(initialize())
 
     // Preload font files to avoid flashes of unstyled text.
     for (const fontUrl of fontsToPreload) {
@@ -106,25 +87,27 @@ export default class Init extends React.PureComponent {
       linkElem.setAttribute('crossorigin', 'anonymous')
       document.getElementsByTagName('head')[0].appendChild(linkElem)
     }
+  }, [dispatch])
+
+  if (error) {
+    throw error
   }
 
-  render() {
-    const { initialized, error } = this.props
-
-    if (error) {
-      throw error
-    }
-
-    if (!initialized) {
-      return (
-        <div style={{ height: '100vh' }}>
-          <Spinner center>
-            <Message content={m.initializing} />
-          </Spinner>
-        </div>
-      )
-    }
-
-    return this.props.children
+  if (!initialized) {
+    return (
+      <div style={{ height: '100vh' }}>
+        <Spinner center>
+          <Message content={m.initializing} />
+        </Spinner>
+      </div>
+    )
   }
+
+  return children
 }
+
+Init.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+}
+
+export default Init

--- a/pkg/webui/lib/components/intl-helmet.js
+++ b/pkg/webui/lib/components/intl-helmet.js
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,67 +12,60 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Helmet } from 'react-helmet'
-import { injectIntl } from 'react-intl'
+import { useIntl } from 'react-intl'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 import { warn } from '@ttn-lw/lib/log'
 
-/**
- * IntlHelmet is a HOC that enables usage of i18n message objects inside the
- * props in react-helmet, which will be translated automatically.
- */
-@injectIntl
-export default class IntlHelmet extends React.Component {
-  static propTypes = {
-    children: PropTypes.node,
-    intl: PropTypes.shape({
-      formatMessage: PropTypes.func.isRequired,
-    }).isRequired,
-    values: PropTypes.shape({}),
-  }
+const IntlHelmet = ({ children, values, ...rest }) => {
+  const intl = useIntl()
 
-  static defaultProps = {
-    children: undefined,
-    values: undefined,
-  }
-
-  componentDidMount() {
-    if (this.props.children) {
-      warn(`Children of <IntlHelmet /> will not be translated. If you tried to
-translate head elements with <Message />, use props with message objects
-instead.`)
+  useEffect(() => {
+    if (children) {
+      warn(
+        `Children of <IntlHelmet /> will not be translated. If you tried to translate head elements with <Message />, use props with message objects instead.`,
+      )
     }
-  }
+  }, [children])
 
-  render() {
-    const { intl, children, values, ...rest } = this.props
-    let translatedRest = {}
-    for (const key in rest) {
-      let prop = rest[key]
-      if (typeof prop === 'object' && prop.id && prop.defaultMessage) {
-        const messageValues = values || prop.values || {}
-        const translatedMessageValues = {}
+  let translatedRest = {}
+  for (const key in rest) {
+    let prop = rest[key]
+    if (typeof prop === 'object' && prop.id && prop.defaultMessage) {
+      const messageValues = values || prop.values || {}
+      const translatedMessageValues = {}
 
-        for (const entry in messageValues) {
-          const content = messageValues[entry]
-          if (typeof content === 'object' && prop.id && prop.defaultMessage) {
-            translatedMessageValues[entry] = intl.formatMessage(content)
-          } else {
-            translatedMessageValues[entry] = messageValues[entry]
-          }
+      for (const entry in messageValues) {
+        const content = messageValues[entry]
+        if (typeof content === 'object' && prop.id && prop.defaultMessage) {
+          translatedMessageValues[entry] = intl.formatMessage(content)
+        } else {
+          translatedMessageValues[entry] = messageValues[entry]
         }
-
-        prop = intl.formatMessage(prop, translatedMessageValues)
       }
 
-      translatedRest = {
-        ...translatedRest,
-        [key]: prop,
-      }
+      prop = intl.formatMessage(prop, translatedMessageValues)
     }
 
-    return <Helmet {...translatedRest}>{children}</Helmet>
+    translatedRest = {
+      ...translatedRest,
+      [key]: prop,
+    }
   }
+
+  return <Helmet {...translatedRest}>{children}</Helmet>
 }
+
+IntlHelmet.propTypes = {
+  children: PropTypes.node,
+  values: PropTypes.shape({}),
+}
+
+IntlHelmet.defaultProps = {
+  children: undefined,
+  values: undefined,
+}
+
+export default IntlHelmet


### PR DESCRIPTION
#### Summary

This quickfix PR converts some class components to functional components.

References #6376 

#### Changes

- Convert class to functional components

#### Notes for Reviewers

Doing this to get rid of decorators that are preceding export statements, which causes issues when applying codemods.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
