### PR TITLE
Simplify correlation IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ For details about compatibility between different releases, see the **Commitment
 - The Network Server ID (NSID, EUI-64) used in LoRaWAN Backend Interfaces is now included in the application uplink message network metadata as well as in the Backend Interfaces `HomeNSAns` message that Identity Server returns to clients. The NSID is configurable via `is.network.ns-id`.
 - It is now possible to trigger a resending of the email validation email from within the Console. The new action is part of the error screen that users see when they log into the Console without having their contact info validated yet (and the network requires validation before usage).
 - Updated Japanese translations for the Console and backend.
+- `--grpc.correlation-ids-ignore-methods` configuration option, which allows certain gRPC methods to be skipped from the correlation ID middleware which adds a correlation ID with the name of the gRPC method. Methods bear the format used by `--grpc.log-ignore-methods`, such as `/ttn.lorawan.v3.GsNs/HandleUplink`.
 
 ### Changed
 
 - Users can now request a new email for the account validation from time to time instead of once per validation, the interval between email requests is determined by `is.user-registration.contact-info-validation.retry-interval` and by default it is an hour.
+- Traffic related correlation IDs have been simplified. Previously one correlation ID per component was added as traffic passed through different stack components. Now a singular correlation ID relating to the entry point of the message will be added (such as `gs:uplink:xxx` for uplinks, or `as:downlink:xxx` for downlinks), and subsequent components will no longer add any extra correlation IDs (such as `ns:uplink:xxx` or `as:up:xxx`). The uplink entry points are `pba` and `gs`, while the downlink entry points are `pba`, `ns` and `as`.
 
 ### Deprecated
 

--- a/api/ttn/lorawan/v3/api.md
+++ b/api/ttn/lorawan/v3/api.md
@@ -7518,7 +7518,7 @@ Application uplink message.
 | `downlink_queue_invalidated` | [`ApplicationInvalidatedDownlinks`](#ttn.lorawan.v3.ApplicationInvalidatedDownlinks) |  |  |
 | `location_solved` | [`ApplicationLocation`](#ttn.lorawan.v3.ApplicationLocation) |  |  |
 | `service_data` | [`ApplicationServiceData`](#ttn.lorawan.v3.ApplicationServiceData) |  |  |
-| `simulated` | [`bool`](#bool) |  | Signals if the message is coming from the Network Server or is simulated. |
+| `simulated` | [`bool`](#bool) |  | Signals if the message is coming from the Network Server or is simulated. The Application Server automatically sets this field, and callers must not manually set it. |
 
 #### Field Rules
 

--- a/api/ttn/lorawan/v3/api.swagger.json
+++ b/api/ttn/lorawan/v3/api.swagger.json
@@ -4544,7 +4544,7 @@
                 },
                 "simulated": {
                   "type": "boolean",
-                  "description": "Signals if the message is coming from the Network Server or is simulated."
+                  "description": "Signals if the message is coming from the Network Server or is simulated.\nThe Application Server automatically sets this field, and callers must not manually set it."
                 }
               },
               "description": "Application uplink message."
@@ -20453,7 +20453,7 @@
         },
         "simulated": {
           "type": "boolean",
-          "description": "Signals if the message is coming from the Network Server or is simulated."
+          "description": "Signals if the message is coming from the Network Server or is simulated.\nThe Application Server automatically sets this field, and callers must not manually set it."
         }
       },
       "description": "Application uplink message."

--- a/api/ttn/lorawan/v3/messages.proto
+++ b/api/ttn/lorawan/v3/messages.proto
@@ -532,6 +532,7 @@ message ApplicationUp {
   }
 
   // Signals if the message is coming from the Network Server or is simulated.
+  // The Application Server automatically sets this field, and callers must not manually set it.
   bool simulated = 14;
 
   // next: 17

--- a/config/messages.json
+++ b/config/messages.json
@@ -2123,6 +2123,15 @@
       "file": "grpc.go"
     }
   },
+  "error:pkg/applicationserver/io/grpc:simulated": {
+    "translations": {
+      "en": "simulated traffic cannot be simulated again"
+    },
+    "description": {
+      "package": "pkg/applicationserver/io/grpc",
+      "file": "grpc.go"
+    }
+  },
   "error:pkg/applicationserver/io/mqtt:not_authorized": {
     "translations": {
       "en": "not authorized"

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -62,6 +62,11 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+var (
+	appendUpCorrelationID       = events.RegisterCorrelationIDPrefix("uplink", "as:up")
+	appendDownlinkCorrelationID = events.RegisterCorrelationIDPrefix("downlink", "as:downlink")
+)
+
 // ApplicationServer implements the Application Server component.
 //
 // The Application Server exposes the As, AppAs and AsEndDeviceRegistry services.
@@ -429,7 +434,8 @@ func (as *ApplicationServer) processUp(ctx context.Context, up *ttnpb.Applicatio
 	defer trace.StartRegion(ctx, "process up").End()
 
 	ctx = log.NewContextWithField(ctx, "device_uid", unique.ID(ctx, up.EndDeviceIds))
-	ctx = events.ContextWithCorrelationID(ctx, append(up.CorrelationIds, fmt.Sprintf("as:up:%s", events.NewCorrelationID()))...)
+	ctx = events.ContextWithCorrelationID(ctx, up.CorrelationIds...)
+	ctx = appendUpCorrelationID(ctx)
 	up.CorrelationIds = events.CorrelationIDsFromContext(ctx)
 	registerReceiveUp(ctx, up)
 
@@ -708,7 +714,7 @@ func (as *ApplicationServer) initAndValidateConfirmationRetriesConfig(item *ttnp
 }
 
 func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, items []*ttnpb.ApplicationDownlink, op func(ttnpb.AsNsClient, context.Context, *ttnpb.DownlinkQueueRequest, ...grpc.CallOption) (*emptypb.Empty, error)) error {
-	ctx = events.ContextWithCorrelationID(ctx, fmt.Sprintf("as:downlink:%s", events.NewCorrelationID()))
+	ctx = appendDownlinkCorrelationID(ctx)
 	link, err := as.getLink(ctx, ids.ApplicationIds, []string{
 		"default_formatters",
 		"skip_payload_crypto",

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -383,7 +383,6 @@ func (*ApplicationServer) Roles() []ttnpb.ClusterRole {
 // Subscription for traffic and control. If the cluster parameter is true, the subscription receives all of the
 // traffic of the application. Otherwise, only traffic that was processed locally is sent.
 func (as *ApplicationServer) Subscribe(ctx context.Context, protocol string, ids *ttnpb.ApplicationIdentifiers, cluster bool) (*io.Subscription, error) {
-	ctx = events.ContextWithCorrelationID(ctx, fmt.Sprintf("as:conn:%s", events.NewCorrelationID()))
 	if ids != nil {
 		uid := unique.ID(ctx, ids)
 		ctx = log.NewContextWithField(ctx, "application_uid", uid)

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -714,7 +714,9 @@ func (as *ApplicationServer) initAndValidateConfirmationRetriesConfig(item *ttnp
 }
 
 func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, items []*ttnpb.ApplicationDownlink, op func(ttnpb.AsNsClient, context.Context, *ttnpb.DownlinkQueueRequest, ...grpc.CallOption) (*emptypb.Empty, error)) error {
-	ctx = appendDownlinkCorrelationID(ctx)
+	if len(items) <= 1 {
+		ctx = appendDownlinkCorrelationID(ctx)
+	}
 	link, err := as.getLink(ctx, ids.ApplicationIds, []string{
 		"default_formatters",
 		"skip_payload_crypto",
@@ -728,6 +730,9 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids *ttnpb.End
 	}
 	for _, item := range items {
 		ctx := events.ContextWithCorrelationID(ctx, item.CorrelationIds...)
+		if len(items) > 1 {
+			ctx = appendDownlinkCorrelationID(ctx)
+		}
 		item.CorrelationIds = events.CorrelationIDsFromContext(ctx)
 	}
 	now := timestamppb.Now()

--- a/pkg/applicationserver/io/grpc/grpc.go
+++ b/pkg/applicationserver/io/grpc/grpc.go
@@ -21,6 +21,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/messageprocessors"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -213,9 +214,18 @@ func (s *impl) GetMQTTConnectionInfo(ctx context.Context, ids *ttnpb.Application
 var errPayloadCryptoSkipped = errors.DefineFailedPrecondition("payload_crypto_skipped", "payload crypto skipped")
 
 func (s *impl) SimulateUplink(ctx context.Context, up *ttnpb.ApplicationUp) (*emptypb.Empty, error) {
-	if err := rights.RequireApplication(ctx, up.EndDeviceIds.ApplicationIds, ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_UP_WRITE); err != nil {
+	if up.Simulated {
+		// Traffic already marked as simulated is discarded, in order to avoid traffic loops created by injecting
+		// simulated traffic which is then piped into the simulate uplink endpoint itself.
+		return ttnpb.Empty, nil
+	}
+	if err := rights.RequireApplication(
+		ctx, up.EndDeviceIds.ApplicationIds, ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_UP_WRITE,
+	); err != nil {
 		return nil, err
 	}
+	ctx = events.ContextWithCorrelationID(ctx, up.CorrelationIds...)
+	up.CorrelationIds = events.CorrelationIDsFromContext(ctx)
 	skip, err := s.skipPayloadCrypto(ctx, up.EndDeviceIds)
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Debug("Failed to determine if the payload crypto should be skipped")

--- a/pkg/applicationserver/io/grpc/grpc.go
+++ b/pkg/applicationserver/io/grpc/grpc.go
@@ -211,13 +211,16 @@ func (s *impl) GetMQTTConnectionInfo(ctx context.Context, ids *ttnpb.Application
 	}, nil
 }
 
-var errPayloadCryptoSkipped = errors.DefineFailedPrecondition("payload_crypto_skipped", "payload crypto skipped")
+var (
+	errPayloadCryptoSkipped = errors.DefineFailedPrecondition("payload_crypto_skipped", "payload crypto skipped")
+	errSimulated            = errors.DefineInvalidArgument("simulated", "simulated traffic cannot be simulated again")
+)
 
 func (s *impl) SimulateUplink(ctx context.Context, up *ttnpb.ApplicationUp) (*emptypb.Empty, error) {
 	if up.Simulated {
 		// Traffic already marked as simulated is discarded, in order to avoid traffic loops created by injecting
 		// simulated traffic which is then piped into the simulate uplink endpoint itself.
-		return ttnpb.Empty, nil
+		return nil, errSimulated.New()
 	}
 	if err := rights.RequireApplication(
 		ctx, up.EndDeviceIds.ApplicationIds, ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_UP_WRITE,

--- a/pkg/component/grpc.go
+++ b/pkg/component/grpc.go
@@ -41,6 +41,7 @@ func (c *Component) initGRPC() {
 		rpcserver.WithContextFiller(c.FillContext),
 		rpcserver.WithTrustedProxies(c.config.GRPC.TrustedProxies...),
 		rpcserver.WithLogIgnoreMethods(c.config.GRPC.LogIgnoreMethods),
+		rpcserver.WithCorrelationIDsIgnoreMethods(c.config.GRPC.CorrelationIDsIgnoreMethods),
 		rpcserver.WithRateLimiter(c.RateLimiter()),
 	)
 }

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -58,14 +58,15 @@ type Sentry struct {
 
 // GRPC represents gRPC listener configuration.
 type GRPC struct {
-	AllowInsecureForCredentials bool `name:"allow-insecure-for-credentials" description:"Allow transmission of credentials over insecure transport"` //nolint:lll
+	AllowInsecureForCredentials bool `name:"allow-insecure-for-credentials" description:"Allow transmission of credentials over insecure transport"` // nolint:lll
 
 	Listen    string `name:"listen" description:"Address for the TCP gRPC server to listen on"`
 	ListenTLS string `name:"listen-tls" description:"Address for the TLS gRPC server to listen on"`
 
 	TrustedProxies []string `name:"trusted-proxies" description:"CIDRs of trusted reverse proxies"`
 
-	LogIgnoreMethods []string `name:"log-ignore-methods" description:"List of paths for which successful requests will not be logged"` //nolint:lll
+	LogIgnoreMethods            []string `name:"log-ignore-methods" description:"List of methods for which requests will not be logged"`                         // nolint:lll
+	CorrelationIDsIgnoreMethods []string `name:"correlation-ids-ignore-methods" description:"List of methods for which no RPC correlation IDs will be injected"` // nolint:lll
 }
 
 // Cookie represents cookie configuration.

--- a/pkg/events/correlation_class.go
+++ b/pkg/events/correlation_class.go
@@ -1,0 +1,79 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type (
+	correlationIDClass  string
+	correlationIDPrefix string
+)
+
+var (
+	correlationIDPrefixesByClass = make(map[correlationIDClass]map[correlationIDPrefix]struct{})
+	correlationIDClassByPrefix   = make(map[correlationIDPrefix]correlationIDClass)
+)
+
+// RegisterCorrelationIDPrefix register a prefix which ensures that will be unique within the same class.
+// The function returns a function that can be used to add the correlation ID to a context.
+// If the prefix is already registered, the function panics.
+// The function is not goroutine safe, and it is meant to be called during package initialization.
+func RegisterCorrelationIDPrefix(
+	class correlationIDClass, prefix correlationIDPrefix,
+) func(context.Context, ...string) context.Context {
+	byClass, ok := correlationIDPrefixesByClass[class]
+	if !ok {
+		byClass = make(map[correlationIDPrefix]struct{})
+		correlationIDPrefixesByClass[class] = byClass
+	}
+	if _, ok := byClass[prefix]; ok {
+		panic(fmt.Sprintf("prefix `%v` already registered in class `%v`", prefix, class))
+	}
+	if _, ok := correlationIDClassByPrefix[prefix]; ok {
+		panic(fmt.Sprintf("prefix `%v` already registered in class `%v`", prefix, class))
+	}
+	byClass[prefix] = struct{}{}
+	correlationIDClassByPrefix[prefix] = class
+	return func(ctx context.Context, suffixes ...string) context.Context {
+		if correlationIDClassPresent(ctx, byClass) {
+			return ctx
+		}
+		suffix := strings.Join(suffixes, ":")
+		if suffix == "" {
+			suffix = NewCorrelationID()
+		}
+		return ContextWithCorrelationID(ctx, fmt.Sprintf("%v:%v", prefix, suffix))
+	}
+}
+
+func correlationIDClassPresent(ctx context.Context, prefixes map[correlationIDPrefix]struct{}) bool {
+	correlationIDs := CorrelationIDsFromContext(ctx)
+	if len(correlationIDs) == 0 {
+		return false
+	}
+	for prefix := range prefixes {
+		prefix := string(prefix) + ":"
+		for _, correlationID := range correlationIDs {
+			if strings.HasPrefix(correlationID, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -62,6 +62,11 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+var (
+	appendUplinkCorrelationID = events.RegisterCorrelationIDPrefix("uplink", "gs:uplink")
+	appendTxAckCorrelationID  = events.RegisterCorrelationIDPrefix("tx_ack", "gs:tx_ack")
+)
+
 // GatewayServer implements the Gateway Server component.
 //
 // The Gateway Server exposes the Gs, GtwGs and NsGs services and MQTT and UDP frontends for gateways.
@@ -890,10 +895,8 @@ func (gs *GatewayServer) handleUpstream(ctx context.Context, conn connectionEntr
 		case <-ctx.Done():
 			return
 		case msg := <-conn.Up():
-			correlationIDs := make([]string, 0, len(msg.Message.CorrelationIds)+1)
-			correlationIDs = append(correlationIDs, msg.Message.CorrelationIds...)
-			correlationIDs = append(correlationIDs, fmt.Sprintf("gs:uplink:%s", events.NewCorrelationID()))
-			ctx = events.ContextWithCorrelationID(ctx, correlationIDs...)
+			ctx = events.ContextWithCorrelationID(ctx, msg.Message.CorrelationIds...)
+			ctx = appendUplinkCorrelationID(ctx)
 			msg.Message.CorrelationIds = events.CorrelationIDsFromContext(ctx)
 			if msg.Message.Payload == nil {
 				msg.Message.Payload = &ttnpb.Message{}
@@ -916,11 +919,11 @@ func (gs *GatewayServer) handleUpstream(ctx context.Context, conn connectionEntr
 			val = msg
 			registerReceiveStatus(ctx, gtw, msg, protocol)
 		case msg := <-conn.TxAck():
-			correlationIDs := make([]string, 0, len(msg.CorrelationIds)+len(msg.DownlinkMessage.GetCorrelationIds())+1)
+			correlationIDs := make([]string, 0, len(msg.CorrelationIds)+len(msg.DownlinkMessage.GetCorrelationIds()))
 			correlationIDs = append(correlationIDs, msg.CorrelationIds...)
 			correlationIDs = append(correlationIDs, msg.DownlinkMessage.GetCorrelationIds()...)
-			correlationIDs = append(correlationIDs, fmt.Sprintf("gs:tx_ack:%s", events.NewCorrelationID()))
 			ctx = events.ContextWithCorrelationID(ctx, correlationIDs...)
+			ctx = appendTxAckCorrelationID(ctx)
 			msg.CorrelationIds = events.CorrelationIDsFromContext(ctx)
 			if d := msg.DownlinkMessage; d != nil {
 				d.CorrelationIds = events.CorrelationIDsFromContext(ctx)

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -953,7 +953,7 @@ func (ns *NetworkServer) scheduleDownlinkByPaths(
 	default:
 		panic(fmt.Sprintf("attempt to schedule downlink with invalid MType '%s'", req.Payload.MHdr.MType))
 	}
-	ctx = events.ContextWithCorrelationID(ctx, fmt.Sprintf("ns:downlink:%s", events.NewCorrelationID()))
+	ctx = appendDownlinkCorrelationID(ctx)
 	var (
 		errs                    = make([]error, 0, totalAttempts)
 		eventIDOpt              = events.WithIdentifiers(req.EndDeviceIdentifiers)

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1404,10 +1404,8 @@ func (ns *NetworkServer) HandleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 		return nil, err
 	}
 
-	ctx = events.ContextWithCorrelationID(ctx, append(
-		up.CorrelationIds,
-		fmt.Sprintf("ns:uplink:%s", events.NewCorrelationID()),
-	)...)
+	ctx = events.ContextWithCorrelationID(ctx, up.CorrelationIds...)
+	ctx = appendUplinkCorrelationID(ctx)
 	up.CorrelationIds = events.CorrelationIDsFromContext(ctx)
 
 	registerUplinkLatency(ctx, up)
@@ -1487,9 +1485,8 @@ func (ns *NetworkServer) ReportTxAcknowledgment(
 	}
 
 	ack := txAck.GetTxAck()
-	ctx = events.ContextWithCorrelationID(
-		ctx, append(ack.CorrelationIds, fmt.Sprintf("ns:tx_ack:%s", events.NewCorrelationID()))...,
-	)
+	ctx = events.ContextWithCorrelationID(ctx, ack.CorrelationIds...)
+	ctx = appendTxAckCorrelationID(ctx)
 
 	down, err := ns.scheduledDownlinkMatcher.Match(ctx, ack)
 	if err != nil {

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -28,6 +28,12 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
 )
 
+var (
+	appendUplinkCorrelationID   = events.RegisterCorrelationIDPrefix("uplink", "ns:uplink")
+	appendDownlinkCorrelationID = events.RegisterCorrelationIDPrefix("downlink", "ns:downlink")
+	appendTxAckCorrelationID    = events.RegisterCorrelationIDPrefix("tx_ack", "ns:tx_ack")
+)
+
 // nsScheduleWindow returns minimum time.Duration between downlink being added to the queue and it being sent to GS for transmission.
 func nsScheduleWindow() time.Duration {
 	// TODO: Observe this value at runtime https://github.com/TheThingsNetwork/lorawan-stack/issues/1552.

--- a/pkg/packetbrokeragent/agent.go
+++ b/pkg/packetbrokeragent/agent.go
@@ -442,7 +442,6 @@ func (a *Agent) publishUplink(ctx context.Context) error {
 		return err
 	}
 	defer conn.Close()
-	ctx = events.ContextWithCorrelationID(ctx, fmt.Sprintf("pba:conn:up:%s", events.NewCorrelationID()))
 
 	logger := log.FromContext(ctx)
 	logger.Info("Connected as Forwarder")
@@ -514,7 +513,6 @@ func (a *Agent) subscribeDownlink(ctx context.Context) error {
 		return err
 	}
 	defer conn.Close()
-	ctx = events.ContextWithCorrelationID(ctx, fmt.Sprintf("pba:conn:down:%s", events.NewCorrelationID()))
 
 	client := routingpb.NewForwarderDataClient(conn)
 
@@ -801,7 +799,6 @@ func (a *Agent) subscribeUplink(ctx context.Context) error {
 		return err
 	}
 	defer conn.Close()
-	ctx = events.ContextWithCorrelationID(ctx, fmt.Sprintf("pba:conn:up:%s", events.NewCorrelationID()))
 
 	filters := a.getSubscriptionFilters()
 	for i, f := range filters {
@@ -1078,7 +1075,6 @@ func (a *Agent) publishDownlink(ctx context.Context) error {
 		return err
 	}
 	defer conn.Close()
-	ctx = events.ContextWithCorrelationID(ctx, fmt.Sprintf("pba:conn:down:%s", events.NewCorrelationID()))
 
 	logger := log.FromContext(ctx)
 	logger.Info("Connected as Home Network")

--- a/pkg/packetbrokeragent/agent.go
+++ b/pkg/packetbrokeragent/agent.go
@@ -54,6 +54,11 @@ const (
 	publishMessageTimeout = 3 * time.Second
 )
 
+var (
+	appendUplinkCorrelationID   = events.RegisterCorrelationIDPrefix("uplink", "pba:uplink")
+	appendDownlinkCorrelationID = events.RegisterCorrelationIDPrefix("downlink", "pba:downlink")
+)
+
 // TenantContextFiller fills the parent context based on the tenant ID.
 type TenantContextFiller func(parent context.Context, tenantID string) (context.Context, error)
 
@@ -622,7 +627,7 @@ func (a *Agent) handleDownlink(
 		if down.Message == nil {
 			return
 		}
-		ctx = events.ContextWithCorrelationID(ctx, fmt.Sprintf("pba:downlink:%s", down.Id))
+		ctx = appendDownlinkCorrelationID(ctx, down.Id)
 		var homeNetworkNetID types.NetID
 		homeNetworkNetID.UnmarshalNumber(down.HomeNetworkNetId)
 		ctx = log.NewContextWithFields(ctx, log.Fields(
@@ -945,7 +950,7 @@ func (a *Agent) handleUplink(
 		if up.Message == nil {
 			return
 		}
-		ctx = events.ContextWithCorrelationID(ctx, fmt.Sprintf("pba:uplink:%s", up.Id))
+		ctx = appendDownlinkCorrelationID(ctx, up.Id)
 		var forwarderNetID types.NetID
 		forwarderNetID.UnmarshalNumber(up.ForwarderNetId)
 		ctx = log.NewContextWithFields(ctx, log.Fields(

--- a/pkg/packetbrokeragent/agent_test.go
+++ b/pkg/packetbrokeragent/agent_test.go
@@ -984,7 +984,7 @@ func TestHomeNetwork(t *testing.T) {
 				case <-time.After(timeout):
 					t.Fatal("Expected uplink message from Forwarder")
 				}
-				a.So(nsMsg.CorrelationIds, should.HaveLength, 2)
+				a.So(nsMsg.CorrelationIds, should.HaveLength, 1)
 				a.So(*ttnpb.StdTime(nsMsg.ReceivedAt), should.HappenBetween, before, time.Now()) // Packet Broker Agent sets local time on receive.
 
 				expected := ttnpb.Clone(tc.UplinkMessage)

--- a/pkg/packetbrokeragent/grpc_gspba.go
+++ b/pkg/packetbrokeragent/grpc_gspba.go
@@ -16,7 +16,6 @@ package packetbrokeragent
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	mappingpb "go.packetbroker.org/api/mapping/v2"
@@ -72,10 +71,8 @@ func (s *gsPbaServer) PublishUplink(ctx context.Context, up *ttnpb.GatewayUplink
 		return nil, err
 	}
 
-	ctx = events.ContextWithCorrelationID(ctx, append(
-		up.Message.CorrelationIds,
-		fmt.Sprintf("pba:uplink:%s", events.NewCorrelationID()),
-	)...)
+	ctx = events.ContextWithCorrelationID(ctx, up.Message.CorrelationIds...)
+	ctx = appendUplinkCorrelationID(ctx)
 	up.Message.CorrelationIds = events.CorrelationIDsFromContext(ctx)
 
 	msg, err := toPBUplink(ctx, up, s.config)

--- a/pkg/packetbrokeragent/grpc_nspba.go
+++ b/pkg/packetbrokeragent/grpc_nspba.go
@@ -16,7 +16,6 @@ package packetbrokeragent
 
 import (
 	"context"
-	"fmt"
 
 	clusterauth "go.thethings.network/lorawan-stack/v3/pkg/auth/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
@@ -39,10 +38,8 @@ func (s *nsPbaServer) PublishDownlink(ctx context.Context, down *ttnpb.DownlinkM
 		return nil, err
 	}
 
-	ctx = events.ContextWithCorrelationID(ctx, append(
-		down.CorrelationIds,
-		fmt.Sprintf("pba:downlink:%s", events.NewCorrelationID()),
-	)...)
+	ctx = events.ContextWithCorrelationID(ctx, down.CorrelationIds...)
+	ctx = appendDownlinkCorrelationID(ctx)
 	down.CorrelationIds = events.CorrelationIDsFromContext(ctx)
 
 	fps, err := s.frequencyPlans(ctx)

--- a/pkg/ttnpb/messages.pb.go
+++ b/pkg/ttnpb/messages.pb.go
@@ -1587,6 +1587,7 @@ type ApplicationUp struct {
 	//	*ApplicationUp_ServiceData
 	Up isApplicationUp_Up `protobuf_oneof:"up"`
 	// Signals if the message is coming from the Network Server or is simulated.
+	// The Application Server automatically sets this field, and callers must not manually set it.
 	Simulated bool `protobuf:"varint,14,opt,name=simulated,proto3" json:"simulated,omitempty"`
 }
 

--- a/sdk/js/generated/api.json
+++ b/sdk/js/generated/api.json
@@ -33871,7 +33871,7 @@
             },
             {
               "name": "simulated",
-              "description": "Signals if the message is coming from the Network Server or is simulated.",
+              "description": "Signals if the message is coming from the Network Server or is simulated.\nThe Application Server automatically sets this field, and callers must not manually set it.",
               "label": "",
               "type": "bool",
               "longType": "bool",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR proposes a rework of the correlation ID system, by introducing the concept of correlation ID classes and the removal of long lived correlation IDs.

The idea behind the correlation ID classes is that having multiple correlation IDs relating to the same message is superfluous. Any extra correlation ID outside of the source component correlation ID (`gs`/`ns`/`pba` for uplinks, and `as`/`ns`/`pba` for downlinks) is not adding any information outside of 'I've passed this component'. But that is not really information - the traffic path is fixed outside of the entry point: you always go (GS/PBA) -> NS (-> AS) - there isn't any magic path that you are learning from the correlation IDs.

Correlation ID classes make prefixes exclusive one with another - if an uplink originates from the GS, only the `gs:uplink:*` correlation ID will be present, and the NS/AS won't append theirs too. This logic is meant to lower the bandwidth and storage usage both in-between components and with the outside world.

The removal of the long lived correlation IDs refers to the removal of the correlation IDs tied to a connection - the idea here is that for an uplink message it is already possible to trace back the source of the message by looking at the RX metadata, and that is already more useful than a unique identifier for the connection.

The use cases supported by the correlation ID system are still doable - you can still trace the entry point of a message, and all of the correlated events, but the contents are now lighter.

#### Changes

<!-- What are the changes made in this pull request? -->

- Remove connection correlation IDs.
- Add correlation ID classes.
- Support ignoring certain RPCs from the correlation ID injection process.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Manual testing on `staging1` can cover the following subjects:

- Add an OTAA end device and do a full - join -> first uplink - > application downlink flow.
- Uplink related events should not have any `rpc:` correlation IDs, and only the `gs:uplink:` correlation ID should be present in general - correlation IDs like `ns:uplink:` or `as:up:` should not be visible.
- Downlink related events from the application level should have the `as:downlink:` correlation ID, while network level downlinks (like the initial `LinkADRReq` downlinks) should have the `ns:downlink:` correlation ID. No other component downlink correlation IDs should be visible. The transmission correlation ID (`ns:transmission:`) can be present.

Examples of how small the correlation IDs are now:

- Uplink message:
<img width="572" alt="image" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/36161392/fc9aa7fa-3dec-4119-99f9-6d67dde91e49">

- Application layer downlink:
<img width="545" alt="image" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/36161392/76c7ea95-36f7-4e2f-8a3b-61d2483e1676">

- Application layer transmission acknowledgement:
<img width="576" alt="image" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/36161392/5070496a-658f-4ab1-8ceb-87a3c8673ef2">

- Network layer downlink:
<img width="572" alt="image" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/36161392/2723ec36-0891-4876-97ce-198aa44f3c09">

- Network layer transmission acknowledgement:
<img width="548" alt="image" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/36161392/7369e39a-6cb5-4d20-ba73-b5ecd43f5896">

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

This change affects the correlation IDs reported in events and upstream messages, by removing certain correlation IDs in effect. Applications generally do not depend on the stack assigned correlation IDs, and application provided correlation IDs are unaffected as long as they did not use stack prefixes.

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is mainly a proposal PR, so please let me know your thoughts.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
