### PR TITLE
Batch correlation ID insertions

### DIFF
--- a/pkg/events/redis/store.go
+++ b/pkg/events/redis/store.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"hash/fnv"
+	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,6 +34,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/task"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
+	"golang.org/x/exp/slices"
 )
 
 const ttlJitter = 0.01
@@ -257,6 +259,8 @@ func streamPartitionSize(states []*streamState, partitionSize int) int {
 }
 
 func partitionStreamStates(states []*streamState, partitionSize int) [][]*streamState {
+	states = slices.Clone(states)
+	rand.Shuffle(len(states), func(i, j int) { states[i], states[j] = states[j], states[i] })
 	partitionedStates := make([][]*streamState, 0, len(states)/partitionSize+1)
 	for len(states) > 0 {
 		n := streamPartitionSize(states, partitionSize)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes the insertion of correlation ID relations into the events store batched by making the following observation:
the commands [`LPUSH key content1`, `LPUSH key content2`] are equivalent to `LPUSH key content1 content2`.

#### Changes

<!-- What are the changes made in this pull request? -->

- Batch correlation ID insertions.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Local testing and unit tests. No explicit testing is required for the release.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

N/A. The change is semantically equivalent.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
