### PR TITLE
Reflect an user's `primary_email_address` update on its `contact_info` list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For details about compatibility between different releases, see the **Commitment
 - Providing fixed downlink paths to the `ttn-lw-cli devices downlink {push|replace}` commands using the `-class-b-c.gateways` parameter. The gateways IDs are comma separated, and the antenna index `i` can be provided by suffixing the ID with `:i` (i.e. `my-gateway:0` for antenna index 0). The group index `j` can be provided by suffixing the ID with `:j` (i.e. `my-gateway:0:1` for antenna index 0 and group index 1). The antenna index is mandatory if a group index is to be provided, but optional otherwise.
 - Gateway registration without gateway EUI not working.
 - Listing deleted entities is now fixed for both admin and standard users, which previously returned an `account_not_found` error.
+- Update to an user's `PrimaryEmailAddress` via a non admin now invalidates the `PrimaryEmailAddressValidatedAt` as it was intended.
 
 ### Security
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Didn't create a issue for it but its linked to the list of behaviors noted while going through some of the `contact_info` changes. 

References the discussion in https://github.com/TheThingsNetwork/lorawan-stack/issues/6515#issuecomment-1737328616

Changes in the interactions between the update of an user `primary_email_address` and its `contact_info` list.

There are a few areas of which the intended behavior was not happening:
1. Effectively we do not update the primary email contact present in the `contact_info` list when an user performs a request to change its `primary_email_address`.
2. When a non admin updates the `primary_email_address`, it does not set the `primary_email_address_validated_at` to `nil`. It also does not send a email re-requesting its validation.

#### Changes

<!-- What are the changes made in this pull request? -->

- Add `primary_email_address_validated_at` field mask when the update request is made by a non admin
- Updates now changes both the `primary_email_address` and its value present in the `contact_info` list.
- Add more unit test cases covering the sections of code changed 

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Unit tests and manual tests.


<details>
  <summary> Test steps </summary>

  Run the Stack with the following configuration:
  ```yaml
  tls:
    source: file
    root-ca: ./ca.pem
    certificate: ./cert.pem
    key: ./key.pem

  is:
    email:
      dir: ".env/emails" # Example of directory path
      provider: "dir"
      sender-address: ""
      sender-name:  "employee@thethingsindustries.com" # Example "employee@thethingsindustries.com"
      templates:
        directory: # Example "<repo_path>/tts/pkg/email/templates"
    user-registration:
      contact-info-validation:
        required: true
        token-ttl: 48h0m0s
  ```

  Non admin:
  1. Create a new non admin user `ttn-lw-cli usr create <usr_id> --primary-email-address <email> --password <password>`
  2. Validate the new user's email (should have a validation email on the path in `dir` on the config)
  3. Run `tools/bin/mage dev:dbsql`
    3.1. Run `select primary_email_address, primary_email_address_validated_at from users;`
    3.2. User with <usr_id> should be validated
    3.3. Run `select * from contact_infos;`
    3.4. Contact info with <email> value should be validated.
  4. Login into the Console
  5. Access the `<base_url>/oauth/profile-settings` and update the `Email Address`
    5.1. Should receive a warning of restricted rights.
  6. Check the email folder, there should be a new validation email. This happens since the email is now not validated.
  7. Run `tools/bin/mage dev:dbsql`
    7.1. Run `select primary_email_address, primary_email_address_validated_at from users;`
    7.2. User with <usr_id> should be **not be** validated (validated_at being empty)
    7.3. Run `select * from contact_infos;`
    7.4. Contact info with <email> value should **not be** validated. (validated_at being empty)

  Admin:
  1. Create a new non admin user `ttn-lw-cli usr create <usr_id> --primary-email-address <email> --password <password> --admin`
  2. Validate the new user's email (should have a validation email on the path in `dir` on the config)
  3. Run `tools/bin/mage dev:dbsql`
    3.1. Run `select primary_email_address, primary_email_address_validated_at from users;`
    3.2. User with <usr_id> should be validated
    3.3. Run `select * from contact_infos;`
    3.4. Contact info with <email> value should be validated.
  4. Login into the Console
  5. Access the `<base_url>/oauth/profile-settings` and update the `Email Address`
  6. Run `tools/bin/mage dev:dbsql`
    6.1. Run `select primary_email_address, primary_email_address_validated_at from users;`
    6.2. User with <usr_id> should be **be** validated
    6.3. Run `select * from contact_infos;`
    6.4. Contact info with <email> value should **be** validated.

</details>


##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

Ever since https://github.com/TheThingsNetwork/lorawan-stack/commit/65edcafe193d9e266177e87cff977378f2cf8001 when an user who updates its `primary_email_address` the operation is not reflected on the `contact_info` list. Therefore there is a disconnect between the primary email and the values present in the `contact_info`. The field has been deprecated, the primary email is what is used to send emails and we removed references to the `contact_info` field, being only kept for consistency.

Therefore I believe that this change is merely superficial and done in order to have the behavior as expected until the next `major/bump` and we can remove the `contact_info` field. 


#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->



#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
