### PR TITLE
Fix contact info registry tests - email validation flaky test

### DIFF
--- a/pkg/identityserver/contact_info_registry_test.go
+++ b/pkg/identityserver/contact_info_registry_test.go
@@ -48,9 +48,9 @@ func TestContactInfoValidation(t *testing.T) {
 	testWithIdentityServer(t, func(is *IdentityServer, cc *grpc.ClientConn) {
 		reg := ttnpb.NewContactInfoRegistryClient(cc)
 
-		retryInterval := test.Delay << 3
+		retryInterval := test.Delay << 5
 		is.config.UserRegistration.ContactInfoValidation.Required = true
-		is.config.UserRegistration.ContactInfoValidation.TokenTTL = test.Delay << 5
+		is.config.UserRegistration.ContactInfoValidation.TokenTTL = retryInterval * 2
 		is.config.UserRegistration.ContactInfoValidation.RetryInterval = retryInterval
 
 		t.Run("Request Validation", func(t *testing.T) { // nolint:paralleltest


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

The retry interval was previously `test.Delay * 8` which was not enough if a delay happens between test cases and generated an occasional failure in the CI. 

I changed the default `retry_interval` to `test.Delay * 32` after measuring the time spent on each case on my local machine, which is around ~70ms. Also ran the tests ~200 times to guarantee that the time is not too low (with `GOMAXPROCS=2 TEST_DELAY=8`) .