### PR TITLE
Erase uplink token for old recent uplinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For details about compatibility between different releases, see the **Commitment
 - Users can now request a new email for the account validation from time to time instead of once per validation, the interval between email requests is determined by `is.user-registration.contact-info-validation.retry-interval` and by default it is an hour.
 - Traffic related correlation IDs have been simplified. Previously one correlation ID per component was added as traffic passed through different stack components. Now a singular correlation ID relating to the entry point of the message will be added (such as `gs:uplink:xxx` for uplinks, or `as:downlink:xxx` for downlinks), and subsequent components will no longer add any extra correlation IDs (such as `ns:uplink:xxx` or `as:up:xxx`). The uplink entry points are `pba` and `gs`, while the downlink entry points are `pba`, `ns` and `as`.
 - Packet Broker Agent uplink tokens are now serialized in a more efficient manner.
+- The Network Server now stores only the most recent uplinks tokens.
 
 ### Deprecated
 

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -790,10 +790,17 @@ func appendRecentUplink(
 	up *ttnpb.UplinkMessage,
 	window int,
 ) []*ttnpb.MACState_UplinkMessage {
+	ups := toMACStateUplinkMessages(up)
 	if n := len(recent); n > 0 {
 		recent[n-1].CorrelationIds = nil
+		if len(downlinkPathsFromRecentUplinks(ups...)) > 0 {
+			for _, md := range recent[n-1].RxMetadata {
+				md.UplinkToken = nil
+				md.DownlinkPathConstraint = ttnpb.DownlinkPathConstraint_DOWNLINK_PATH_CONSTRAINT_NEVER
+			}
+		}
 	}
-	recent = append(recent, toMACStateUplinkMessages(up)...)
+	recent = append(recent, ups...)
 	if extra := len(recent) - window; extra > 0 {
 		recent = recent[extra:]
 	}

--- a/pkg/networkserver/grpc_gsns_internal_test.go
+++ b/pkg/networkserver/grpc_gsns_internal_test.go
@@ -26,15 +26,30 @@ import (
 )
 
 func TestAppendRecentUplink(t *testing.T) {
+	t.Parallel()
+	dataRate := (&ttnpb.LoRaDataRate{
+		SpreadingFactor: uint32(7),
+		Bandwidth:       125_000,
+		CodingRate:      "4/5",
+	}).DataRate()
+	macSettings := &ttnpb.MACState_UplinkMessage_TxSettings{
+		DataRate: dataRate,
+	}
+	settings := &ttnpb.TxSettings{
+		DataRate: dataRate,
+	}
 	ups := [...]*ttnpb.MACState_UplinkMessage{
 		{
 			DeviceChannelIndex: 1,
+			Settings:           macSettings,
 		},
 		{
 			DeviceChannelIndex: 2,
+			Settings:           macSettings,
 		},
 		{
 			DeviceChannelIndex: 3,
+			Settings:           macSettings,
 		},
 	}
 	for _, tc := range []struct {
@@ -46,6 +61,7 @@ func TestAppendRecentUplink(t *testing.T) {
 		{
 			Up: &ttnpb.UplinkMessage{
 				DeviceChannelIndex: 1,
+				Settings:           settings,
 			},
 			Window:   1,
 			Expected: ups[:1],
@@ -54,6 +70,7 @@ func TestAppendRecentUplink(t *testing.T) {
 			Recent: ups[:1],
 			Up: &ttnpb.UplinkMessage{
 				DeviceChannelIndex: 2,
+				Settings:           settings,
 			},
 			Window:   1,
 			Expected: ups[1:2],
@@ -62,6 +79,7 @@ func TestAppendRecentUplink(t *testing.T) {
 			Recent: ups[:2],
 			Up: &ttnpb.UplinkMessage{
 				DeviceChannelIndex: 3,
+				Settings:           settings,
 			},
 			Window:   1,
 			Expected: ups[2:3],
@@ -70,6 +88,7 @@ func TestAppendRecentUplink(t *testing.T) {
 			Recent: ups[:1],
 			Up: &ttnpb.UplinkMessage{
 				DeviceChannelIndex: 2,
+				Settings:           settings,
 			},
 			Window:   2,
 			Expected: ups[:2],
@@ -78,6 +97,7 @@ func TestAppendRecentUplink(t *testing.T) {
 			Recent: ups[:2],
 			Up: &ttnpb.UplinkMessage{
 				DeviceChannelIndex: 3,
+				Settings:           settings,
 			},
 			Window:   2,
 			Expected: ups[1:3],


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR proposes that the recent uplinks stored in the end device MAC state no longer keep _all_ of the uplink tokens, but rather only the uplink tokens of the last uplink. The reason for this is that downlink paths are decided by checking the downlink paths of the most recent uplinks only, so as long as the last uplink contains a downlink path, all of the 'old' ones are ignored anyway:

https://github.com/TheThingsNetwork/lorawan-stack/blob/7edb81c392eaed51759e6f56c723eb77ccc0bc14/pkg/networkserver/downlink.go#L712-L719

#### Changes

<!-- What are the changes made in this pull request? -->

- Erase the uplink tokens of the previous recent uplinks.
  - This is done progressively - as uplinks are pushed, we erase the tokens of the existing ones.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Unit testing. An additional test on `staging1` could just check that after sending two uplink messages, and going into the Console and downloading the MAC state data, the `recent_uplinks` contain uplink tokens only in the last uplink. 

_NOTE: Refresh the page before downloading the MAC data - it is generated on page load, not on button press._

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

The risk here is that we lose useful uplink tokens. This risk is unlikely here because the downlink path selection algorithm already discards these paths, and we also ensure that there are paths in the new uplink upon insertion.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
