### PR TITLE
Fix snapcraft telemetry access bug

### DIFF
--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -120,10 +120,14 @@ snapcrafts:
         plugs: [home, network, network-bind]
         command: ttn-lw-stack.wrapper
         completer: config/completion/bash/ttn-lw-stack
+        environment:
+          XDG_CACHE_HOME: $SNAP_USER_COMMON
       ttn-lw-cli:
         plugs: [home, network, network-bind]
         command: ttn-lw-cli.wrapper
         completer: config/completion/bash/ttn-lw-cli-snap
+        environment:
+          XDG_CACHE_HOME: $SNAP_USER_COMMON
 
 brews:
   - name: ttn-lw-stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ For details about compatibility between different releases, see the **Commitment
 - Listing deleted entities is now fixed for both admin and standard users, which previously returned an `account_not_found` error.
 - Update to an user's `PrimaryEmailAddress` via a non admin now invalidates the `PrimaryEmailAddressValidatedAt` as it was intended.
 - Negative number support in Cayenne LPP.
+- Fix panic in snapcraft CLI deployment, commands will no longer generate a panic error message when telemetry is enabled.
 
 ### Security
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #6598

Where snap application's permissions made a panic trigger when using the CLI provided in the snap deployment.

#### Changes

<!-- What are the changes made in this pull request? -->

- Add `XDG_CACHE_HOME` to snapcraft options in goreleaser's release file.
- Add snapcraft options to goreleaser's snapshot file.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Install locally the snap and validate if the panic still happens.

<details>
<summary> Test steps </summary>

#### Requirements

If you are building the snap before the release you need to have the following:

- Be on a linux machine that has `snap` installed.
- Have `golang` installed.
- Have `goreleaser` installed.
- Run `make init` on the repository.
- Run `tools/bin/mage cli:autocomplete js:build`.

##### Create the snap file

Create a `.goreleaser.yml` file at the root of the repository folder. Its contents are:
```yml
project_name: lorawan-stack

changelog:
  skip: true

release:
  disable: true

builds:
  - id: stack
    main: ./cmd/ttn-lw-stack
    binary: ttn-lw-stack
    ldflags:
      - -s
      - -w
      - -X go.thethings.network/lorawan-stack/v3/pkg/version.BuildDate={{.Date}}
      - -X go.thethings.network/lorawan-stack/v3/pkg/version.GitCommit={{.ShortCommit}}
      - -X go.thethings.network/lorawan-stack/v3/pkg/version.TTN={{ trimprefix .Version "v" }}
    env:
      - CGO_ENABLED=0
    goos: [linux]
    goarch: [amd64, arm64]

  - id: cli
    main: ./cmd/ttn-lw-cli
    binary: ttn-lw-cli
    ldflags:
      - -s
      - -w
      - -X go.thethings.network/lorawan-stack/v3/pkg/version.BuildDate={{.Date}}
      - -X go.thethings.network/lorawan-stack/v3/pkg/version.GitCommit={{.ShortCommit}}
      - -X go.thethings.network/lorawan-stack/v3/pkg/version.TTN={{ trimprefix .Version "v" }}
    env:
      - CGO_ENABLED=0
    goos: [linux]
    goarch: [amd64, arm64]

dockers:
  - goos: linux
    goarch: amd64
    dockerfile: Dockerfile
    use: buildx
    ids:
      - cli
      - stack
    build_flag_templates:
      - --platform=linux/amd64
      - '--label=org.opencontainers.image.created={{.Date}}'
      - '--label=org.opencontainers.image.vendor=The Things Network Foundation'
      - '--label=org.opencontainers.image.title=The Things Stack'
      - '--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs'
      - '--label=org.opencontainers.image.revision={{.FullCommit}}'
    image_templates:
      - 'lorawan-stack-dev:{{ .FullCommit }}-amd64'
    skip_push: true
    extra_files:
      - data
      - public

snapcrafts:
  - id: stack
    builds:
      - cli
      - stack
    name: ttn-lw-stack
    summary: The Things Stack for LoRaWAN
    description: The Things Stack for LoRaWAN
    grade: stable
    confinement: strict
    publish: false
    extra_files:
      - source: config/snap/ttn-lw-stack.wrapper
        destination: ttn-lw-stack.wrapper
        mode: 0755
      - source: config/snap/ttn-lw-cli.wrapper
        destination: ttn-lw-cli.wrapper
        mode: 0755
    apps:
      ttn-lw-stack:
        plugs: [home, network, network-bind]
        command: ttn-lw-stack.wrapper
        completer: config/completion/bash/ttn-lw-stack
        environment:
          XDG_CACHE_HOME: $SNAP_USER_COMMON
      ttn-lw-cli:
        plugs: [home, network, network-bind]
        command: ttn-lw-cli.wrapper
        completer: config/completion/bash/ttn-lw-cli-snap
        environment:
          XDG_CACHE_HOME: $SNAP_USER_COMMON
```

Do the following steps:
- Run `goreleaser --snapshot -f .goreleaser.yml --clean`
- Access the `dist` folder by doing `cd dist`.
- Install the local snap file by running `snap install ./lorawan-stack_3.27.2-SNAPSHOT-5444dc67a_linux_amd64.snap --dangerous`
    - Might be under a slightly different name.

#### Test step

Run `ttn-lw-stack.ttn-lw-cli login`. If it is the first time you run the binary, you should see the `Sent telemetry information` while its waiting for the authorization, it can take a few seconds to appear.
```
ttn-lw-stack.ttn-lw-cli login
INFO    Telemetry is enabled. Check the documentation for more information on what is collected and how to disable it   {"documentation_url": "https://www.thethingsindustries.com/docs/reference/telemetry/cli"}
INFO    Opening your browser on https://localhost/oauth/authorize?client_id=cli&redirect_uri=local-callback&response_type=code
WARN    Could not open your browser, you'll have to go there yourself   {"error": "fork/exec /usr/bin/xdg-open: permission denied"}
INFO    After logging in and authorizing the CLI, we'll get an access token for future commands.
INFO    Waiting for your authorization...
INFO    Sent telemetry information
```

Running `snap remove ttn-lw-stack` and installing again deletes the telemetry cache file, so guarantees that after every install a telemetry message is sent and the log `Sent telemetry information` is shown.

</details>

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

Bug fix


#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Instead of attempting to write the telemetry cache file in the `$HOME/.cache` path we set the value of `XDG_CACHE_HOME` in order to assure that the cache file is written within the bounds of the snap application.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
