### PR TITLE
Debounce webhook health status updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ For details about compatibility between different releases, see the **Commitment
 - Traffic related correlation IDs have been simplified. Previously one correlation ID per component was added as traffic passed through different stack components. Now a singular correlation ID relating to the entry point of the message will be added (such as `gs:uplink:xxx` for uplinks, or `as:downlink:xxx` for downlinks), and subsequent components will no longer add any extra correlation IDs (such as `ns:uplink:xxx` or `as:up:xxx`). The uplink entry points are `pba` and `gs`, while the downlink entry points are `pba`, `ns` and `as`.
 - Packet Broker Agent uplink tokens are now serialized in a more efficient manner.
 - The Network Server now stores only the most recent uplinks tokens.
+- The Application Server webhook health system now records failures only every retry interval while in monitor mode, as opposed to recording every failure.
+  - Monitor mode in this context refers to situations in which either `--as.webhooks.unhealthy-attempts-threshold` or `--as.webhooks.unhealthy-retry-interval` are less or equal to zero. In such situations, the Application Server will record failures but will not stop the execution of the webhooks.
+  - Using a retry interval of zero and a non zero attempts threshold restores the previous behavior.
 
 ### Deprecated
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR changes the behavior of the webhook health system in order to avoid avalanches of webhook state updates when an endpoint becomes unavailable, by recording failures only every interval instead of every time.

The context here is that the monitor mode allows users to check if a webhook is healthy or not, by recording failures in the webhook itself, without stopping the webhooks. The problem is that when a webhook is down, we are guaranteed to do one write for each failed message, which is costly on the hot path compared to the added benefit.

#### Changes

<!-- What are the changes made in this pull request? -->

- Write the failure details to the webhook health state only once per retry interval while in monitor mode.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Unit testing and local testing. 

How to test this on `staging1`:
1. Register an end device. The parameters don't matter - we will simulate traffic.
2. Create a webhook towards `google.com`.
3. Simulate one uplink.
4. `ttn-lw-cli app webhook get <application ID> <webhook ID> --health-status` and expect to see the unhealthy state.
5. Simulate one uplink.
6. Repeat the command, and expect the `last_failed_attempt_at` to stay the same.
7. Wait 6 minutes.
8. Simulate one uplink.
9. Repeat the command, and expect the `last_failed_attempt_at` to be the current timestamp.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

Deployments that were previously using monitor mode with a non zero retry interval and zero threshold will now no longer see instant feedback for failures. This is acceptable as the performance penalty for these updates is high in high traffic applications, and the instant feedback can be kept by using the instructions in the changelog.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
