### PR TITLE
Make forwarder information part of the gateway uplink tokens

### DIFF
--- a/pkg/packetbrokeragent/agent.go
+++ b/pkg/packetbrokeragent/agent.go
@@ -691,7 +691,8 @@ func (a *Agent) handleDownlinkMessage(
 		}
 	}
 
-	uid, msg, err := fromPBDownlink(ctx, down.Message, receivedAt, a.forwarderConfig)
+	forwarderData := forwarderAdditionalData(down.ForwarderNetId, down.ForwarderTenantId, down.ForwarderClusterId)
+	uid, msg, err := fromPBDownlink(ctx, down.Message, forwarderData, receivedAt, a.forwarderConfig)
 	if err != nil {
 		logger.WithError(err).Warn("Failed to convert incoming downlink message")
 		return err

--- a/pkg/packetbrokeragent/agent_test.go
+++ b/pkg/packetbrokeragent/agent_test.go
@@ -428,8 +428,9 @@ func TestForwarder(t *testing.T) {
 		}))
 		tokenNonce := make([]byte, aead.NonceSize())
 		test.Must(io.ReadFull(rand.Reader, tokenNonce))
+		forwarderData := []byte("000013:foo-tenant:test")
 		token := test.Must(proto.Marshal(&ttnpb.PacketBrokerAgentEncryptedPayload{
-			Ciphertext: aead.Seal(nil, tokenNonce, plainToken, nil),
+			Ciphertext: aead.Seal(nil, tokenNonce, plainToken, forwarderData),
 			Nonce:      tokenNonce,
 		}))
 

--- a/pkg/packetbrokeragent/crypto.go
+++ b/pkg/packetbrokeragent/crypto.go
@@ -1,0 +1,21 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetbrokeragent
+
+import "fmt"
+
+func forwarderAdditionalData(netID uint32, tenantID string, clusterID string) []byte {
+	return []byte(fmt.Sprintf("%06x:%s:%s", netID, tenantID, clusterID))
+}

--- a/pkg/packetbrokeragent/grpc_gspba.go
+++ b/pkg/packetbrokeragent/grpc_gspba.go
@@ -75,7 +75,8 @@ func (s *gsPbaServer) PublishUplink(ctx context.Context, up *ttnpb.GatewayUplink
 	ctx = appendUplinkCorrelationID(ctx)
 	up.Message.CorrelationIds = events.CorrelationIDsFromContext(ctx)
 
-	msg, err := toPBUplink(ctx, up, s.config)
+	forwarderData := forwarderAdditionalData(s.netID.MarshalNumber(), s.tenantIDExtractor(ctx), s.clusterID)
+	msg, err := toPBUplink(ctx, up, forwarderData, s.config)
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Warn("Failed to convert outgoing uplink message")
 		return nil, err

--- a/pkg/packetbrokeragent/translation_internal_test.go
+++ b/pkg/packetbrokeragent/translation_internal_test.go
@@ -34,6 +34,7 @@ func WrapUplinkTokens(gateway, forwarder []byte, agent *ttnpb.PacketBrokerAgentU
 func TestWrapGatewayUplinkToken(t *testing.T) {
 	a, ctx := test.New(t)
 	key := bytes.Repeat([]byte{0x42}, 16)
+	forwarderData := []byte("000013:tnt:eu1")
 	blockCipher, err := aes.NewCipher(key)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
@@ -43,15 +44,19 @@ func TestWrapGatewayUplinkToken(t *testing.T) {
 		t.FailNow()
 	}
 
-	wrappedToken, err := wrapGatewayUplinkToken(ctx, &ttnpb.GatewayIdentifiers{GatewayId: "test-gateway"},
-		[]byte{0x1, 0x2, 0x3}, aead,
+	wrappedToken, err := wrapGatewayUplinkToken(
+		ctx,
+		&ttnpb.GatewayIdentifiers{GatewayId: "test-gateway"},
+		[]byte{0x1, 0x2, 0x3},
+		forwarderData,
+		aead,
 	)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
 	t.Logf("Wrapped token: %q", base64.RawStdEncoding.EncodeToString(wrappedToken))
 
-	uid, gtwToken, err := unwrapGatewayUplinkToken(wrappedToken, aead, nil)
+	uid, gtwToken, err := unwrapGatewayUplinkToken(wrappedToken, forwarderData, aead, key)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Reference https://github.com/packetbroker/router/issues/109

#### Changes

<!-- What are the changes made in this pull request? -->

- The forwarder information (net ID, tenant ID and cluster ID) is now part of the signature of the encrypted gateway tokens.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Unit testing. On `staging1` just checking that Packet Broker still works suffices.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

We did not have a release yet which uses the new optimized format, so adding the additional data won't break anything.

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Are there situations during routing in which the forwarder information changes ? I am specifically afraid of a forwarder publishing their traffic, without a tenant ID let's say, and the router somewhere in its bowels adds this tenant ID while routing the message to the home network.

I am asking this because it would be problematic while receiving a routed downlink message since the forwarder additional data would be different (we used an empty string while sealing the token, but we are now trying to unseal it with another tenant ID being in there).

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
