### PR TITLE
Fix unexpected RekeyInd handling

### DIFF
--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1396,7 +1396,7 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 	return nil
 }
 
-var errRejoinRequest = errors.DefineUnimplemented("rejoin_request", "rejoin-request handling is not implemented")
+var errRejoinRequest = errors.DefineUnavailable("rejoin_request", "rejoin-request handling is not implemented")
 
 func (ns *NetworkServer) handleRejoinRequest(ctx context.Context, up *ttnpb.UplinkMessage) error {
 	defer trace.StartRegion(ctx, "handle rejoin request").End()

--- a/pkg/networkserver/mac/rekey.go
+++ b/pkg/networkserver/mac/rekey.go
@@ -42,10 +42,12 @@ func HandleRekeyInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCom
 	evs := events.Builders{
 		EvtReceiveRekeyIndication.With(events.WithData(pld)),
 	}
-	if !dev.SupportsJoin {
+	if !dev.SupportsJoin || !macspec.UseRekeyInd(dev.LorawanVersion) {
 		return evs, nil
 	}
-	if dev.PendingSession != nil && dev.MacState.PendingJoinRequest != nil && types.MustDevAddr(dev.PendingSession.DevAddr).OrZero().Equal(devAddr) {
+	if dev.PendingSession != nil &&
+		dev.MacState.PendingJoinRequest != nil &&
+		types.MustDevAddr(dev.PendingSession.DevAddr).OrZero().Equal(devAddr) {
 		dev.Ids.DevAddr = dev.PendingSession.DevAddr
 		dev.Session = dev.PendingSession
 	}

--- a/pkg/networkserver/mac/rekey_test.go
+++ b/pkg/networkserver/mac/rekey_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestHandleRekeyInd(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
@@ -48,8 +49,9 @@ func TestHandleRekeyInd(t *testing.T) {
 		{
 			Name: "empty queue/original",
 			Device: &ttnpb.EndDevice{
-				SupportsJoin: true,
-				Ids:          &ttnpb.EndDeviceIdentifiers{},
+				LorawanVersion: ttnpb.MACVersion_MAC_V1_1,
+				SupportsJoin:   true,
+				Ids:            &ttnpb.EndDeviceIdentifiers{},
 				PendingSession: &ttnpb.Session{
 					DevAddr:       test.DefaultDevAddr.Bytes(),
 					LastFCntUp:    42,
@@ -62,7 +64,8 @@ func TestHandleRekeyInd(t *testing.T) {
 				},
 			},
 			Expected: &ttnpb.EndDevice{
-				SupportsJoin: true,
+				LorawanVersion: ttnpb.MACVersion_MAC_V1_1,
+				SupportsJoin:   true,
 				Ids: &ttnpb.EndDeviceIdentifiers{
 					DevAddr: test.DefaultDevAddr.Bytes(),
 				},
@@ -95,7 +98,8 @@ func TestHandleRekeyInd(t *testing.T) {
 		{
 			Name: "empty queue/retransmission/non-matching pending session",
 			Device: &ttnpb.EndDevice{
-				SupportsJoin: true,
+				LorawanVersion: ttnpb.MACVersion_MAC_V1_1,
+				SupportsJoin:   true,
 				Ids: &ttnpb.EndDeviceIdentifiers{
 					DevAddr: test.DefaultDevAddr.Bytes(),
 				},
@@ -116,7 +120,8 @@ func TestHandleRekeyInd(t *testing.T) {
 				},
 			},
 			Expected: &ttnpb.EndDevice{
-				SupportsJoin: true,
+				LorawanVersion: ttnpb.MACVersion_MAC_V1_1,
+				SupportsJoin:   true,
 				Ids: &ttnpb.EndDeviceIdentifiers{
 					DevAddr: test.DefaultDevAddr.Bytes(),
 				},
@@ -149,7 +154,8 @@ func TestHandleRekeyInd(t *testing.T) {
 		{
 			Name: "empty queue/retransmission/no pending session",
 			Device: &ttnpb.EndDevice{
-				SupportsJoin: true,
+				LorawanVersion: ttnpb.MACVersion_MAC_V1_1,
+				SupportsJoin:   true,
 				Ids: &ttnpb.EndDeviceIdentifiers{
 					DevAddr: test.DefaultDevAddr.Bytes(),
 				},
@@ -161,7 +167,8 @@ func TestHandleRekeyInd(t *testing.T) {
 				MacState: &ttnpb.MACState{},
 			},
 			Expected: &ttnpb.EndDevice{
-				SupportsJoin: true,
+				LorawanVersion: ttnpb.MACVersion_MAC_V1_1,
+				SupportsJoin:   true,
 				Ids: &ttnpb.EndDeviceIdentifiers{
 					DevAddr: test.DefaultDevAddr.Bytes(),
 				},
@@ -194,8 +201,9 @@ func TestHandleRekeyInd(t *testing.T) {
 		{
 			Name: "non-empty queue",
 			Device: &ttnpb.EndDevice{
-				SupportsJoin: true,
-				Ids:          &ttnpb.EndDeviceIdentifiers{},
+				LorawanVersion: ttnpb.MACVersion_MAC_V1_1,
+				SupportsJoin:   true,
+				Ids:            &ttnpb.EndDeviceIdentifiers{},
 				PendingSession: &ttnpb.Session{
 					DevAddr:       test.DefaultDevAddr.Bytes(),
 					LastFCntUp:    42,
@@ -212,7 +220,8 @@ func TestHandleRekeyInd(t *testing.T) {
 				},
 			},
 			Expected: &ttnpb.EndDevice{
-				SupportsJoin: true,
+				LorawanVersion: ttnpb.MACVersion_MAC_V1_1,
+				SupportsJoin:   true,
 				Ids: &ttnpb.EndDeviceIdentifiers{
 					DevAddr: test.DefaultDevAddr.Bytes(),
 				},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes our handling of `RekeyInd` a bit smarter by discarding `RekeyInd` commands which are unexpected (specifically, if the LNS did not set the `OptNeg` bit during the Join Request handling). 

This has showed up during some accidental fuzz testing - random bytes on FPort 0 are sent by the end device, and the LNS parses them as legitimate commands. A possible such command is `RekeyInd`, which switches the LoRaWAN version of the MAC state. If a 1.0.x end device sends this command, we must always discard it, otherwise we risk failing to match the packet (because the requested minor may be higher than 1, and thus enable the 1.1+ extra MIC checks).

#### Changes

<!-- What are the changes made in this pull request? -->

- Discard unexpected `RekeyInd` commands.
- Change the error code for the unimplemented rejoin-request handler. `Unimplemented` errors are reported to Sentry and are logged with error level, as they generally signal some deep version mismatch, but the unimplemented state here is intentional.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Local testing. This feature does not require explicit testing.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

The `RekeyInd` commands will now be rejected if the end device version is < 1.1+, which is the correct behavior anyway.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
