### PR TITLE
Fix panic on empty device address

### DIFF
--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -2137,7 +2137,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 			"pending_mac_state.queued_join_accept.payload":                  func() bool { return len(st.Device.PendingMacState.QueuedJoinAccept.Payload) == 0 },
 			"pending_mac_state.queued_join_accept.dev_addr": types.MustDevAddr(
 				st.Device.PendingMacState.QueuedJoinAccept.DevAddr,
-			).IsZero,
+			).OrZero().IsZero,
 		} {
 			p, isZero := p, isZero
 			if err := st.ValidateSetField(func() bool { return !isZero() }, p); err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes https://the-things-industries.sentry.io/issues/4558812598

#### Changes

<!-- What are the changes made in this pull request? -->

- Do not call `IsZero` on potentially null device address.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Untested, but the issue stems from the fact that `MustDevAddr` returns a potentially `nil` device address if the provided slice is `nil`. This is the only call site in our whole stack in which `IsZero` is not called after an `OrZero`.

No manual testing is required.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

N/A. An `nil` device address semantically is equivalent to a zero device address due to our `gogoproto` legacy. 

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
