### PR TITLE
Use RangeStreams in application uplink queue

### DIFF
--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -302,7 +302,6 @@ var startCommand = &cobra.Command{
 				int64(applicationUplinkQueueSize),
 				redisConsumerGroup,
 				time.Minute,
-				redis.DefaultStreamBlockLimit,
 			)
 			if err := applicationUplinkQueue.Init(ctx); err != nil {
 				return shared.ErrInitializeNetworkServer.WithCause(err)

--- a/pkg/networkserver/internal/test/shared/redis.go
+++ b/pkg/networkserver/internal/test/shared/redis.go
@@ -36,7 +36,7 @@ func testStreamBlockLimit() time.Duration {
 func NewRedisApplicationUplinkQueue(ctx context.Context) (ApplicationUplinkQueue, func()) {
 	tb := test.MustTBFromContext(ctx)
 	cl, flush := test.NewRedis(ctx, append(redisNamespace[:], "application-uplinks")...)
-	q := redis.NewApplicationUplinkQueue(cl, 100, redisConsumerGroup, 0, testStreamBlockLimit())
+	q := redis.NewApplicationUplinkQueue(cl, 100, redisConsumerGroup, 0)
 	if err := q.Init(ctx); err != nil {
 		tb.Fatalf("Failed to initialize Redis application uplink queue: %s", test.FormatError(err))
 	}

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -20,7 +20,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
-	"sync"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
@@ -167,7 +166,6 @@ type NetworkServer struct {
 	newDevAddr      newDevAddrFunc
 	devAddrPrefixes devAddrPrefixesFunc
 
-	applicationServers *sync.Map // string -> *applicationUpStream
 	applicationUplinks ApplicationUplinkQueue
 
 	downlinkTasks      DownlinkTaskQueue
@@ -282,7 +280,6 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 		clusterID:                conf.ClusterID,
 		newDevAddr:               makeNewDevAddrFunc(devAddrPrefixes...),
 		devAddrPrefixes:          makeDevAddrPrefixesFunc(devAddrPrefixes...),
-		applicationServers:       &sync.Map{},
 		applicationUplinks:       conf.ApplicationUplinkQueue.Queue,
 		deduplicationWindow:      makeWindowDurationFunc(conf.DeduplicationWindow),
 		collectionWindow:         makeWindowDurationFunc(conf.DeduplicationWindow + conf.CooldownWindow),

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -885,17 +885,23 @@ func LockedWatch(ctx context.Context, r WatchCmdable, k, id string, expiration t
 	return nil
 }
 
-// RangeStreams sequentially iterates over all non-acknowledged messages in streams calling f with at most count messages.
+// RangeStreams sequentially iterates over all non-acknowledged messages in streams calling f with at most count
+// messages. f must acknowledge the messages which have been processed.
 // RangeStreams assumes that within its lifetime it is the only consumer within group group using ID id.
 // RangeStreams iterates over all pending messages, which have been idle for at least minIdle milliseconds first.
-func RangeStreams(ctx context.Context, r redis.Cmdable, group, id string, count int64, minIdle time.Duration, f func(string, ...redis.XMessage) error, streams ...string) error {
-	var ack func(context.Context, string, ...redis.XMessage) error
-	{
-		ids := make([]string, 0, int(count))
-		ack = func(ctx context.Context, stream string, msgs ...redis.XMessage) error {
-			ids = ids[:0]
-			for _, msg := range msgs {
-				ids = append(ids, msg.ID)
+func RangeStreams(
+	ctx context.Context,
+	r redis.Cmdable,
+	group, id string,
+	count int64,
+	minIdle time.Duration,
+	f func(string, func(...string) error, ...redis.XMessage) error,
+	streams ...string,
+) error {
+	makeAck := func(stream string) func(...string) error {
+		return func(ids ...string) error {
+			if len(ids) == 0 {
+				return nil
 			}
 			_, err := r.Pipelined(ctx, func(p redis.Pipeliner) error {
 				// NOTE: Both calls below copy contents of ids internally.
@@ -903,13 +909,17 @@ func RangeStreams(ctx context.Context, r redis.Cmdable, group, id string, count 
 				p.XDel(ctx, stream, ids...)
 				return nil
 			})
-			return err
+			if err != nil {
+				return ConvertError(err)
+			}
+			return nil
 		}
 	}
 
 	for _, stream := range streams {
-		for start := "-"; ; {
-			msgs, lastID, err := r.XAutoClaim(ctx, &redis.XAutoClaimArgs{
+		for start := "-"; start != "0-0"; {
+			var err error
+			_, start, err = r.XAutoClaimJustID(ctx, &redis.XAutoClaimArgs{
 				Stream:   stream,
 				Group:    group,
 				Consumer: id,
@@ -918,36 +928,25 @@ func RangeStreams(ctx context.Context, r redis.Cmdable, group, id string, count 
 				Count:    count,
 			}).Result()
 			if err != nil {
-				return err
+				return ConvertError(err)
 			}
-			if len(msgs) == 0 {
-				break
-			}
-			if err := f(stream, msgs...); err != nil {
-				return err
-			}
-			if err := ack(ctx, stream, msgs...); err != nil {
-				return err
-			}
-			start = lastID
 		}
 	}
 
 	streamCount := len(streams)
-	streamsArg := make([]string, 2*streamCount)
-	idsArg := make([]string, 2*streamCount)
-	for i, stream := range streams {
-		j := i * 2
-		streamsArg[j], streamsArg[j+1], idsArg[j], idsArg[j+1] = stream, stream, "0", ">"
+	args := make([]string, 2*streamCount)
+	streamsArg := args[:streamCount]
+	idsArg := args[streamCount:]
+	for i := range streams {
+		streamsArg[i], idsArg[i] = streams[i], "0"
 	}
 
-	drainedOld := make(map[string]struct{}, streamCount)
-outer:
+	finishedOld := false
 	for {
 		rets, err := r.XReadGroup(ctx, &redis.XReadGroupArgs{
 			Group:    group,
 			Consumer: id,
-			Streams:  append(streamsArg, idsArg...),
+			Streams:  args,
 			Count:    count,
 			Block:    -1, // do not block
 		}).Result()
@@ -958,38 +957,33 @@ outer:
 			return ConvertError(err)
 		}
 
+		cont := false
 		for i, ret := range rets {
-			if idsArg[i] == "0" && len(ret.Messages) < int(count) {
-				drainedOld[ret.Stream] = struct{}{}
-			}
-			if len(ret.Messages) == 0 {
-				if i == len(rets)-1 {
-					return nil
-				}
+			n := int64(len(ret.Messages))
+			if n == 0 {
 				continue
 			}
-
-			if err := f(ret.Stream, ret.Messages...); err != nil {
+			cont = cont || n == count
+			idsArg[i] = ret.Messages[len(ret.Messages)-1].ID
+			if err := f(ret.Stream, makeAck(ret.Stream), ret.Messages...); err != nil {
 				return err
-			}
-			if err := ack(ctx, ret.Stream, ret.Messages...); err != nil {
-				return err
-			}
-			if len(ret.Messages) == int(count) {
-				continue outer
 			}
 		}
 
-		streamsArg = streamsArg[:0]
-		idsArg = idsArg[:0]
-		for _, stream := range streams {
-			_, ok := drainedOld[stream]
-			if !ok {
-				streamsArg = append(streamsArg, stream)
-				idsArg = append(idsArg, "0")
+		switch {
+		case cont:
+			// At least one stream has returned `count` messages.
+		case finishedOld:
+			// All streams have returned less than `count` messages,
+			// and we have already processed all of the old and new messages.
+			return nil
+		default: // !cont && !finishedOld
+			// All streams have returned less than `count` messages,
+			// and we have processed all of the old messages.
+			finishedOld = true
+			for i := range streams {
+				idsArg[i] = ">"
 			}
-			streamsArg = append(streamsArg, stream)
-			idsArg = append(idsArg, ">")
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/pull/3890

#### Changes

<!-- What are the changes made in this pull request? -->

- Allow `ttnredis.RangeStreams` to acknowledge only certain batches of messages.
  - Semantically, `ttnredis.RangeStreams` will visit the same messages at most once in one iteration. Subsequent iterations will re-encounter the messages which have not been acknowledged.
  - There are two message passes - one through the messages which are pending for the current consumer (starting from `0`), and then one for the messages which are pending in the stream (`>`).
- Use `ttnredis.RangeStreams` in the application uplink queue.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Unit testing: `go test -count=1000 -run TestApplicationUplinkQueue`.

To be tested on `staging1` with the following procedure:
1. Scale the Application Server to zero.
2. Wait 5 minutes.
3. Scale the Application Server back to original scale.
4. Expect the messages to be dequeued and submitted to the Application Server.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

This PR fixes a regression in itself (currently the NS does not re-submit the messages once the Application Server is back).

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@cvetkovski98 please take a look.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
