### PR TITLE
Fix DevAddr filter based on NetID configuration

### DIFF
--- a/pkg/packetbrokeragent/agent.go
+++ b/pkg/packetbrokeragent/agent.go
@@ -178,7 +178,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*Agent, error) {
 			}
 			devAddrPrefix := types.DevAddrPrefix{
 				DevAddr: devAddr,
-				Length:  uint8(conf.NetID.IDBits()),
+				Length:  uint8(32 - types.NwkAddrBits(conf.NetID)),
 			}
 			devAddrPrefixes = append(devAddrPrefixes, devAddrPrefix)
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes the DevAddr that PBA uses for subscribing as home network when there's only a NetID configured.

#### Changes

<!-- What are the changes made in this pull request? -->

- The prefix length is now based on the `NwkAddr` bits instead of the `NwkID` bits.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

None, we don't have unit testing for this. The code is taken from Network Server.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

None, this is a bugfix.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
