### PR TITLE
Fix frequency plans getting unset if any of the frequency plans is removed

### DIFF
--- a/pkg/webui/console/views/gateway-general-settings/index.js
+++ b/pkg/webui/console/views/gateway-general-settings/index.js
@@ -81,24 +81,17 @@ const GatewayGeneralSettingsInner = () => {
       if (isEqual(gateway.attributes || {}, attributes)) {
         delete formValues.attributes
       }
-      const changed = diff(gateway, formValues)
-      let update
-      if ('attributes' in changed) {
-        update = {
-          ...changed,
-          attributes,
-        }
-      } else if ('frequency_plan_ids' in changed) {
-        update = {
-          ...changed,
-          frequency_plan_ids,
-        }
-      } else {
-        update = changed
+      if (isEqual(gateway.frequency_plan_ids || {}, frequency_plan_ids)) {
+        delete formValues.frequency_plan_ids
       }
 
+      const changed = diff(gateway, formValues, {
+        patchArraysItems: false,
+        patchInFull: ['attributes', 'frequency_plan_ids'],
+      })
+
       try {
-        await dispatch(updateGateway(gtwId, update))
+        await dispatch(updateGateway(gtwId, changed))
         toast({
           title: gtwId,
           message: m.updateSuccess,

--- a/pkg/webui/console/views/gateway-general-settings/index.js
+++ b/pkg/webui/console/views/gateway-general-settings/index.js
@@ -77,12 +77,26 @@ const GatewayGeneralSettingsInner = () => {
   const handleSubmit = useCallback(
     async values => {
       const formValues = { ...values }
-      const { attributes } = formValues
+      const { attributes, frequency_plan_ids } = formValues
       if (isEqual(gateway.attributes || {}, attributes)) {
         delete formValues.attributes
       }
       const changed = diff(gateway, formValues)
-      const update = 'attributes' in changed ? { ...changed, attributes } : changed
+      let update
+      if ('attributes' in changed) {
+        update = {
+          ...changed,
+          attributes,
+        }
+      } else if ('frequency_plan_ids' in changed) {
+        update = {
+          ...changed,
+          frequency_plan_ids,
+        }
+      } else {
+        update = changed
+      }
+
       try {
         await dispatch(updateGateway(gtwId, update))
         toast({


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References point 2. from [https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1000#issuecomment-1772764348](https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1000#issuecomment-1772764348)

#### Changes

<!-- What are the changes made in this pull request? -->

- Include `frequency_plan_ids` in the submit object.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Go to register a gateway.
2. Add a couple of frequency plans (e.g. US_902_928_FSB_1 & US_902_928_FSB_2)
3. Register the gateway should be successful.
4. In the gateway general settings page, remove any of the frequency plans. E.g. US_902_928_FSB_2
5. Click Save changes.
6. Only the rest of the frequency plan ids should remain in the field.


#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
