### PR TITLE
Use Gateway Stats Batch API in the Console

### DIFF
--- a/pkg/webui/console/store/middleware/logics/gateways.js
+++ b/pkg/webui/console/store/middleware/logics/gateways.js
@@ -118,39 +118,38 @@ const getGatewaysLogic = createRequestLogic({
     if (options.withStatus) {
       const gsConfig = selectGsConfig()
       const consoleGsAddress = getHostFromUrl(gsConfig.base_url)
+      const gatewayIds = entities.map(e => e.ids)
+      const gatewaysStats = await tts.Gateways.getBatchStatistics(gatewayIds)
 
-      entities = await Promise.all(
-        data.gateways.map(gateway => {
-          const gatewayServerAddress = getHostFromUrl(gateway.gateway_server_address)
+      entities = data.gateways.map(gateway => {
+        const gatewayServerAddress = getHostFromUrl(gateway.gateway_server_address)
 
-          if (!Boolean(gatewayServerAddress)) {
-            return Promise.resolve({ ...gateway, status: 'unknown' })
-          }
+        if (!Boolean(gatewayServerAddress)) {
+          return { ...gateway, status: 'unknown' }
+        }
 
-          if (gatewayServerAddress !== consoleGsAddress) {
-            return Promise.resolve({ ...gateway, status: 'other-cluster' })
-          }
+        if (gatewayServerAddress !== consoleGsAddress) {
+          return { ...gateway, status: 'other-cluster' }
+        }
 
-          const id = getGatewayId(gateway)
-          return tts.Gateways.getStatisticsById(id)
-            .then(stats => {
-              let status = 'unknown'
-              if (Boolean(stats) && Boolean(stats.connected_at)) {
-                status = 'connected'
-              } else if (Boolean(stats) && Boolean(stats.disconnected_at)) {
-                status = 'disconnected'
-              }
-              return { ...gateway, status }
-            })
-            .catch(err => {
-              if (err && err.code === 5) {
-                return { ...gateway, status: 'disconnected' }
-              }
+        if (!gatewaysStats?.entries) {
+          return { ...gateway, status: 'disconnected' }
+        }
 
-              return { ...gateway, status: 'unknown' }
-            })
-        }),
-      )
+        const id = getGatewayId(gateway)
+        let status = 'unknown'
+
+        if (Boolean(gatewaysStats.entries[id]) && Boolean(gatewaysStats.entries[id].connected_at)) {
+          status = 'connected'
+        } else if (
+          !Boolean(gatewaysStats.entries[id]) ||
+          Boolean(gatewaysStats.entries[id].disconnected_at)
+        ) {
+          status = 'disconnected'
+        }
+
+        return { ...gateway, status }
+      })
     }
 
     return {

--- a/sdk/js/src/service/gateways.js
+++ b/sdk/js/src/service/gateways.js
@@ -221,6 +221,14 @@ class Gateways {
     return Marshaler.payloadSingleResponse(response)
   }
 
+  async getBatchStatistics(gatewayIds) {
+    const response = await this._api.Gs.BatchGetGatewayConnectionStats(undefined, {
+      gateway_ids: gatewayIds
+    })
+
+    return Marshaler.payloadSingleResponse(response)
+  }
+
   async getRightsById(gatewayId) {
     const result = await this._api.GatewayAccess.ListRights({
       routeParams: { gateway_id: gatewayId },


### PR DESCRIPTION
#### Summary

Closes #5635 

#### Changes

When fetching gateways we were sending a request for every gateway. Now we send only one request for the loaded gateways.

#### Testing

1. Login in the console.
2. Go to `/console/gateways` page.
3. Check if the gateways have the correct status.
4. Check in developers console in Network tab if we are sending only one request related to the stats.

#### Notes for Reviewers

In the gateway details page we are still using the old endpoint but we are sending one request anyway. That's the reason I didn't consider changing it.

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
