### PR TITLE
Re-add gzip compression of HTTP server responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- The `http.client.transport.compression` experimental flag. It controls whether the HTTP clients used by the stack support gzip and zstd decompression of server responses. It is enabled by default.
+
 ### Changed
 
 - The Things Stack is now built with Go 1.21.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - The `http.client.transport.compression` experimental flag. It controls whether the HTTP clients used by the stack support gzip and zstd decompression of server responses. It is enabled by default.
+- The `http.server.transport.compression` experimental flag. It controls whether the HTTP servers used by the stack support gzip compression of the server response. It is enabled by default.
 
 ### Changed
 

--- a/pkg/experimental/experimental_test.go
+++ b/pkg/experimental/experimental_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestExperimentalFeatures(t *testing.T) {
+	t.Parallel()
+
 	a := assertions.New(t)
 
 	r := NewRegistry()
@@ -32,21 +34,21 @@ func TestExperimentalFeatures(t *testing.T) {
 
 	feature := DefineFeature("experimental.feature", false)
 	a.So(feature.GetValue(ctx), should.BeFalse)
-	a.So(AllFeatures(ctx), should.Resemble, map[string]bool{"experimental.feature": false})
+	a.So(AllFeatures(ctx)["experimental.feature"], should.BeFalse)
 	a.So(feature.GetValue(context.Background()), should.BeFalse)
-	a.So(AllFeatures(context.Background()), should.Resemble, map[string]bool{"experimental.feature": false})
+	a.So(AllFeatures(context.Background())["experimental.feature"], should.BeFalse)
 
 	r.EnableFeatures("experimental.feature")
 	a.So(feature.GetValue(ctx), should.BeTrue)
-	a.So(AllFeatures(ctx), should.Resemble, map[string]bool{"experimental.feature": true})
+	a.So(AllFeatures(ctx)["experimental.feature"], should.BeTrue)
 	a.So(feature.GetValue(context.Background()), should.BeFalse)
-	a.So(AllFeatures(context.Background()), should.Resemble, map[string]bool{"experimental.feature": false})
+	a.So(AllFeatures(context.Background())["experimental.feature"], should.BeFalse)
 
 	EnableFeatures("experimental.feature")
 	r.DisableFeatures("experimental.feature")
 
 	a.So(feature.GetValue(ctx), should.BeFalse)
-	a.So(AllFeatures(ctx), should.Resemble, map[string]bool{"experimental.feature": false})
+	a.So(AllFeatures(ctx)["experimental.feature"], should.BeFalse)
 	a.So(feature.GetValue(context.Background()), should.BeTrue)
-	a.So(AllFeatures(context.Background()), should.Resemble, map[string]bool{"experimental.feature": true})
+	a.So(AllFeatures(context.Background())["experimental.feature"], should.BeTrue)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/4921

This PR reintroduces the `gzip` compression of server responses, if the client signals that it supports it. We had this functionality by default between 2019 and 2021 as part of the stack, but it was removed as part of the Echo framework removal, and never reintroduced back, until now.

On the client side we now have support for `zstd` as well. Should we have any regressions related to this reintroduction, we can disable both client and server side support using an experimental feature flag.

If the changes are accepted, the experimental flags should be removed as part of the `v3.29.0` release.

#### Changes

<!-- What are the changes made in this pull request? -->

- Add HTTP client support for both `gzip` and `zstd` compression of server responses.
- Add HTTP server support for `gzip` compression of server responses.
  - This change does not apply to the interop server.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Local testing of the stack. One can manually check that the server side compression is working by looking in the browser developer tools network tab:
<img width="431" alt="image" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/36161392/683bb7cf-2493-4604-b443-6d4d771a8c47">

Notice that the amount transferred is lower than the content size, and that the `Content-Encoding` is set to `gzip`.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

Our first public v3 bug report (https://github.com/TheThingsNetwork/lorawan-stack/issues/82, followed up by https://github.com/TheThingsNetwork/lorawan-stack/issues/84) was related to `gzip` compression due to a mis-chaining of `Flush` calls - this bug does not exist in `gzhttp`, so we are safe.

A second consideration is [BREACH](https://breachattack.com/) - in short, we don't really reflect user input into API call contents, such that the compressed result size could leak something about page contents. Our CSRF tokens are also generated on a per request basis, so you cannot brute force the CSRF token by repeatedly loading the page. 

`gzhttp` is capable of using [HTB](https://ieeexplore.ieee.org/document/9754554), which is a general purpose amelioration of the BREACH attack, but it seems that it breaks `Content-Type` detection so until that issue is cleared up we'll not enable the random content padding.

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The experimental tracking issues will be created after the PR is merged.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
