### PR TITLE
console: Fix fetching stats if there are no gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - The Things Stack is now built with Go 1.21.
+- Statistics for gateways are now fetched in a single request.
 
 ### Deprecated
 

--- a/pkg/webui/console/store/middleware/logics/gateways.js
+++ b/pkg/webui/console/store/middleware/logics/gateways.js
@@ -119,7 +119,10 @@ const getGatewaysLogic = createRequestLogic({
       const gsConfig = selectGsConfig()
       const consoleGsAddress = getHostFromUrl(gsConfig.base_url)
       const gatewayIds = entities.map(e => e.ids)
-      const gatewaysStats = await tts.Gateways.getBatchStatistics(gatewayIds)
+      let gatewaysStats = null
+      if (gatewayIds.length) {
+        gatewaysStats = await tts.Gateways.getBatchStatistics(gatewayIds)
+      }
 
       entities = data.gateways.map(gateway => {
         const gatewayServerAddress = getHostFromUrl(gateway.gateway_server_address)


### PR DESCRIPTION
#### Summary

There was an error shown instead of empty table when trying to fetch statistics with empty list.

#### Changes

Added condition to check, if there are no gateway, don't send request to fetch batch statistics.

#### Testing

1. Login in the console.
2. Go to /console/gateways.
3. Have an empty slate of not having gateways.
4. An error should not be shown.

#### Notes for Reviewers

This was fixed in [ENT PR](https://github.com/TheThingsIndustries/lorawan-stack/pull/3956)

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
