### PR TITLE
Add multiple frequency plans to SX1301 config file

### DIFF
--- a/pkg/pfconfig/semtechudp/semtechudp.go
+++ b/pkg/pfconfig/semtechudp/semtechudp.go
@@ -24,8 +24,8 @@ import (
 
 // Config represents the full configuration for Semtech's UDP Packet Forwarder.
 type Config struct {
-	SX1301Conf  shared.SX1301Config `json:"SX1301_conf"`
-	GatewayConf GatewayConf         `json:"gateway_conf"`
+	SX1301Conf  []*shared.SX1301Config `json:"SX1301_conf"`
+	GatewayConf GatewayConf            `json:"gateway_conf"`
 }
 
 // GatewayConf contains the configuration for the gateway's server connection.
@@ -50,22 +50,26 @@ func Build(gateway *ttnpb.Gateway, store *frequencyplans.Store) (*Config, error)
 	if gateway.GetIds().GetEui() != nil {
 		c.GatewayConf.GatewayID = types.MustEUI64(gateway.GetIds().GetEui()).String()
 	}
-	c.GatewayConf.ServerAddress, c.GatewayConf.ServerPortUp, c.GatewayConf.ServerPortDown = host, uint32(port), uint32(port)
+	c.GatewayConf.ServerAddress = host
+	c.GatewayConf.ServerPortUp = uint32(port)
+	c.GatewayConf.ServerPortDown = uint32(port)
 	server := c.GatewayConf
 	server.Enabled = true
 	c.GatewayConf.Servers = append(c.GatewayConf.Servers, server)
 
-	frequencyPlan, err := store.GetByID(gateway.FrequencyPlanId)
-	if err != nil {
-		return nil, err
-	}
-	if len(frequencyPlan.Radios) != 0 {
-		sx1301Config, err := shared.BuildSX1301Config(frequencyPlan)
+	c.SX1301Conf = make([]*shared.SX1301Config, 0, len(gateway.FrequencyPlanIds))
+	for _, frequencyPlanID := range gateway.FrequencyPlanIds {
+		frequencyPlan, err := store.GetByID(frequencyPlanID)
 		if err != nil {
 			return nil, err
 		}
-		c.SX1301Conf = *sx1301Config
+		if len(frequencyPlan.Radios) != 0 {
+			sx1301Config, err := shared.BuildSX1301Config(frequencyPlan)
+			if err != nil {
+				return nil, err
+			}
+			c.SX1301Conf = append(c.SX1301Conf, sx1301Config)
+		}
 	}
-
 	return &c, nil
 }

--- a/pkg/pfconfig/semtechudp/semtechudp_test.go
+++ b/pkg/pfconfig/semtechudp/semtechudp_test.go
@@ -1,0 +1,166 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semtechudp_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/smarty/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/pfconfig/semtechudp"
+	"go.thethings.network/lorawan-stack/v3/pkg/pfconfig/shared"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+func getSX1301Conf(t *testing.T) *shared.SX1301Config {
+	t.Helper()
+
+	return &shared.SX1301Config{
+		LoRaWANPublic: true,
+		ClockSource:   1,
+		AntennaGain:   0,
+		Radios: []shared.RFConfig{
+			{
+				Enable:     true,
+				Type:       "SX1257",
+				Frequency:  867500000,
+				TxEnable:   true,
+				TxFreqMin:  863000000,
+				TxFreqMax:  870000000,
+				RSSIOffset: -166,
+			},
+			{
+				Enable: true, Type: "SX1257",
+				Frequency:  868500000,
+				TxEnable:   false,
+				TxFreqMin:  0,
+				TxFreqMax:  0,
+				RSSIOffset: -166,
+			},
+		},
+		Channels: []shared.IFConfig{
+			{Enable: true, Radio: 1, IFValue: -400000, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+			{Enable: true, Radio: 1, IFValue: -200000, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+			{Enable: true, Radio: 1, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+			{Enable: true, Radio: 0, IFValue: -400000, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+			{Enable: true, Radio: 0, IFValue: -200000, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+			{Enable: true, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+			{Enable: true, Radio: 0, IFValue: 200000, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+			{Enable: true, Radio: 0, IFValue: 400000, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+		},
+		LoRaStandardChannel: &shared.IFConfig{
+			Enable:       true,
+			Radio:        1,
+			IFValue:      -200000,
+			Bandwidth:    250000,
+			SpreadFactor: 7,
+			Datarate:     0,
+		},
+		FSKChannel: &shared.IFConfig{
+			Enable:       true,
+			Radio:        1,
+			IFValue:      -200000,
+			Bandwidth:    250000,
+			SpreadFactor: 7,
+			Datarate:     0,
+		},
+		TxLUTConfigs: []shared.TxLUTConfig{
+			{PAGain: 0, MixGain: 8, RFPower: -6, DigGain: 0},
+			{PAGain: 0, MixGain: 10, RFPower: -3, DigGain: 0},
+			{PAGain: 0, MixGain: 12, RFPower: 0, DigGain: 0},
+			{PAGain: 1, MixGain: 8, RFPower: 3, DigGain: 0},
+			{PAGain: 1, MixGain: 10, RFPower: 6, DigGain: 0},
+			{PAGain: 1, MixGain: 12, RFPower: 10, DigGain: 0},
+			{PAGain: 1, MixGain: 13, RFPower: 11, DigGain: 0},
+			{PAGain: 2, MixGain: 9, RFPower: 12, DigGain: 0},
+			{PAGain: 1, MixGain: 15, RFPower: 13, DigGain: 0},
+			{PAGain: 2, MixGain: 10, RFPower: 14, DigGain: 0},
+			{PAGain: 2, MixGain: 11, RFPower: 16, DigGain: 0},
+			{PAGain: 3, MixGain: 9, RFPower: 20, DigGain: 0},
+			{PAGain: 3, MixGain: 10, RFPower: 23, DigGain: 0},
+			{PAGain: 3, MixGain: 11, RFPower: 25, DigGain: 0},
+			{PAGain: 3, MixGain: 12, RFPower: 26, DigGain: 0},
+			{PAGain: 3, MixGain: 14, RFPower: 27, DigGain: 0},
+		},
+	}
+}
+
+func getGtwConfig(t *testing.T) semtechudp.GatewayConf {
+	t.Helper()
+
+	return semtechudp.GatewayConf{
+		ServerAddress:  "localhost",
+		ServerPortUp:   1700,
+		ServerPortDown: 1700,
+		Servers: []semtechudp.GatewayConf{
+			{
+				ServerAddress:  "localhost",
+				ServerPortUp:   1700,
+				ServerPortDown: 1700,
+				Enabled:        true,
+			},
+		},
+	}
+}
+
+func TestConfigSerialization(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Name string
+		*semtechudp.Config
+	}{
+		{
+			Name: "Single Frequency Plan",
+			Config: &semtechudp.Config{
+				SX1301Conf: []*shared.SX1301Config{
+					getSX1301Conf(t),
+				},
+				GatewayConf: getGtwConfig(t),
+			},
+		},
+		{
+			Name: "Multiple Frequency Plans",
+			Config: &semtechudp.Config{
+				SX1301Conf: []*shared.SX1301Config{
+					getSX1301Conf(t),
+					getSX1301Conf(t),
+					getSX1301Conf(t),
+				},
+				GatewayConf: getGtwConfig(t),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			a := assertions.New(t)
+			marshalled, err := json.Marshal(tc.Config)
+			if !a.So(err, should.BeNil) {
+				t.FailNow()
+			}
+
+			var cfg2 semtechudp.Config
+			err = json.Unmarshal(marshalled, &cfg2)
+			if !a.So(err, should.BeNil) {
+				t.FailNow()
+			}
+
+			a.So(cfg2, should.Resemble, *tc.Config)
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
Closes #6652 

#### Changes
- Iterate through all the frequency plans when generating the `global_conf.json` file. 

#### Testing
- Manual
- Add multiple frequency plans to a gateway
- Download the `global_conf.json` file for the gateway and ensure there is an `sx1301` config entry for every frequency plan.
- Ensure that the `sx1301` field in the `global_conf.json` file is an array when multiple frequency plans are configured and an object otherwise.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
