### PR TITLE
Improve HTTP rate limiting classes and keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Rate limiting classes for individual HTTP paths.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - Rate limiting classes for individual HTTP paths.
+- Rate limiting keys for HTTP endpoints now contain the caller API key ID when available. The caller IP is still available as a fallback.
 
 ### Changed
 

--- a/pkg/basicstation/cups/server.go
+++ b/pkg/basicstation/cups/server.go
@@ -33,7 +33,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/web"
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
 // Server implements the Basic Station Configuration and Update Server.
@@ -182,17 +181,6 @@ func (s *Server) RegisterRoutes(web *web.Server) {
 	router := web.Router().NewRoute().Subrouter()
 	router.Use(ratelimit.HTTPMiddleware(s.component.RateLimiter(), "http:gcs:cups"))
 	router.Path("/update-info").HandlerFunc(s.UpdateInfo).Methods(http.MethodPost)
-}
-
-func getContext(r *http.Request) context.Context {
-	ctx := r.Context()
-	md := metadata.New(map[string]string{
-		"authorization": r.Header.Get("Authorization"),
-	})
-	if ctxMd, ok := metadata.FromIncomingContext(ctx); ok {
-		md = metadata.Join(ctxMd, md)
-	}
-	return metadata.NewIncomingContext(ctx, md)
 }
 
 var errNoTrust = errors.DefineInternal("no_trust", "no trusted certificate found")

--- a/pkg/console/internal/events/events.go
+++ b/pkg/console/internal/events/events.go
@@ -62,9 +62,9 @@ func (h *eventsHandler) RegisterRoutes(server *web.Server) {
 	router := server.APIRouter().PathPrefix(ttnpb.HTTPAPIPrefix + "/console/internal/events/").Subrouter()
 	router.Use(
 		mux.MiddlewareFunc(webmiddleware.Namespace("console/internal/events")),
-		ratelimit.HTTPMiddleware(h.component.RateLimiter(), "http:console:internal:events"),
 		mux.MiddlewareFunc(middleware.ProtocolAuthentication(authorizationProtocolPrefix)),
 		mux.MiddlewareFunc(webmiddleware.Metadata("Authorization")),
+		ratelimit.HTTPMiddleware(h.component.RateLimiter(), "http:console:internal:events"),
 	)
 	router.Path("/").HandlerFunc(h.handleEvents).Methods(http.MethodGet)
 }

--- a/pkg/gatewayconfigurationserver/http.go
+++ b/pkg/gatewayconfigurationserver/http.go
@@ -38,8 +38,8 @@ func (s *Server) RegisterRoutes(server *web.Server) {
 	router := server.Prefix(ttnpb.HTTPAPIPrefix + "/gcs/gateways/{gateway_id}/").Subrouter()
 	router.Use(
 		mux.MiddlewareFunc(webmiddleware.Namespace("gatewayconfigurationserver")),
-		ratelimit.HTTPMiddleware(s.Component.RateLimiter(), "http:gcs"),
 		mux.MiddlewareFunc(webmiddleware.Metadata("Authorization")),
+		ratelimit.HTTPMiddleware(s.Component.RateLimiter(), "http:gcs"),
 		validateAndFillIDs,
 	)
 	if s.config.RequireAuth {

--- a/pkg/gatewayconfigurationserver/v2/server.go
+++ b/pkg/gatewayconfigurationserver/v2/server.go
@@ -84,9 +84,9 @@ func (s *Server) RegisterRoutes(server *web.Server) {
 
 	middleware := []webmiddleware.MiddlewareFunc{
 		webmiddleware.Namespace("gatewayconfigurationserver/v2"),
-		ratelimit.HTTPMiddleware(s.component.RateLimiter(), "http:gcs"),
 		rewriteAuthorization,
 		webmiddleware.Metadata("Authorization"),
+		ratelimit.HTTPMiddleware(s.component.RateLimiter(), "http:gcs"),
 	}
 
 	router.Handle(

--- a/pkg/ratelimit/grpc.go
+++ b/pkg/ratelimit/grpc.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.thethings.network/lorawan-stack/v3/pkg/auth"
 	clusterauth "go.thethings.network/lorawan-stack/v3/pkg/auth/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmetadata"
@@ -42,17 +41,6 @@ func grpcEntityFromRequest(ctx context.Context, req any) string {
 
 func grpcIsClusterAuthCall(ctx context.Context) bool {
 	return rpcmetadata.FromIncomingContext(ctx).AuthType == clusterauth.AuthType
-}
-
-func grpcAuthTokenID(ctx context.Context) string {
-	if authValue := rpcmetadata.FromIncomingContext(ctx).AuthValue; authValue != "" {
-		_, id, _, err := auth.SplitToken(authValue)
-		if err != nil {
-			return "unauthenticated"
-		}
-		return id
-	}
-	return "unauthenticated"
 }
 
 // UnaryServerInterceptor returns a gRPC unary server interceptor that rate limits incoming gRPC requests.

--- a/pkg/ratelimit/http_test.go
+++ b/pkg/ratelimit/http_test.go
@@ -54,6 +54,26 @@ func TestHTTP(t *testing.T) {
 		a.So(limiter.calledWithResource.Classes(), should.Resemble, []string{class, "http"})
 	})
 
+	t.Run("PathTemplate", func(t *testing.T) {
+		limiter.limit = false
+		limiter.result = ratelimit.Result{Limit: 10}
+
+		restore := ratelimit.SetPathTemplate(func(r *http.Request) (string, bool) {
+			return "/path/{id}", true
+		})
+		defer restore()
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httpRequest("/path/123", "10.10.10.10"))
+
+		a.So(rec.Header().Get("x-rate-limit-limit"), should.Equal, "10")
+		a.So(rec.Result().StatusCode, should.Equal, http.StatusOK)
+
+		a.So(limiter.calledWithResource.Key(), should.ContainSubstring, "/path/123")
+		a.So(limiter.calledWithResource.Key(), should.ContainSubstring, "10.10.10.10")
+		a.So(limiter.calledWithResource.Classes(), should.Resemble, []string{"http:test:/path/{id}", class, "http"})
+	})
+
 	t.Run("Limit", func(t *testing.T) {
 		limiter.limit = true
 		rec := httptest.NewRecorder()

--- a/pkg/ratelimit/resource_util_test.go
+++ b/pkg/ratelimit/resource_util_test.go
@@ -1,0 +1,24 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ratelimit
+
+import "net/http"
+
+// SetPathTemplate sets the path template function for HTTP rate limiting.
+func SetPathTemplate(f func(*http.Request) (string, bool)) func() {
+	old := pathTemplate
+	pathTemplate = f
+	return func() { pathTemplate = old }
+}

--- a/pkg/ratelimit/util_test.go
+++ b/pkg/ratelimit/util_test.go
@@ -1,0 +1,31 @@
+// Copyright © 2023 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ratelimit_test
+
+import (
+	"context"
+	"fmt"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"google.golang.org/grpc/metadata"
+)
+
+const authTokenID = "my-token-id"
+
+func tokenContext(authTokenID string) context.Context {
+	return metadata.NewIncomingContext(test.Context(), metadata.Pairs(
+		"authorization", fmt.Sprintf("Bearer NNSXS.%s.authTokenKey", authTokenID),
+	))
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR allows more fine grained control of HTTP endpoint rate limiting, by adding a class which includes the path template. This allows rate limiting individual HTTP endpoints (like `http:account:/oauth/api/auth/login`) next to the full class (like `http:account`).

Paths which contain a template (containing a gateway ID for example) will maintain their template form (like `http:gcs:/api/v3/gcs/gateways/{gateway_id}/semtechudp/global_conf.json`).

#### Changes

<!-- What are the changes made in this pull request? -->

- Ensure that rate limiting middlewares are called _after_ the authorization header has been converted to gRPC metadata.
- Use the API token ID as an identifier of the caller, instead of the IP, when available. The IP is still used when there is no authorization available.
- Add path template classes to HTTP rate limiting.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Add the following rate limiting configuration to your stack configuration file:

```yaml
rate-limiting:
  profiles:
    - name: HTTP Account login
      max-per-min: 5
      associations:
        - http:account:/oauth/api/auth/login
```

Then try to login with a wrong password 5 times - you should get a rate limiting error.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

There is a behavioral change regarding the caller identity - using different API keys with the same caller IP will now have individual rate limits, which can allow more calls for a single source IP. This should allow better cloud-to-cloud connectivity via HTTP APIs (of which there aren't many, but still), and I consider it to be a reasonable change.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
