### PR TITLE
console: Rollback old http stream

### DIFF
--- a/pkg/webui/console/containers/device-importer/index.js
+++ b/pkg/webui/console/containers/device-importer/index.js
@@ -155,7 +155,7 @@ const DeviceImporter = () => {
         devices = await new Promise((resolve, reject) => {
           const chunks = []
 
-          templateStream.on('chunk', message => {
+          templateStream.on('message', message => {
             appendToLog(message)
             chunks.push(message)
           })
@@ -252,7 +252,7 @@ const DeviceImporter = () => {
         createStream.current = tts.Applications.Devices.bulkCreate(appId, devices)
 
         await new Promise(resolve => {
-          createStream.current.on('chunk', handleCreationSuccess)
+          createStream.current.on('message', handleCreationSuccess)
           createStream.current.on('error', handleCreationError)
           createStream.current.on('close', resolve)
 

--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -24,6 +24,8 @@ import {
   RATE_LIMIT_RETRIES,
 } from '../util/constants'
 
+import subscribeToHttpStream from './stream/subscribeToHttpStream'
+
 /**
  * Http Class is a connector for the API that uses the HTTP bridge to connect.
  */
@@ -85,7 +87,7 @@ class Http {
     }
   }
 
-  async handleRequest(method, endpoint, component, payload = {}) {
+  async handleRequest(method, endpoint, component, payload = {}, isStream) {
     const parsedComponent = component || this._parseStackComponent(endpoint)
     if (!this._stackConfig.isComponentAvailable(parsedComponent)) {
       // If the component has not been defined in The Things Stack config, make no
@@ -96,6 +98,11 @@ class Http {
     }
 
     try {
+      if (isStream) {
+        const url = this._stackConfig.getComponentUrlByName(parsedComponent) + endpoint
+        return subscribeToHttpStream(payload, url)
+      }
+
       const config = {
         method,
         url: endpoint,

--- a/sdk/js/src/api/index.js
+++ b/sdk/js/src/api/index.js
@@ -62,12 +62,13 @@ Signature tried: ${paramSignature}`)
           }
 
           let route = endpoint.pattern
+          const isStream = Boolean(endpoint.stream)
 
           for (const parameter of endpoint.parameters) {
             route = route.replace(`{${parameter}}`, routeParams[parameter])
           }
 
-          return connector.handleRequest(endpoint.method, route, component, payload)
+          return connector.handleRequest(endpoint.method, route, component, payload, isStream)
         }
 
         this[serviceName][`${rpcName}AllowedFieldMaskPaths`] = rpc.allowedFieldMaskPaths

--- a/sdk/js/src/api/index.test.js
+++ b/sdk/js/src/api/index.test.js
@@ -92,6 +92,7 @@ describe('API class', () => {
       '/users/test/applications',
       undefined,
       { name: 'test-name' },
+      false,
     )
   })
 
@@ -103,8 +104,27 @@ describe('API class', () => {
 
   it('respects the search query', () => {
     api.ApplicationRegistry.List(undefined, { limit: 2, page: 1 })
+    expect(api._connector.handleRequest).toHaveBeenCalledTimes(1)
+    expect(api._connector.handleRequest).toHaveBeenCalledWith(
+      'get',
+      '/applications',
+      undefined,
+      { limit: 2, page: 1 },
+      false,
+    )
+  })
+
+  it('sets stream value to true for streaming endpoints', () => {
+    api.ApplicationRegistry.Events()
 
     expect(api._connector.handleRequest).toHaveBeenCalledTimes(1)
+    expect(api._connector.handleRequest).toHaveBeenCalledWith(
+      'get',
+      '/events',
+      undefined,
+      undefined,
+      true,
+    )
     expect(api._connector.handleRequest).toHaveBeenCalledWith('get', '/applications', undefined, {
       limit: 2,
       page: 1,

--- a/sdk/js/src/api/index.test.js
+++ b/sdk/js/src/api/index.test.js
@@ -104,6 +104,7 @@ describe('API class', () => {
 
   it('respects the search query', () => {
     api.ApplicationRegistry.List(undefined, { limit: 2, page: 1 })
+
     expect(api._connector.handleRequest).toHaveBeenCalledTimes(1)
     expect(api._connector.handleRequest).toHaveBeenCalledWith(
       'get',
@@ -125,9 +126,5 @@ describe('API class', () => {
       undefined,
       true,
     )
-    expect(api._connector.handleRequest).toHaveBeenCalledWith('get', '/applications', undefined, {
-      limit: 2,
-      page: 1,
-    })
   })
 })

--- a/sdk/js/src/api/stream/subscribeToHttpStream.js
+++ b/sdk/js/src/api/stream/subscribeToHttpStream.js
@@ -1,0 +1,145 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArrayBufferToString from 'arraybuffer-to-string'
+
+import Token from '../../util/token'
+
+import { notify, EVENTS } from './shared'
+import 'web-streams-polyfill/dist/polyfill'
+
+/**
+ * Opens a new stream.
+ *
+ * @async
+ * @param {object} payload -  - The body of the initial request.
+ * @param {string} url - The stream endpoint.
+ *
+ * @example
+ * (async () => {
+ *    const stream = await stream(
+ *      { identifiers: [{ application_ids: { application_id: 'my-app' }}]},
+ *      '/api/v3/events',
+ *    )
+ *
+ *    // Add listeners to the stream.
+ *    stream
+ *      .on('start', () => console.log('conn opened'))
+ *      .on('message', message => console.log('received message', message))
+ *      .on('error', error => console.log(error))
+ *      .on('close', wasClientRequest => console.log(wasClientRequest ? 'conn closed by client' : 'conn closed by server'))
+ *
+ *    // Start the stream after attaching listerners.
+ *    stream.open()
+ *
+ *     // Close the stream after 20 s.
+ *    setTimeout(() => stream.close(), 20000)
+ * })()
+ *
+ * @returns {object} The stream subscription object with the `on` function for
+ * attaching listeners and the `close` function to close the stream.
+ */
+export default async (payload, url) => {
+  const initialListeners = Object.values(EVENTS).reduce(
+    (acc, curr) => ({ ...acc, [curr]: null }),
+    {},
+  )
+  let listeners = initialListeners
+  let closeRequested = false
+  const token = new Token().get()
+
+  let Authorization = null
+  if (typeof token === 'function') {
+    Authorization = `Bearer ${(await token()).access_token}`
+  } else {
+    Authorization = `Bearer ${token}`
+  }
+
+  const abortController = new AbortController()
+  const response = await fetch(url, {
+    body: JSON.stringify(payload),
+    method: 'POST',
+    signal: abortController.signal,
+    headers: {
+      Authorization,
+      Accept: 'text/event-stream',
+    },
+  })
+
+  if (response.status !== 200) {
+    const err = await response.json()
+
+    throw 'error' in err ? err.error : err
+  }
+
+  let buffer = ''
+  const reader = response.body.getReader()
+  const onMessage = ({ done, value }) => {
+    if (done) {
+      notify(listeners[EVENTS.CLOSE], closeRequested)
+      listeners = initialListeners
+      return
+    }
+
+    const parsed = ArrayBufferToString(value)
+    buffer += parsed
+    const lines = buffer.split(/\n\n/)
+    buffer = lines.pop()
+    for (const line of lines) {
+      notify(listeners[EVENTS.MESSAGE], JSON.parse(line).result)
+    }
+
+    return reader.read().then(onMessage)
+  }
+
+  return {
+    open: () => {
+      reader
+        .read()
+        .then(data => {
+          notify(listeners[EVENTS.START])
+
+          return data
+        })
+        .then(onMessage)
+        .catch(error => {
+          notify(listeners[EVENTS.ERROR], error)
+          listeners = initialListeners
+        })
+    },
+    on(eventName, callback) {
+      if (listeners[eventName] === undefined) {
+        throw new Error(
+          `${eventName} event is not supported. Should be one of: start, error, message or close`,
+        )
+      }
+
+      listeners[eventName] = callback
+
+      return this
+    },
+    close: () => {
+      closeRequested = true
+
+      reader
+        .cancel()
+        .then(() => {
+          abortController.abort()
+        })
+        .catch(error => {
+          notify(listeners[EVENTS.ERROR], error)
+        })
+    },
+  }
+}

--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -15,7 +15,7 @@
 import autoBind from 'auto-bind'
 
 import Marshaler from '../util/marshaler'
-import subscribeToStream from '../api/stream/subscribeToStream'
+import subscribeToWebSocketStream from '../api/stream/subscribeToWebSocketStream'
 import combineStreams from '../util/combine-streams'
 import { STACK_COMPONENTS_MAP } from '../util/constants'
 
@@ -236,7 +236,7 @@ class Applications {
       distinctComponents.map(component => this._stackConfig.getComponentUrlByName(component)),
     )
 
-    const streams = [...baseUrls].map(baseUrl => subscribeToStream(payload, baseUrl))
+    const streams = [...baseUrls].map(baseUrl => subscribeToWebSocketStream(payload, baseUrl))
 
     // Combine all stream sources to one subscription generator.
     return combineStreams(streams)

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -19,7 +19,7 @@ import traverse from 'traverse'
 
 import { notify, EVENTS } from '../../api/stream/shared'
 import Marshaler from '../../util/marshaler'
-import subscribeToStream from '../../api/stream/subscribeToStream'
+import subscribeToWebSocketStream from '../../api/stream/subscribeToWebSocketStream'
 import deviceEntityMap from '../../../generated/device-entity-map.json'
 import DownlinkQueue from '../downlink-queue'
 import { STACK_COMPONENTS_MAP } from '../../util/constants'
@@ -664,7 +664,7 @@ class Devices {
       on(eventName, callback) {
         if (listeners[eventName] === undefined) {
           throw new Error(
-            `${eventName} event is not supported. Should be one of: start, error, chunk or close`,
+            `${eventName} event is not supported. Should be one of: open, error, message or close`,
           )
         }
 
@@ -699,7 +699,7 @@ class Devices {
       distinctComponents.map(component => this._stackConfig.getComponentUrlByName(component)),
     )
 
-    const streams = [...baseUrls].map(baseUrl => subscribeToStream(payload, baseUrl))
+    const streams = [...baseUrls].map(baseUrl => subscribeToWebSocketStream(payload, baseUrl))
 
     // Combine all stream sources to one subscription generator.
     return combineStreams(streams)

--- a/sdk/js/src/service/gateways.js
+++ b/sdk/js/src/service/gateways.js
@@ -15,7 +15,7 @@
 import autoBind from 'auto-bind'
 
 import Marshaler from '../util/marshaler'
-import subscribeToStream from '../api/stream/subscribeToStream'
+import subscribeToWebSocketStream from '../api/stream/subscribeToWebSocketStream'
 import { STACK_COMPONENTS_MAP } from '../util/constants'
 import combineStreams from '../util/combine-streams'
 
@@ -262,7 +262,7 @@ class Gateways {
       distinctComponents.map(component => this._stackConfig.getComponentUrlByName(component)),
     )
 
-    const streams = [...baseUrls].map(baseUrl => subscribeToStream(payload, baseUrl))
+    const streams = [...baseUrls].map(baseUrl => subscribeToWebSocketStream(payload, baseUrl))
 
     // Combine all stream sources to one subscription generator.
     return combineStreams(streams)

--- a/sdk/js/src/service/organizations.js
+++ b/sdk/js/src/service/organizations.js
@@ -15,7 +15,7 @@
 import autoBind from 'auto-bind'
 
 import Marshaler from '../util/marshaler'
-import subscribeToStream from '../api/stream/subscribeToStream'
+import subscribeToWebSocketStream from '../api/stream/subscribeToWebSocketStream'
 import { STACK_COMPONENTS_MAP } from '../util/constants'
 
 import ApiKeys from './api-keys'
@@ -168,7 +168,7 @@ class Organizations {
 
     const baseUrl = this._stackConfig.getComponentUrlByName(STACK_COMPONENTS_MAP.is)
 
-    return subscribeToStream(payload, baseUrl)
+    return subscribeToWebSocketStream(payload, baseUrl)
   }
 }
 


### PR DESCRIPTION
#### Summary

There was an error when trying to import end devices(or calling any other http stream endpoint), because the logic for http streams was removed during web socket changes.

#### Changes

Rollback of the old logic for http stream.

#### Testing

1. Go to console.
2. Go to `/console/applications/:appId/devices/import`.
3. Import a file.
4. Error should not be shown and everything should work like before.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
