### PR TITLE
Fix multiple chain rights assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Batch gateway rights assertions when multiple membership chains are available (for example, both via a user and an organization).
+
 ### Security
 
 ## [3.28.1] - 2023-11-27

--- a/pkg/identityserver/gateway_access_test.go
+++ b/pkg/identityserver/gateway_access_test.go
@@ -589,6 +589,21 @@ func TestGatewayBatchAccess(t *testing.T) {
 	locUserKey, _ := p.NewAPIKey(locUser.GetEntityIdentifiers(), ttnpb.Right_RIGHT_ALL)
 	locUserCreds := rpcCreds(locUserKey)
 
+	dualMembershipUser := p.NewUser()
+	dualMembershipUserKey, _ := p.NewAPIKey(dualMembershipUser.GetEntityIdentifiers(), ttnpb.Right_RIGHT_ALL)
+	dualMembershipUserCreds := rpcCreds(dualMembershipUserKey)
+	p.NewMembership(
+		dualMembershipUser.GetOrganizationOrUserIdentifiers(),
+		gtw3.GetEntityIdentifiers(),
+		ttnpb.Right_RIGHT_GATEWAY_ALL,
+	)
+	org1 := p.NewOrganization(dualMembershipUser.GetOrganizationOrUserIdentifiers())
+	p.NewMembership(
+		org1.GetOrganizationOrUserIdentifiers(),
+		gtw3.GetEntityIdentifiers(),
+		ttnpb.Right_RIGHT_GATEWAY_ALL,
+	)
+
 	testWithIdentityServer(t, func(is *IdentityServer, cc *grpc.ClientConn) {
 		reg := ttnpb.NewGatewayBatchAccessClient(cc)
 
@@ -955,6 +970,20 @@ func TestGatewayBatchAccess(t *testing.T) {
 					},
 				},
 				Credentials: usr1Creds,
+			},
+			{
+				Name: "Dual membership user",
+				Request: &ttnpb.AssertGatewayRightsRequest{
+					GatewayIds: []*ttnpb.GatewayIdentifiers{
+						gtw3.GetIds(),
+					},
+					Required: &ttnpb.Rights{
+						Rights: []ttnpb.Right{
+							ttnpb.Right_RIGHT_GATEWAY_ALL,
+						},
+					},
+				},
+				Credentials: dualMembershipUserCreds,
 			},
 		} {
 			tc := tc


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes another edge case of the `AssertRights` RPC, specifically the case in which the user has _multiple_ chains of rights towards the entity. This can happen if the user is part of an organization, and the organization is also an entity collaborator, next to the user.

#### Changes

<!-- What are the changes made in this pull request? -->

- Take the union of rights over all of the entity chains for an individual entity.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Local testing and unit testing.

Testing steps (as a non admin user):
1. Create an organization, associated with the user.
2. Create a gateway, associated with the user.
3. Add the organization as a collaborator to the gateway.
4. Check the gateways list in the Console. No error should occur.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

This fixes a regression caused by the fact that we use the `BatchGetGatewayConnectionStats` in the Console now. No extra regressions are expected.

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I've gone again through the logic of [getRights](https://github.com/TheThingsNetwork/lorawan-stack/blob/e72beeea0bdd3ccfcc665226ab44ed39f26f295c/pkg/identityserver/rights.go#L42) and I think this was the final difference between single entity rights assertions and batch rights assertions, but please take another sanity check.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
