### PR TITLE
Disconnect gateway on Gateway Server address change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - Server side events replaced with single socket connection using the native WebSocket API.
+- Gateways now disconnect if the Gateway Server address has changed.
+  - This enables CUPS-enabled gateways to change their LNS before the periodic CUPS lookup occurs.
 
 ### Deprecated
 

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -486,6 +486,7 @@ func (gs *GatewayServer) Connect(
 			"enforce_duty_cycle",
 			"frequency_plan_id",
 			"frequency_plan_ids",
+			"gateway_server_address",
 			"location_public",
 			"require_authenticated_connection",
 			"schedule_anytime_delay",
@@ -611,7 +612,8 @@ func requireDisconnect(connected, current *ttnpb.Gateway) bool {
 		connected.StatusPublic != current.StatusPublic ||
 		connected.UpdateLocationFromStatus != current.UpdateLocationFromStatus ||
 		connected.FrequencyPlanId != current.FrequencyPlanId ||
-		len(connected.FrequencyPlanIds) != len(current.FrequencyPlanIds) {
+		len(connected.FrequencyPlanIds) != len(current.FrequencyPlanIds) ||
+		connected.GatewayServerAddress != current.GatewayServerAddress {
 		return true
 	}
 	for i := range connected.FrequencyPlanIds {
@@ -646,6 +648,7 @@ func (gs *GatewayServer) startDisconnectOnChangeTask(conn connectionEntry) {
 					"enforce_duty_cycle",
 					"frequency_plan_id",
 					"frequency_plan_ids",
+					"gateway_server_address",
 					"location_public",
 					"require_authenticated_connection",
 					"schedule_anytime_delay",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1007

#### Changes

<!-- What are the changes made in this pull request? -->

- Disconnect gateways if the Gateway Server address has changed.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Local testing. Manual testing steps:

1. Register a Basic Station gateway. You may use LNS directly or do it via CUPS.
2. Connect the gateway.
3. After the gateway has connected, change the gateway server address.
4. You will have to wait approximately 12 minutes for the periodic check to occur.
5. Your gateway should disconnect with error `gateway_changed`.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

N/A. The gateway server address is covered by the already existing API key rights, so there shouldn't be any regression.

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
