### PR TITLE
Check authorization in Basics Station discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 - Server side events replaced with single socket connection using the native WebSocket API.
 - Gateways now disconnect if the Gateway Server address has changed.
   - This enables CUPS-enabled gateways to change their LNS before the periodic CUPS lookup occurs.
+- The LoRa Basics Station discovery endpoint now verifies the authorization credentials of the caller.
+  - This enables the gateways to migrate to another instance gracefully while using CUPS.
 
 ### Deprecated
 

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -450,6 +450,11 @@ type connectionEntry struct {
 	tasksDone *sync.WaitGroup
 }
 
+// AssertGatewayRights checks that the caller has the required rights over the provided gateway identifiers.
+func (gs *GatewayServer) AssertGatewayRights(ctx context.Context, ids *ttnpb.GatewayIdentifiers, rights ...ttnpb.Right) error {
+	return gs.entityRegistry.AssertGatewayRights(ctx, ids, rights...)
+}
+
 // Connect connects a gateway by its identifiers to the Gateway Server, and returns a io.Connection for traffic and
 // control.
 func (gs *GatewayServer) Connect(
@@ -459,7 +464,7 @@ func (gs *GatewayServer) Connect(
 	addr *ttnpb.GatewayRemoteAddress,
 	opts ...io.ConnectionOption,
 ) (*io.Connection, error) {
-	if err := gs.entityRegistry.AssertGatewayRights(ctx, ids, ttnpb.Right_RIGHT_GATEWAY_LINK); err != nil {
+	if err := gs.AssertGatewayRights(ctx, ids, ttnpb.Right_RIGHT_GATEWAY_LINK); err != nil {
 		return nil, err
 	}
 

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -60,8 +60,11 @@ type Server interface {
 	GetBaseConfig(ctx context.Context) config.ServiceBase
 	// FillGatewayContext fills the given context and identifiers.
 	// This method should only be used for request contexts.
-	FillGatewayContext(ctx context.Context,
-		ids *ttnpb.GatewayIdentifiers) (context.Context, *ttnpb.GatewayIdentifiers, error)
+	FillGatewayContext(
+		ctx context.Context, ids *ttnpb.GatewayIdentifiers,
+	) (context.Context, *ttnpb.GatewayIdentifiers, error)
+	// AssertGatewayRights checks that the caller has the required rights over the provided gateway identifiers.
+	AssertGatewayRights(ctx context.Context, ids *ttnpb.GatewayIdentifiers, required ...ttnpb.Right) error
 	// Connect connects a gateway by its identifiers to the Gateway Server, and returns a Connection for traffic and
 	// control.
 	Connect(

--- a/pkg/gatewayserver/io/mock/server.go
+++ b/pkg/gatewayserver/io/mock/server.go
@@ -76,6 +76,11 @@ func (s *server) FillGatewayContext(ctx context.Context, ids *ttnpb.GatewayIdent
 	return ctx, ids, nil
 }
 
+// AssertRights implements io.Server.
+func (*server) AssertGatewayRights(ctx context.Context, ids *ttnpb.GatewayIdentifiers, required ...ttnpb.Right) error {
+	return rights.RequireGateway(ctx, ids, required...)
+}
+
 // Connect implements io.Server.
 func (s *server) Connect(
 	ctx context.Context,
@@ -84,7 +89,7 @@ func (s *server) Connect(
 	addr *ttnpb.GatewayRemoteAddress,
 	opts ...io.ConnectionOption,
 ) (*io.Connection, error) {
-	if err := rights.RequireGateway(ctx, ids, ttnpb.Right_RIGHT_GATEWAY_LINK); err != nil {
+	if err := s.AssertGatewayRights(ctx, ids, ttnpb.Right_RIGHT_GATEWAY_LINK); err != nil {
 		return nil, err
 	}
 	gtw, err := s.identityStore.GatewayRegistry().Get(ctx, &ttnpb.GetGatewayRequest{GatewayIds: ids})

--- a/pkg/gatewayserver/io/ws/format.go
+++ b/pkg/gatewayserver/io/ws/format.go
@@ -41,12 +41,22 @@ type Formatter interface {
 	Endpoints() Endpoints
 	// HandleConnectionInfo handles connection information requests from web socket based protocols.
 	// This function returns a byte stream that contains connection information (ex: scheme, host, port etc) or an error if applicable.
-	HandleConnectionInfo(ctx context.Context, raw []byte, server io.Server, serverInfo ServerInfo, receivedAt time.Time) []byte
+	HandleConnectionInfo(
+		ctx context.Context,
+		raw []byte,
+		server io.Server,
+		serverInfo ServerInfo,
+		assertAuth func(context.Context, *ttnpb.GatewayIdentifiers) error,
+	) []byte
 	// HandleUp handles upstream messages from web socket based gateways.
 	// This function optionally returns a byte stream to be sent as response to the upstream message.
-	HandleUp(ctx context.Context, raw []byte, ids *ttnpb.GatewayIdentifiers, conn *io.Connection, receivedAt time.Time) ([]byte, error)
+	HandleUp(
+		ctx context.Context, raw []byte, ids *ttnpb.GatewayIdentifiers, conn *io.Connection, receivedAt time.Time,
+	) ([]byte, error)
 	// FromDownlink generates a downlink byte stream that can be sent over the WS connection.
 	FromDownlink(ctx context.Context, down *ttnpb.DownlinkMessage, bandID string, dlTime time.Time) ([]byte, error)
 	// TransferTime generates a spurious time transfer message for a particular server time.
-	TransferTime(ctx context.Context, serverTime time.Time, gpsTime *time.Time, concentratorTime *scheduling.ConcentratorTime) ([]byte, error)
+	TransferTime(
+		ctx context.Context, serverTime time.Time, gpsTime *time.Time, concentratorTime *scheduling.ConcentratorTime,
+	) ([]byte, error)
 }

--- a/pkg/gatewayserver/io/ws/lbslns/discover_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/discover_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/smarty/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/ws"
@@ -69,9 +68,11 @@ func TestDiscover(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			msg, err := json.Marshal(tc.Query)
 			a.So(err, should.BeNil)
-			resp := lbsLNS.HandleConnectionInfo(ctx, msg, mockServer, info, time.Now())
+			resp := lbsLNS.HandleConnectionInfo(ctx, msg, mockServer, info, noopAssertRights)
 			expected, _ := json.Marshal(tc.ExpectedResponse)
 			a.So(string(resp), should.Equal, string(expected))
 		})
 	}
 }
+
+func noopAssertRights(context.Context, *ttnpb.GatewayIdentifiers) error { return nil }

--- a/pkg/gatewayserver/io/ws/lbslns/discover_util_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/discover_util_test.go
@@ -37,6 +37,10 @@ func (srv mockServer) FillGatewayContext(ctx context.Context, ids *ttnpb.Gateway
 	return ctx, srv.ids, nil
 }
 
+func (mockServer) AssertGatewayRights(context.Context, *ttnpb.GatewayIdentifiers, ...ttnpb.Right) error {
+	return nil
+}
+
 func (mockServer) Connect(
 	context.Context, io.Frontend, *ttnpb.GatewayIdentifiers, *ttnpb.GatewayRemoteAddress, ...io.ConnectionOption,
 ) (*io.Connection, error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1007
References https://github.com/TheThingsIndustries/lorawan-stack/pull/3974

#### Changes

<!-- What are the changes made in this pull request? -->

- Allow individual gateway protocol frontends to assert the rights of the caller, without connecting per se as the gateway.
- Assert that the caller has the required rights over a gateway while calling the LNS discovery endpoint.
  - Currently, the gateway doesn't realize that its credentials may need to be updated, because the LNS gives mixed signals - it accepts the credentials during discovery, but not during traffic. As such, the gateway falls back to doing a discovery round again, instead of doing a CUPS lookup.
  - The changes proposed here allow the gateway to correctly fall back to CUPS in order to update both its credentials and the LNS address.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Unit tests and local testing. _This is currently live on `staging1`._

Testing steps:
1. Register a Basic Station gateway using CUPS.
2. Connect said gateway.
3. Invalidate (delete or just remove the linking right) the LNS key.
4. Generate new LNS key and set it as LNS key.
5. Trigger a gateway reconnect remotely (i.e. toggle the 'disable Packet Broker forwarding' option).
6. Expect the gateway to reconnect using the new LNS key before the next periodic CUPS lookup (i.e. in less than 24 hour, preferably way faster).

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

All of the implementations derived form the Semtech reference implementation provide the credentials during discovery. Tektelic also provides the credentials during discovery. So does Kerlink.

I've ran the above test sequence for all of the vendors. 

Kerlink unfortunately doesn't re-trigger CUPS if discovery fails, but that's unrelated to this fix. They run CUPS periodically every hour, so should someone need to migrate, it should more manageable. For reference, the reference implementation runs CUPS every 24 hours if discovery never fails.

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We cannot unfortunately return a 'good' HTTP status code, as the gateway identifiers are not available before the WebSocket upgrade occurs. We have to return the error via WebSockets.

No need to review.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
