### PR TITLE
Allow to only set frequency plans within the same band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Rate limiting classes for individual HTTP paths.
 - Rate limiting keys for HTTP endpoints now contain the caller API key ID when available. The caller IP is still available as a fallback.
+- Allow users to set multiple frequency plans only in the same band in the Console.
 
 ### Changed
 

--- a/cypress/e2e/console/gateways/create.spec.js
+++ b/cypress/e2e/console/gateways/create.spec.js
@@ -174,7 +174,7 @@ describe('Gateway create', () => {
     )
     cy.findByRole('heading', { name: `eui-${gateway.eui}` })
     cy.findByText('Frequency plan')
-    cy.findByText('EU_863_870 , US_902_928_FSB_1').should('be.visible')
+    cy.findByText('EU_863_870 , EU_863_870_TTN').should('be.visible')
     cy.findByTestId('error-notification').should('not.exist')
   })
 

--- a/cypress/e2e/console/gateways/create.spec.js
+++ b/cypress/e2e/console/gateways/create.spec.js
@@ -159,7 +159,12 @@ describe('Gateway create', () => {
       .first()
       .selectOption(gateway.frequency_plan)
     cy.findByRole('button', { name: /Add frequency plan/ }).click()
-    cy.findByText('Frequency plan').parent().parent().find('input').eq(2).selectOption('US_902_928')
+    cy.findByText('Frequency plan')
+      .parent()
+      .parent()
+      .find('input')
+      .eq(2)
+      .selectOption('EU_863_870_TTN')
     cy.findByRole('button', { name: 'Register gateway' }).click()
 
     cy.findByTestId('error-notification').should('not.exist')

--- a/cypress/e2e/console/gateways/edit.spec.js
+++ b/cypress/e2e/console/gateways/edit.spec.js
@@ -294,7 +294,7 @@ describe('Gateway general settings', () => {
   })
 
   it('succeeds editing multiple frequency plans', () => {
-    const newFrequencyPlan = 'Asia 920-923 MHz'
+    const newFrequencyPlan = 'EU_863_870_ROAMING_DRAFT'
     cy.loginConsole({ user_id: user.ids.user_id, password: user.password })
     cy.visit(
       `${Cypress.config('consoleRootPath')}/gateways/${gateway2.ids.gateway_id}/general-settings`,

--- a/cypress/e2e/console/gateways/edit.spec.js
+++ b/cypress/e2e/console/gateways/edit.spec.js
@@ -294,7 +294,7 @@ describe('Gateway general settings', () => {
   })
 
   it('succeeds editing multiple frequency plans', () => {
-    const newFrequencyPlan = 'EU_863_870_ROAMING_DRAFT'
+    const newFrequencyPlan = 'Europe 863-870 MHz, 6 channels for roaming (Draft)'
     cy.loginConsole({ user_id: user.ids.user_id, password: user.password })
     cy.visit(
       `${Cypress.config('consoleRootPath')}/gateways/${gateway2.ids.gateway_id}/general-settings`,

--- a/pkg/webui/components/key-value-map/entry.js
+++ b/pkg/webui/components/key-value-map/entry.js
@@ -44,6 +44,7 @@ const Entry = ({
   removeMessage,
   distinctOptions,
   atLeastOneEntry,
+  filterByTag,
 }) => {
   const [currentValue, setCurrentValue] = useState(value)
   const [newOptions, setNewOptions] = useState(undefined)
@@ -98,8 +99,15 @@ const Entry = ({
     } else {
       newOptions = options.filter(v => !fieldValue.includes(v.value))
     }
-    setNewOptions(newOptions)
-  }, [currentValue, options, fieldValue])
+
+    let taggedOptions = newOptions
+    if (fieldValue.length >= 2 && filterByTag) {
+      const selectedOption = options.find(v => v.value === fieldValue[0])
+      taggedOptions = newOptions.filter(v => selectedOption.tag === v.tag)
+    }
+
+    setNewOptions(taggedOptions)
+  }, [currentValue, options, fieldValue, filterByTag])
 
   const showRemoveButton = atLeastOneEntry ? index !== 0 : true
 
@@ -157,6 +165,7 @@ Entry.propTypes = {
   atLeastOneEntry: PropTypes.bool,
   distinctOptions: PropTypes.bool,
   fieldValue: PropTypes.any,
+  filterByTag: PropTypes.bool,
   index: PropTypes.number.isRequired,
   indexAsKey: PropTypes.bool.isRequired,
   inputElement: PropTypes.elementType.isRequired,
@@ -184,6 +193,7 @@ Entry.defaultProps = {
   distinctOptions: false,
   fieldValue: undefined,
   atLeastOneEntry: false,
+  filterByTag: false,
 }
 
 export default Entry

--- a/pkg/webui/components/key-value-map/index.js
+++ b/pkg/webui/components/key-value-map/index.js
@@ -46,6 +46,7 @@ const KeyValueMap = ({
   valuePlaceholder,
   distinctOptions,
   atLeastOneEntry,
+  filterByTag,
 }) => {
   const handleEntryChange = useCallback(
     (index, newValues) => {
@@ -98,6 +99,7 @@ const KeyValueMap = ({
               removeMessage={removeMessage}
               distinctOptions={distinctOptions}
               atLeastOneEntry={atLeastOneEntry}
+              filterByTag={filterByTag}
             />
           ))}
       </div>
@@ -122,6 +124,7 @@ KeyValueMap.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   distinctOptions: PropTypes.bool,
+  filterByTag: PropTypes.bool,
   indexAsKey: PropTypes.bool,
   inputElement: PropTypes.elementType,
   isReadOnly: PropTypes.func,
@@ -157,6 +160,7 @@ KeyValueMap.defaultProps = {
   removeMessage: undefined,
   distinctOptions: false,
   atLeastOneEntry: false,
+  filterByTag: false,
 }
 
 export default KeyValueMap

--- a/pkg/webui/console/containers/freq-plans-select/gs-frequency-plan-select.js
+++ b/pkg/webui/console/containers/freq-plans-select/gs-frequency-plan-select.js
@@ -69,6 +69,7 @@ const GatewayFrequencyPlansSelect = () => {
       additionalInputProps={{ options: freqPlanOptions }}
       distinctOptions
       atLeastOneEntry
+      filterByTag
       required
     />
   )

--- a/pkg/webui/console/containers/freq-plans-select/utils.js
+++ b/pkg/webui/console/containers/freq-plans-select/utils.js
@@ -14,12 +14,13 @@
 
 import { defineMessages } from 'react-intl'
 
-export const formatOptions = plans => plans.map(plan => ({ value: plan.id, label: plan.name }))
+export const formatOptions = plans =>
+  plans.map(plan => ({ value: plan.id, label: plan.name, tag: plan.band_id }))
 export const m = defineMessages({
   warning: 'Frequency plans unavailable',
   none: 'Do not set a frequency plan',
   selectFrequencyPlan: 'Select a frequency plan...',
   addFrequencyPlan: 'Add frequency plan',
   frequencyPlanDescription:
-    'Note: most gateways use a single frequency plan. Some 16 and 64 channel gateways however allow setting multiple.',
+    'Note: most gateways use a single frequency plan. Some 16 and 64 channel gateways however allow setting multiple. Furthermore, setting frequency plans from different brands is not supported.',
 })

--- a/pkg/webui/console/containers/freq-plans-select/utils.js
+++ b/pkg/webui/console/containers/freq-plans-select/utils.js
@@ -22,5 +22,5 @@ export const m = defineMessages({
   selectFrequencyPlan: 'Select a frequency plan...',
   addFrequencyPlan: 'Add frequency plan',
   frequencyPlanDescription:
-    'Note: most gateways use a single frequency plan. Some 16 and 64 channel gateways however allow setting multiple. Furthermore, setting frequency plans from different brands is not supported.',
+    'Note: most gateways use a single frequency plan. Some 16 and 64 channel gateways however allow setting multiple within the same band.',
 })

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -514,7 +514,7 @@
   "console.containers.freq-plans-select.utils.none": "Do not set a frequency plan",
   "console.containers.freq-plans-select.utils.selectFrequencyPlan": "Select a frequency plan...",
   "console.containers.freq-plans-select.utils.addFrequencyPlan": "Add frequency plan",
-  "console.containers.freq-plans-select.utils.frequencyPlanDescription": "Note: most gateways use a single frequency plan. Some 16 and 64 channel gateways however allow setting multiple. Furthermore, setting frequency plans from different brands is not supported.",
+  "console.containers.freq-plans-select.utils.frequencyPlanDescription": "Note: most gateways use a single frequency plan. Some 16 and 64 channel gateways however allow setting multiple within the same band.",
   "console.containers.gateway-connection.index.lastSeenAvailableTooltip": "The elapsed time since the network registered the last activity of this gateway. This is determined from received uplinks, or sent status messages of this gateway.",
   "console.containers.gateway-connection.index.disconnectedTooltip": "The gateway has currently no TCP connection established with the Gateway Server. For (rare) UDP based gateways, this can also mean that the gateway initiated no pull/push data request within the last 30 seconds.",
   "console.containers.gateway-connection.index.connectedTooltip": "This gateway is connected to the Gateway Server but the network has not registered any activity (sent uplinks or status messages) from it yet.",

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -514,7 +514,7 @@
   "console.containers.freq-plans-select.utils.none": "Do not set a frequency plan",
   "console.containers.freq-plans-select.utils.selectFrequencyPlan": "Select a frequency plan...",
   "console.containers.freq-plans-select.utils.addFrequencyPlan": "Add frequency plan",
-  "console.containers.freq-plans-select.utils.frequencyPlanDescription": "Note: most gateways use a single frequency plan. Some 16 and 64 channel gateways however allow setting multiple.",
+  "console.containers.freq-plans-select.utils.frequencyPlanDescription": "Note: most gateways use a single frequency plan. Some 16 and 64 channel gateways however allow setting multiple. Furthermore, setting frequency plans from different brands is not supported.",
   "console.containers.gateway-connection.index.lastSeenAvailableTooltip": "The elapsed time since the network registered the last activity of this gateway. This is determined from received uplinks, or sent status messages of this gateway.",
   "console.containers.gateway-connection.index.disconnectedTooltip": "The gateway has currently no TCP connection established with the Gateway Server. For (rare) UDP based gateways, this can also mean that the gateway initiated no pull/push data request within the last 30 seconds.",
   "console.containers.gateway-connection.index.connectedTooltip": "This gateway is connected to the Gateway Server but the network has not registered any activity (sent uplinks or status messages) from it yet.",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #6644 

#### Changes

<!-- What are the changes made in this pull request? -->

- Introduce tags in `Select` options.
- Add a `filterByTag` prop and allow filtering by the tag of the first chosen option.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Log into the console
2. Proceed to adding a gateway
3. Choose one frequency plan
4. Add another frequency plan
5. See that the dropdown shows frequency plans only within the same band

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
