### PR TITLE
Fix event stream error handling and reconnection

### DIFF
--- a/sdk/js/src/api/stream/subscribeToWebSocketStream.js
+++ b/sdk/js/src/api/stream/subscribeToWebSocketStream.js
@@ -28,6 +28,7 @@ const initialListeners = Object.values(EVENTS).reduce((acc, curr) => ({ ...acc, 
  * @param {object} payload -  - The body of the initial request.
  * @param {string} baseUrl - The stream baseUrl.
  * @param {string} endpoint - The stream endpoint.
+ * @param {number} timeout - The timeout for the stream.
  *
  * @example
  * (async () => {
@@ -51,7 +52,12 @@ const initialListeners = Object.values(EVENTS).reduce((acc, curr) => ({ ...acc, 
  * @returns {object} The stream subscription object with the `on` function for
  * attaching listeners and the `close` function to close the stream.
  */
-export default async (payload, baseUrl, endpoint = '/console/internal/events/') => {
+export default async (
+  payload,
+  baseUrl,
+  endpoint = '/console/internal/events/',
+  timeout = 10000,
+) => {
   const subscriptionId = Date.now()
   const subscriptionPayload = JSON.stringify({
     type: MESSAGE_TYPES.SUBSCRIBE,
@@ -65,84 +71,109 @@ export default async (payload, baseUrl, endpoint = '/console/internal/events/') 
   let closeRequested = false
   const url = baseUrl + endpoint
 
-  await new Promise(async resolve => {
-    // Add the new subscription to the subscriptions object.
-    // Also add the resolver function to the subscription object to be able
-    // to resolve the promise after the subscription confirmation message.
-    subscriptions = {
-      ...subscriptions,
-      [subscriptionId]: { ...initialListeners, url, _resolver: resolve },
-    }
+  await Promise.race([
+    new Promise(async (resolve, reject) => {
+      // Add the new subscription to the subscriptions object.
+      // Also add the resolver function to the subscription object to be able
+      // to resolve the promise after the subscription confirmation message.
+      subscriptions = {
+        ...subscriptions,
+        [subscriptionId]: { ...initialListeners, url, _resolver: resolve },
+      }
 
-    const token = new Token().get()
-    const tokenParsed = typeof token === 'function' ? (await token()).access_token : token
-    const baseUrlParsed = baseUrl.replace('http', 'ws')
+      try {
+        const token = new Token().get()
+        const tokenParsed = typeof token === 'function' ? `${(await token()).access_token}` : token
+        const baseUrlParsed = baseUrl.replace('http', 'ws')
 
-    // Open up the WebSocket connection if it doesn't exist.
-    if (!wsInstances[url]) {
-      wsInstances[url] = new WebSocket(`${baseUrlParsed}${endpoint}`, [
-        'ttn.lorawan.v3.console.internal.events.v1',
-        `ttn.lorawan.v3.header.authorization.bearer.${tokenParsed}`,
-      ])
+        // Open up the WebSocket connection if it doesn't exist.
+        if (!wsInstances[url]) {
+          wsInstances[url] = new WebSocket(`${baseUrlParsed}${endpoint}`, [
+            'ttn.lorawan.v3.console.internal.events.v1',
+            `ttn.lorawan.v3.header.authorization.bearer.${tokenParsed}`,
+          ])
 
-      // Event listener for 'open'
-      wsInstances[url].addEventListener('open', () => {
-        wsInstances[url].send(subscriptionPayload)
-      })
+          // Event listener for 'open'
+          wsInstances[url].addEventListener('open', () => {
+            wsInstances[url].send(subscriptionPayload)
+          })
 
-      // Broadcast connection errors to all listeners.
-      wsInstances[url].addEventListener('error', error => {
+          // Broadcast connection errors to all listeners.
+          wsInstances[url].addEventListener('error', error => {
+            Object.values(subscriptions)
+              .filter(s => s.url === url)
+              .forEach(s => notify(s[EVENTS.ERROR], new Error(error)))
+            // The error is an error event, but we should only throw proper errors.
+            // It has an optional error code that we could use to map to a proper error.
+            // However, the error codes are optional and not always used.
+            reject(new Error('Error in WebSocket connection'))
+          })
+
+          // Event listener for 'close'
+          wsInstances[url].addEventListener('close', closeEvent => {
+            delete wsInstances[url]
+            Object.values(subscriptions)
+              .filter(s => s.url === url)
+              .forEach(s => notify(s[EVENTS.CLOSE], closeRequested))
+
+            if (closeRequested) {
+              resolve()
+            } else {
+              reject(
+                new Error(`WebSocket connection closed unexpectedly with code ${closeEvent.code}`),
+              )
+            }
+          })
+
+          // After the WebSocket connection is open, add the event listeners.
+          // Wait for the subscription confirmation message before resolving.
+          wsInstances[url].addEventListener('message', ({ data }) => {
+            const dataParsed = JSON.parse(data)
+            const listeners = subscriptions[dataParsed.id]
+
+            if (!listeners) {
+              warn('Message received for closed or unknown subscription with ID', dataParsed.id)
+
+              return
+            }
+
+            if (dataParsed.type === MESSAGE_TYPES.SUBSCRIBE) {
+              notify(listeners[EVENTS.OPEN])
+              // Resolve the promise after the subscription confirmation message.
+              listeners._resolver()
+            }
+
+            if (dataParsed.type === MESSAGE_TYPES.ERROR) {
+              notify(listeners[EVENTS.ERROR], dataParsed)
+            }
+
+            if (dataParsed.type === MESSAGE_TYPES.PUBLISH) {
+              notify(listeners[EVENTS.MESSAGE], dataParsed.event)
+            }
+
+            if (dataParsed.type === MESSAGE_TYPES.UNSUBSCRIBE) {
+              notify(listeners[EVENTS.CLOSE], closeRequested)
+              // Remove the subscription.
+              delete subscriptions[dataParsed.id]
+              if (!Object.values(subscriptions).some(s => s.url === url)) {
+                wsInstances[url].close()
+              }
+            }
+          })
+        } else if (wsInstances[url] && wsInstances[url].readyState === WebSocket.OPEN) {
+          // If the WebSocket connection is already open, only add the subscription.
+          wsInstances[url].send(subscriptionPayload)
+        }
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(error)
         Object.values(subscriptions)
           .filter(s => s.url === url)
-          .forEach(s => notify(s[EVENTS.ERROR], error))
-        resolve()
-      })
-
-      // Event listener for 'close'
-      wsInstances[url].addEventListener('close', () => {
-        delete wsInstances[url]
-      })
-
-      // After the WebSocket connection is open, add the event listeners.
-      // Wait for the subscription confirmation message before resolving.
-      wsInstances[url].addEventListener('message', ({ data }) => {
-        const dataParsed = JSON.parse(data)
-        const listeners = subscriptions[dataParsed.id]
-
-        if (!listeners) {
-          warn('Message received for closed or unknown subscription with ID', dataParsed.id)
-
-          return
-        }
-
-        if (dataParsed.type === MESSAGE_TYPES.SUBSCRIBE) {
-          notify(listeners[EVENTS.OPEN])
-          // Resolve the promise after the subscription confirmation message.
-          listeners._resolver()
-        }
-
-        if (dataParsed.type === MESSAGE_TYPES.ERROR) {
-          notify(listeners[EVENTS.ERROR], dataParsed)
-        }
-
-        if (dataParsed.type === MESSAGE_TYPES.PUBLISH) {
-          notify(listeners[EVENTS.MESSAGE], dataParsed.event)
-        }
-
-        if (dataParsed.type === MESSAGE_TYPES.UNSUBSCRIBE) {
-          notify(listeners[EVENTS.CLOSE], closeRequested)
-          // Remove the subscription.
-          delete subscriptions[dataParsed.id]
-          if (!Object.values(subscriptions).some(s => s.url === url)) {
-            wsInstances[url].close()
-          }
-        }
-      })
-    } else if (wsInstances[url] && wsInstances[url].readyState === WebSocket.OPEN) {
-      // If the WebSocket connection is already open, only add the subscription.
-      wsInstances[url].send(subscriptionPayload)
-    }
-  })
+          .forEach(s => notify(s[EVENTS.ERROR], err))
+        reject(err)
+      }
+    }),
+    new Promise((resolve, reject) => setTimeout(() => reject(new Error('timeout')), timeout)),
+  ])
 
   // Return an observer object with the `on` and `close` functions for
   // the current subscription.


### PR DESCRIPTION
#### Summary
This PR fixes error handling and reconnection logic of event streams.

#### Changes

- Convert stream errors to error objects
- Implement a timeout for WebSocket connection attempts
- Fix checks that determine whether reconnects should be attempted

#### Testing

Local testing.

#### Notes for Reviewers

This is a somewhat preliminary fix to get the reconnects working again. Error handling in general needs some more love since error propagation is now quite different under the WebSocket logic than it has been before. Concretely we should look into how to identify special errors such as authentication and network errors when using the WebSocket connection to apply special logic in these cases.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
