### PR TITLE
Dropdown V2 improvements

### DIFF
--- a/pkg/webui/components/button-v2/button.styl
+++ b/pkg/webui/components/button-v2/button.styl
@@ -115,5 +115,3 @@
 .icon
   margin-left: - $cs.xxs
 
-.dropdown
-  top: -4.3rem

--- a/pkg/webui/components/button-v2/index.js
+++ b/pkg/webui/components/button-v2/index.js
@@ -121,7 +121,7 @@ const Button = forwardRef((props, ref) => {
       else document.removeEventListener('mousedown', handleClickOutside)
       return newState
     })
-  }, [])
+  }, [handleClickOutside])
 
   const handleClick = useCallback(
     evt => {

--- a/pkg/webui/components/button-v2/story.js
+++ b/pkg/webui/components/button-v2/story.js
@@ -51,7 +51,7 @@ export const PrimayDropdown = () => {
   const ref = useRef()
 
   return (
-    <div style={{ textAlign: 'center', height: '6rem' }}>
+    <div style={{ textAlign: 'center', height: '6rem', paddingTop: '4rem' }}>
       <Button primary icon="favorite" message="Dropdown" ref={ref} dropdownItems={dropdownItems} />
     </div>
   )
@@ -61,7 +61,7 @@ export const PrimayOnlyIconDropdown = () => {
   const ref = useRef()
 
   return (
-    <div style={{ textAlign: 'center', height: '6rem' }}>
+    <div style={{ textAlign: 'center', height: '6rem', paddingTop: '4rem' }}>
       <Button primary icon="favorite" dropdownItems={dropdownItems} ref={ref} />
     </div>
   )
@@ -89,7 +89,7 @@ export const SecondaryDropdown = () => {
   const ref = useRef()
 
   return (
-    <div style={{ textAlign: 'center', height: '6rem' }}>
+    <div style={{ textAlign: 'center', height: '6rem', paddingTop: '4rem' }}>
       <Button
         secondary
         icon="favorite"
@@ -105,7 +105,7 @@ export const SecondaryOnlyIconDropdown = () => {
   const ref = useRef()
 
   return (
-    <div style={{ textAlign: 'center', height: '6rem' }}>
+    <div style={{ textAlign: 'center', height: '6rem', paddingTop: '4rem' }}>
       <Button secondary icon="favorite" dropdownItems={dropdownItems} ref={ref} />
     </div>
   )

--- a/pkg/webui/components/dropdown-v2/dropdown.styl
+++ b/pkg/webui/components/dropdown-v2/dropdown.styl
@@ -20,13 +20,33 @@ ul.dropdown
   border: 1px solid $c.grey-200
   background: $c.white
   box-shadow: 0px 3px 16px 0px rgba(0, 0, 0, 0.06)
-  z-index: $zi.nav
-  right: 0
   position: absolute
   padding: $cs.xs
   min-width: 14rem
   z-index: $zi.dropdown
   margin: $cs.xxs 0 0
+
+  &.below
+    bottom: auto
+    top: calc(100% + 2px)
+
+  &.above
+    top: auto
+    bottom: calc(100% + 2px)
+
+  &.left
+    left: 0
+    right: auto
+
+  &.right
+    right: 0
+    left: auto
+
+  &.example
+    bottom: auto
+    top: 0
+    left: 0
+    right: auto
 
   &.larger
     li.dropdown-item

--- a/pkg/webui/components/dropdown-v2/dropdown.styl
+++ b/pkg/webui/components/dropdown-v2/dropdown.styl
@@ -54,9 +54,8 @@ ul.dropdown
         padding: $cs.l
 
   hr
-    margin-top: 0
-    height: .1rem
-    background-color: $c-divider
+    height: 1px
+    background-color: $c['grey-200']
 
   li.dropdown-header-item
     display: block
@@ -102,6 +101,8 @@ ul.dropdown
 
       &:hover
         color: $tc-deep-gray
+        background: $c.tts-primary-150
+        transition: background 0.2s ease
 
         .icon
           color: $tc-deep-gray

--- a/pkg/webui/components/dropdown-v2/story.js
+++ b/pkg/webui/components/dropdown-v2/story.js
@@ -24,11 +24,13 @@ export default {
 }
 
 export const Default = () => (
-  <div style={{ height: '6rem' }}>
+  <div style={{ height: '8rem' }}>
     <Dropdown className={style.example}>
       <Dropdown.HeaderItem title={'dropdown items'} />
-      <Dropdown.Item title={'Example'} path={'example/path'} icon="favorite" />
-      <Dropdown.Item title={'Add'} path={'add/path'} icon="add" />
+      <Dropdown.Item title={'Profile Settings'} path={'profile/path'} icon="person" />
+      <Dropdown.Item title={'Admin panel'} path={'admin/path'} icon="admin_panel_settings" />
+      <hr />
+      <Dropdown.Item title={'Logout'} path={'logout/path'} icon="logout" />
     </Dropdown>
   </div>
 )

--- a/pkg/webui/components/dropdown-v2/story.js
+++ b/pkg/webui/components/dropdown-v2/story.js
@@ -14,6 +14,8 @@
 
 import React from 'react'
 
+import style from './dropdown.styl'
+
 import Dropdown from '.'
 
 export default {
@@ -23,7 +25,7 @@ export default {
 
 export const Default = () => (
   <div style={{ height: '6rem' }}>
-    <Dropdown>
+    <Dropdown className={style.example}>
       <Dropdown.HeaderItem title={'dropdown items'} />
       <Dropdown.Item title={'Example'} path={'example/path'} icon="favorite" />
       <Dropdown.Item title={'Add'} path={'add/path'} icon="add" />


### PR DESCRIPTION
#### Summary
Improve dropdown positioning. If there is no screen available for the dropdown menu, position it on the opposite side. Default positioning is bottom left.

#### Changes

Added `useEffect` in dropdown-v2 component which decides where to place the menu based on the screen space available. Also updated some styling to match the style on [Figma](https://www.figma.com/file/7pBLWK4tsjoAbyJq2viMAQ/2023-console-redesign?type=design&node-id=1549-17628&mode=design&t=gj0pm2j4w2nHch4c-0).
![image](https://github.com/TheThingsNetwork/lorawan-stack/assets/49171937/eee26f6c-cc20-4493-8020-c7d0f6da2494)
![image](https://github.com/TheThingsNetwork/lorawan-stack/assets/49171937/121e918d-b840-42fc-beeb-b665ca3bc61a)


#### Testing

1. Run storybook.
2. Check `Dropdown V2` and `Button V2` components.

#### Notes for Reviewers
To distinguish whether we want to show drop up or drop down arrow on the button, we cannot know if the screen space available is going to be enough for the dropdown menu because when it's not open it's not rendered in the DOM. The only solution for edge cases(ex. the button is on the bottom of the side bar menu) would be to send prop to the button v2 component for explicitly setting the arrow icon.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
