### PR TITLE
Add band served relay backoff

### DIFF
--- a/pkg/band/shared.go
+++ b/pkg/band/shared.go
@@ -50,6 +50,9 @@ type SharedParameters struct {
 	RelayForwardDelay time.Duration
 	// RelayReceiveDelay is the default RxR window timing in seconds.
 	RelayReceiveDelay time.Duration
+	// ServedRelayBackoff is the default number of wake on radio attempts before sending the uplink message directly
+	// by a served relay device.
+	ServedRelayBackoff uint32
 }
 
 var (
@@ -68,6 +71,7 @@ var (
 		parameters := universalSharedParameters
 		parameters.RelayForwardDelay = 50 * time.Millisecond
 		parameters.RelayReceiveDelay = 18 * time.Second
+		parameters.ServedRelayBackoff = 8
 		return parameters
 	}()
 )

--- a/pkg/band/testdata/AS_923_2_RP002_V1_0_1.json
+++ b/pkg/band/testdata/AS_923_2_RP002_V1_0_1.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_2_RP002_V1_0_2.json
+++ b/pkg/band/testdata/AS_923_2_RP002_V1_0_2.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_2_RP002_V1_0_3.json
+++ b/pkg/band/testdata/AS_923_2_RP002_V1_0_3.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_2_RP002_V1_0_4.json
+++ b/pkg/band/testdata/AS_923_2_RP002_V1_0_4.json
@@ -710,6 +710,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/AS_923_3_RP002_V1_0_1.json
+++ b/pkg/band/testdata/AS_923_3_RP002_V1_0_1.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_3_RP002_V1_0_2.json
+++ b/pkg/band/testdata/AS_923_3_RP002_V1_0_2.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_3_RP002_V1_0_3.json
+++ b/pkg/band/testdata/AS_923_3_RP002_V1_0_3.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_3_RP002_V1_0_4.json
+++ b/pkg/band/testdata/AS_923_3_RP002_V1_0_4.json
@@ -710,6 +710,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/AS_923_4_RP002_V1_0_3.json
+++ b/pkg/band/testdata/AS_923_4_RP002_V1_0_3.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_4_RP002_V1_0_4.json
+++ b/pkg/band/testdata/AS_923_4_RP002_V1_0_4.json
@@ -710,6 +710,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/AS_923_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/AS_923_PHY_V1_0_2_REV_A.json
@@ -702,6 +702,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/AS_923_PHY_V1_0_2_REV_B.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/AS_923_PHY_V1_0_3_REV_A.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/AS_923_PHY_V1_1_REV_A.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/AS_923_PHY_V1_1_REV_B.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_RP002_V1_0_0.json
+++ b/pkg/band/testdata/AS_923_RP002_V1_0_0.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_RP002_V1_0_1.json
+++ b/pkg/band/testdata/AS_923_RP002_V1_0_1.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_RP002_V1_0_2.json
+++ b/pkg/band/testdata/AS_923_RP002_V1_0_2.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_RP002_V1_0_3.json
+++ b/pkg/band/testdata/AS_923_RP002_V1_0_3.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AS_923_RP002_V1_0_4.json
+++ b/pkg/band/testdata/AS_923_RP002_V1_0_4.json
@@ -710,6 +710,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/AU_915_928_PHY_V1_0_1.json
+++ b/pkg/band/testdata/AU_915_928_PHY_V1_0_1.json
@@ -926,6 +926,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AU_915_928_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/AU_915_928_PHY_V1_0_2_REV_A.json
@@ -926,6 +926,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AU_915_928_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/AU_915_928_PHY_V1_0_2_REV_B.json
@@ -996,6 +996,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AU_915_928_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/AU_915_928_PHY_V1_0_3_REV_A.json
@@ -1001,6 +1001,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AU_915_928_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/AU_915_928_PHY_V1_1_REV_A.json
@@ -996,6 +996,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AU_915_928_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/AU_915_928_PHY_V1_1_REV_B.json
@@ -1000,6 +1000,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AU_915_928_RP002_V1_0_0.json
+++ b/pkg/band/testdata/AU_915_928_RP002_V1_0_0.json
@@ -1000,6 +1000,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AU_915_928_RP002_V1_0_1.json
+++ b/pkg/band/testdata/AU_915_928_RP002_V1_0_1.json
@@ -1000,6 +1000,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AU_915_928_RP002_V1_0_2.json
+++ b/pkg/band/testdata/AU_915_928_RP002_V1_0_2.json
@@ -1024,6 +1024,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AU_915_928_RP002_V1_0_3.json
+++ b/pkg/band/testdata/AU_915_928_RP002_V1_0_3.json
@@ -1024,6 +1024,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/AU_915_928_RP002_V1_0_4.json
+++ b/pkg/band/testdata/AU_915_928_RP002_V1_0_4.json
@@ -1035,6 +1035,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_0.json
+++ b/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_0.json
@@ -1112,6 +1112,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_1.json
@@ -1123,6 +1123,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_2.json
@@ -1123,6 +1123,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_3.json
@@ -1123,6 +1123,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_4.json
+++ b/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_4.json
@@ -1134,6 +1134,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_0.json
+++ b/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_0.json
@@ -1112,6 +1112,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_1.json
@@ -1123,6 +1123,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_2.json
@@ -1123,6 +1123,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_3.json
@@ -1123,6 +1123,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_4.json
+++ b/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_4.json
@@ -1134,6 +1134,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_0.json
+++ b/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_0.json
@@ -836,6 +836,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_1.json
@@ -847,6 +847,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_2.json
@@ -847,6 +847,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_3.json
@@ -847,6 +847,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_4.json
+++ b/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_4.json
@@ -858,6 +858,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_0.json
+++ b/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_0.json
@@ -836,6 +836,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_1.json
@@ -847,6 +847,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_2.json
@@ -847,6 +847,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_3.json
@@ -847,6 +847,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_4.json
+++ b/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_4.json
@@ -858,6 +858,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/CN_470_510_PHY_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_PHY_V1_0_1.json
@@ -1210,6 +1210,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/CN_470_510_PHY_V1_0_2_REV_A.json
@@ -1210,6 +1210,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/CN_470_510_PHY_V1_0_2_REV_B.json
@@ -1210,6 +1210,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/CN_470_510_PHY_V1_0_3_REV_A.json
@@ -1210,6 +1210,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/CN_470_510_PHY_V1_1_REV_A.json
@@ -1210,6 +1210,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_470_510_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/CN_470_510_PHY_V1_1_REV_B.json
@@ -1210,6 +1210,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_779_787_PHY_V1_0.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_0.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_779_787_PHY_V1_0_1.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_0_1.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_779_787_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_0_2_REV_A.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_779_787_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_0_2_REV_B.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_779_787_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_0_3_REV_A.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_779_787_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_1_REV_A.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_779_787_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_1_REV_B.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_779_787_RP002_V1_0_0.json
+++ b/pkg/band/testdata/CN_779_787_RP002_V1_0_0.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_779_787_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_779_787_RP002_V1_0_1.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_779_787_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_779_787_RP002_V1_0_2.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/CN_779_787_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_779_787_RP002_V1_0_3.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_433_PHY_V1_0.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_0.json
@@ -552,6 +552,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_433_PHY_V1_0_1.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_0_1.json
@@ -552,6 +552,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_433_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_0_2_REV_A.json
@@ -552,6 +552,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_433_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_0_2_REV_B.json
@@ -552,6 +552,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_433_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_0_3_REV_A.json
@@ -552,6 +552,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_433_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_1_REV_A.json
@@ -552,6 +552,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_433_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_1_REV_B.json
@@ -552,6 +552,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_433_RP002_V1_0_0.json
+++ b/pkg/band/testdata/EU_433_RP002_V1_0_0.json
@@ -552,6 +552,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_433_RP002_V1_0_1.json
+++ b/pkg/band/testdata/EU_433_RP002_V1_0_1.json
@@ -552,6 +552,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_433_RP002_V1_0_2.json
+++ b/pkg/band/testdata/EU_433_RP002_V1_0_2.json
@@ -552,6 +552,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_433_RP002_V1_0_3.json
+++ b/pkg/band/testdata/EU_433_RP002_V1_0_3.json
@@ -552,6 +552,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_433_RP002_V1_0_4.json
+++ b/pkg/band/testdata/EU_433_RP002_V1_0_4.json
@@ -552,6 +552,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/EU_863_870_PHY_V1_0.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_0.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_863_870_PHY_V1_0_1.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_0_1.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_863_870_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_0_2_REV_A.json
@@ -582,6 +582,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_863_870_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_0_2_REV_B.json
@@ -584,6 +584,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_863_870_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_0_3_REV_A.json
@@ -584,6 +584,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_863_870_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_1_REV_A.json
@@ -584,6 +584,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_863_870_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_1_REV_B.json
@@ -584,6 +584,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_863_870_RP002_V1_0_0.json
+++ b/pkg/band/testdata/EU_863_870_RP002_V1_0_0.json
@@ -584,6 +584,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_863_870_RP002_V1_0_1.json
+++ b/pkg/band/testdata/EU_863_870_RP002_V1_0_1.json
@@ -584,6 +584,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_863_870_RP002_V1_0_2.json
+++ b/pkg/band/testdata/EU_863_870_RP002_V1_0_2.json
@@ -680,6 +680,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_863_870_RP002_V1_0_3.json
+++ b/pkg/band/testdata/EU_863_870_RP002_V1_0_3.json
@@ -680,6 +680,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/EU_863_870_RP002_V1_0_4.json
+++ b/pkg/band/testdata/EU_863_870_RP002_V1_0_4.json
@@ -691,6 +691,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/IN_865_867_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/IN_865_867_PHY_V1_0_2_REV_B.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/IN_865_867_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/IN_865_867_PHY_V1_0_3_REV_A.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/IN_865_867_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/IN_865_867_PHY_V1_1_REV_A.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/IN_865_867_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/IN_865_867_PHY_V1_1_REV_B.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/IN_865_867_RP002_V1_0_0.json
+++ b/pkg/band/testdata/IN_865_867_RP002_V1_0_0.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/IN_865_867_RP002_V1_0_1.json
+++ b/pkg/band/testdata/IN_865_867_RP002_V1_0_1.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/IN_865_867_RP002_V1_0_2.json
+++ b/pkg/band/testdata/IN_865_867_RP002_V1_0_2.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/IN_865_867_RP002_V1_0_3.json
+++ b/pkg/band/testdata/IN_865_867_RP002_V1_0_3.json
@@ -704,6 +704,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/IN_865_867_RP002_V1_0_4.json
+++ b/pkg/band/testdata/IN_865_867_RP002_V1_0_4.json
@@ -715,6 +715,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/ISM_2400_PHY_V1_0.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_0.json
@@ -556,6 +556,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/ISM_2400_PHY_V1_0_1.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_0_1.json
@@ -556,6 +556,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/ISM_2400_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_0_2_REV_A.json
@@ -556,6 +556,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/ISM_2400_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_0_2_REV_B.json
@@ -556,6 +556,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/ISM_2400_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_0_3_REV_A.json
@@ -556,6 +556,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/ISM_2400_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_1_REV_A.json
@@ -556,6 +556,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/ISM_2400_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_1_REV_B.json
@@ -556,6 +556,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/ISM_2400_RP002_V1_0_0.json
+++ b/pkg/band/testdata/ISM_2400_RP002_V1_0_0.json
@@ -556,6 +556,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/ISM_2400_RP002_V1_0_1.json
+++ b/pkg/band/testdata/ISM_2400_RP002_V1_0_1.json
@@ -556,6 +556,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/ISM_2400_RP002_V1_0_2.json
+++ b/pkg/band/testdata/ISM_2400_RP002_V1_0_2.json
@@ -556,6 +556,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/ISM_2400_RP002_V1_0_3.json
+++ b/pkg/band/testdata/ISM_2400_RP002_V1_0_3.json
@@ -556,6 +556,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/ISM_2400_RP002_V1_0_4.json
+++ b/pkg/band/testdata/ISM_2400_RP002_V1_0_4.json
@@ -556,6 +556,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/KR_920_923_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/KR_920_923_PHY_V1_0_2_REV_A.json
@@ -505,6 +505,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/KR_920_923_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/KR_920_923_PHY_V1_0_2_REV_B.json
@@ -506,6 +506,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/KR_920_923_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/KR_920_923_PHY_V1_0_3_REV_A.json
@@ -506,6 +506,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/KR_920_923_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/KR_920_923_PHY_V1_1_REV_A.json
@@ -506,6 +506,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/KR_920_923_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/KR_920_923_PHY_V1_1_REV_B.json
@@ -506,6 +506,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/KR_920_923_RP002_V1_0_0.json
+++ b/pkg/band/testdata/KR_920_923_RP002_V1_0_0.json
@@ -506,6 +506,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/KR_920_923_RP002_V1_0_1.json
+++ b/pkg/band/testdata/KR_920_923_RP002_V1_0_1.json
@@ -506,6 +506,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/KR_920_923_RP002_V1_0_2.json
+++ b/pkg/band/testdata/KR_920_923_RP002_V1_0_2.json
@@ -506,6 +506,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/KR_920_923_RP002_V1_0_3.json
+++ b/pkg/band/testdata/KR_920_923_RP002_V1_0_3.json
@@ -506,6 +506,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/KR_920_923_RP002_V1_0_4.json
+++ b/pkg/band/testdata/KR_920_923_RP002_V1_0_4.json
@@ -517,6 +517,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_0.json
+++ b/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_0.json
@@ -614,6 +614,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_0_1.json
+++ b/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_0_1.json
@@ -614,6 +614,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_0_2_REV_A.json
@@ -614,6 +614,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_0_2_REV_B.json
@@ -614,6 +614,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_0_3_REV_A.json
@@ -614,6 +614,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_1_REV_A.json
@@ -614,6 +614,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/MA_869_870_DRAFT_PHY_V1_1_REV_B.json
@@ -614,6 +614,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/MA_869_870_DRAFT_RP002_V1_0_0.json
+++ b/pkg/band/testdata/MA_869_870_DRAFT_RP002_V1_0_0.json
@@ -614,6 +614,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/MA_869_870_DRAFT_RP002_V1_0_1.json
+++ b/pkg/band/testdata/MA_869_870_DRAFT_RP002_V1_0_1.json
@@ -614,6 +614,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/MA_869_870_DRAFT_RP002_V1_0_2.json
+++ b/pkg/band/testdata/MA_869_870_DRAFT_RP002_V1_0_2.json
@@ -614,6 +614,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/MA_869_870_DRAFT_RP002_V1_0_3.json
+++ b/pkg/band/testdata/MA_869_870_DRAFT_RP002_V1_0_3.json
@@ -614,6 +614,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/MA_869_870_DRAFT_RP002_V1_0_4.json
+++ b/pkg/band/testdata/MA_869_870_DRAFT_RP002_V1_0_4.json
@@ -614,6 +614,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/RU_864_870_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/RU_864_870_PHY_V1_0_3_REV_A.json
@@ -544,6 +544,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/RU_864_870_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/RU_864_870_PHY_V1_1_REV_A.json
@@ -544,6 +544,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/RU_864_870_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/RU_864_870_PHY_V1_1_REV_B.json
@@ -544,6 +544,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/RU_864_870_RP002_V1_0_0.json
+++ b/pkg/band/testdata/RU_864_870_RP002_V1_0_0.json
@@ -544,6 +544,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/RU_864_870_RP002_V1_0_1.json
+++ b/pkg/band/testdata/RU_864_870_RP002_V1_0_1.json
@@ -544,6 +544,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/RU_864_870_RP002_V1_0_2.json
+++ b/pkg/band/testdata/RU_864_870_RP002_V1_0_2.json
@@ -544,6 +544,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/RU_864_870_RP002_V1_0_3.json
+++ b/pkg/band/testdata/RU_864_870_RP002_V1_0_3.json
@@ -544,6 +544,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/RU_864_870_RP002_V1_0_4.json
+++ b/pkg/band/testdata/RU_864_870_RP002_V1_0_4.json
@@ -555,6 +555,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }

--- a/pkg/band/testdata/US_902_928_PHY_V1_0.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0.json
@@ -932,6 +932,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/US_902_928_PHY_V1_0_1.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0_1.json
@@ -932,6 +932,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/US_902_928_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0_2_REV_A.json
@@ -932,6 +932,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/US_902_928_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0_2_REV_B.json
@@ -932,6 +932,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/US_902_928_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0_3_REV_A.json
@@ -937,6 +937,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/US_902_928_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_1_REV_A.json
@@ -936,6 +936,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/US_902_928_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_1_REV_B.json
@@ -936,6 +936,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_0.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_0.json
@@ -936,6 +936,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_1.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_1.json
@@ -936,6 +936,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_2.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_2.json
@@ -976,6 +976,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_3.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_3.json
@@ -976,6 +976,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 0,
-    "RelayReceiveDelay": 0
+    "RelayReceiveDelay": 0,
+    "ServedRelayBackoff": 0
   }
 }

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_4.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_4.json
@@ -987,6 +987,7 @@
     "MinRetransmitTimeout": 1000000000,
     "MaxRetransmitTimeout": 3000000000,
     "RelayForwardDelay": 50000000,
-    "RelayReceiveDelay": 18000000000
+    "RelayReceiveDelay": 18000000000,
+    "ServedRelayBackoff": 8
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/6721

_This PR exists in order to make reviewing the PR above more easier to go through._

#### Changes

<!-- What are the changes made in this pull request? -->

- Add the default wake on radio frame backoff to the band definitions, as it is defined in RP2.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

N/A.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

N/A.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
