### PR TITLE
Fix documentation link to bulk import devices

### DIFF
--- a/pkg/webui/console/components/device-import-form/index.js
+++ b/pkg/webui/console/components/device-import-form/index.js
@@ -116,7 +116,7 @@ const DeviceBulkCreateFormInner = props => {
         className={style.info}
         values={{
           DocLink: msg => (
-            <Link.DocLink secondary path="/the-things-stack/migrating/import-devices/">
+            <Link.DocLink secondary path="/devices/adding-devices/adding-devices-in-bulk">
               {msg}
             </Link.DocLink>
           ),

--- a/pkg/webui/console/containers/device-importer/processor.js
+++ b/pkg/webui/console/containers/device-importer/processor.js
@@ -44,7 +44,7 @@ const statusMap = {
 }
 
 const docLinkValue = msg => (
-  <Link.DocLink secondary path="/the-thing-stack/migrating/import-devices/">
+  <Link.DocLink secondary path="/devices/adding-devices/adding-devices-in-bulk">
     {msg}
   </Link.DocLink>
 )


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-docs/pull/1227

#### Changes

<!-- What are the changes made in this pull request? -->

Fix link to adding devices in bulk documentation page.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Go to an application
2. Click import end devices
3. Click the documentation link
4. It should not 404

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

N/A

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

With the aforementioned documentation PR merged, there's no more 404, but the Console should use the right page to avoid unnecessary redirects.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
