### PR TITLE
Fix race condition in stream opening

### DIFF
--- a/pkg/webui/console/store/middleware/logics/events.js
+++ b/pkg/webui/console/store/middleware/logics/events.js
@@ -275,6 +275,7 @@ const createEventsConnectLogics = (reducerName, entityName, onEventsStart) => {
     }),
     createLogic({
       type: SET_EVENT_FILTER,
+      debounce: 250,
       process: async ({ action }, dispatch, done) => {
         if (channel) {
           try {

--- a/sdk/js/src/api/stream/subscribeToWebSocketStream.js
+++ b/sdk/js/src/api/stream/subscribeToWebSocketStream.js
@@ -20,6 +20,7 @@ import { notify, EVENTS, MESSAGE_TYPES } from './shared'
 const wsInstances = {}
 let subscriptions = {}
 const initialListeners = Object.values(EVENTS).reduce((acc, curr) => ({ ...acc, [curr]: {} }), {})
+let closeRequested = false
 
 /**
  * Opens a new stream.
@@ -68,7 +69,6 @@ export default async (
     type: MESSAGE_TYPES.UNSUBSCRIBE,
     id: subscriptionId,
   })
-  let closeRequested = false
   const url = baseUrl + endpoint
 
   await Promise.race([

--- a/sdk/js/src/api/stream/subscribeToWebSocketStream.js
+++ b/sdk/js/src/api/stream/subscribeToWebSocketStream.js
@@ -93,11 +93,6 @@ export default async (
             `ttn.lorawan.v3.header.authorization.bearer.${tokenParsed}`,
           ])
 
-          // Event listener for 'open'
-          wsInstances[url].addEventListener('open', () => {
-            wsInstances[url].send(subscriptionPayload)
-          })
-
           // Broadcast connection errors to all listeners.
           wsInstances[url].addEventListener('error', error => {
             Object.values(subscriptions)
@@ -163,9 +158,16 @@ export default async (
               }
             }
           })
-        } else if (wsInstances[url] && wsInstances[url].readyState === WebSocket.OPEN) {
+        }
+
+        if (wsInstances[url] && wsInstances[url].readyState === WebSocket.OPEN) {
           // If the WebSocket connection is already open, only add the subscription.
           wsInstances[url].send(subscriptionPayload)
+        } else if (wsInstances[url] && wsInstances[url].readyState === WebSocket.CONNECTING) {
+          // Otherwise wait for the connection to open and then add the subscription.
+          wsInstances[url].addEventListener('open', () => {
+            wsInstances[url].send(subscriptionPayload)
+          })
         }
       } catch (error) {
         const err = error instanceof Error ? error : new Error(error)


### PR DESCRIPTION

#### Summary
This PR will address a possible race condition in the event stream logic when opening multiple subscriptions in quick succession. It also addresses an unnecessary stream closure event when switching between verbose and normal filtering.

#### Changes

- Make sure to send the subscription message only when the stream has been opened
- Fix wrong scoping of state variable in the stream library

#### Testing

- The underlying issue is somewhat hard to reproduce
- It can happen sometimes when opening a device data page and refreshing the page
- Based on how fast the connections (app events and dev events) are opened there can be a race condition where the device stream tries to send the subscripiton message before the stream was opened

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
