### PR TITLE
Prevent state changes on unmounted components

### DIFF
--- a/pkg/webui/lib/hooks/use-request.js
+++ b/pkg/webui/lib/hooks/use-request.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useDispatch } from 'react-redux'
 
 import attachPromise from '@ttn-lw/lib/store/actions/attach-promise'
@@ -22,6 +22,14 @@ const useRequest = requestAction => {
   const [fetching, setFetching] = useState(true)
   const [error, setError] = useState('')
   const [result, setResult] = useState()
+  const isMounted = useRef(true)
+
+  useEffect(
+    () => () => {
+      isMounted.current = false
+    },
+    [],
+  )
 
   useEffect(() => {
     if (requestAction) {
@@ -33,13 +41,17 @@ const useRequest = requestAction => {
           : dispatch(attachPromise(requestAction))
 
       promise
-        .then(() => {
-          setResult(result)
-          setFetching(false)
+        .then(result => {
+          if (isMounted.current) {
+            setResult(result)
+            setFetching(false)
+          }
         })
         .catch(error => {
-          setError(error)
-          setFetching(false)
+          if (isMounted.current) {
+            setError(error)
+            setFetching(false)
+          }
         })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
#### Summary
This quickfix PR makes sure that components using `FetchTable` and `RequireRequest` are not attempting to do state updates after they've been unmounted, which results in memory leaks and warnings/errors in the browser console.

#### Changes

- Keep track of mounting status and check it before doing state updates

#### Testing

- This is not something that can be observed externally, since this will only result in warnings in the development console (in dev mode), so there's no testing necessary here


#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
