### PR TITLE
Make `contact_info` a read-only field for entities

### DIFF
--- a/pkg/identityserver/application_registry_test.go
+++ b/pkg/identityserver/application_registry_test.go
@@ -176,6 +176,32 @@ func TestApplicationsCRUD(t *testing.T) {
 			a.So(errors.IsPermissionDenied(err), should.BeTrue)
 		}
 
+		// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6804)
+		t.Run("Contact_info fieldmask", func(t *testing.T) { // nolint:paralleltest
+			a, ctx := test.New(t)
+			got, err := reg.Get(ctx, &ttnpb.GetApplicationRequest{
+				ApplicationIds: created.GetIds(),
+				FieldMask:      ttnpb.FieldMask("contact_info"),
+			}, creds)
+			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+				a.So(got.ContactInfo, should.HaveLength, 2)
+				a.So(got.ContactInfo[0].Value, should.Equal, usr1.PrimaryEmailAddress)
+				a.So(got.ContactInfo[0].ContactType, should.Equal, ttnpb.ContactType_CONTACT_TYPE_OTHER)
+				a.So(got.ContactInfo[1].Value, should.Equal, usr1.PrimaryEmailAddress)
+				a.So(got.ContactInfo[1].ContactType, should.Equal, ttnpb.ContactType_CONTACT_TYPE_TECHNICAL)
+			}
+
+			// Testing the `PublicSafe` method, which should not return the contact_info's email address when the caller
+			// does not have the appropriate rights.
+			got, err = reg.Get(ctx, &ttnpb.GetApplicationRequest{
+				ApplicationIds: created.GetIds(),
+				FieldMask:      ttnpb.FieldMask("contact_info"),
+			}, credsWithoutRights)
+			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+				a.So(got.ContactInfo, should.HaveLength, 0)
+			}
+		})
+
 		updated, err := reg.Update(ctx, &ttnpb.UpdateApplicationRequest{
 			Application: &ttnpb.Application{
 				Ids:  created.GetIds(),

--- a/pkg/identityserver/bunstore/end_device_store.go
+++ b/pkg/identityserver/bunstore/end_device_store.go
@@ -328,8 +328,6 @@ func (*endDeviceStore) selectWithFields(q *bun.SelectQuery, fieldMask store.Fiel
 				columns = append(columns, "brand_id", "model_id", "hardware_version", "firmware_version", "band_id")
 			case "attributes":
 				q = q.Relation("Attributes")
-			case "contact_info":
-				q = q.Relation("ContactInfo")
 			case "locations":
 				q = q.Relation("Locations")
 			case "picture":

--- a/pkg/identityserver/bunstore/store_test.go
+++ b/pkg/identityserver/bunstore/store_test.go
@@ -142,13 +142,6 @@ func TestMembershipStore(t *testing.T) {
 	st.TestMembershipStorePagination(t)
 }
 
-func TestContactInfoStore(t *testing.T) {
-	t.Parallel()
-
-	st := storetest.New(t, newTestStore)
-	st.TestContactInfoStoreCRUD(t)
-}
-
 func TestEmailValidationStore(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/identityserver/client_registry_test.go
+++ b/pkg/identityserver/client_registry_test.go
@@ -166,6 +166,32 @@ func TestClientsCRUD(t *testing.T) {
 			a.So(errors.IsPermissionDenied(err), should.BeTrue)
 		}
 
+		// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6804)
+		t.Run("Contact_info fieldmask", func(t *testing.T) { // nolint:paralleltest
+			a, ctx := test.New(t)
+			got, err := reg.Get(ctx, &ttnpb.GetClientRequest{
+				ClientIds: created.GetIds(),
+				FieldMask: ttnpb.FieldMask("contact_info"),
+			}, creds)
+			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+				a.So(got.ContactInfo, should.HaveLength, 2)
+				a.So(got.ContactInfo[0].Value, should.Equal, usr1.PrimaryEmailAddress)
+				a.So(got.ContactInfo[0].ContactType, should.Equal, ttnpb.ContactType_CONTACT_TYPE_OTHER)
+				a.So(got.ContactInfo[1].Value, should.Equal, usr1.PrimaryEmailAddress)
+				a.So(got.ContactInfo[1].ContactType, should.Equal, ttnpb.ContactType_CONTACT_TYPE_TECHNICAL)
+			}
+
+			// Testing the `PublicSafe` method, which should not return the contact_info's email address when the caller
+			// does not have the appropriate rights.
+			got, err = reg.Get(ctx, &ttnpb.GetClientRequest{
+				ClientIds: created.GetIds(),
+				FieldMask: ttnpb.FieldMask("contact_info"),
+			}, credsWithoutRights)
+			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+				a.So(got.ContactInfo, should.HaveLength, 0)
+			}
+		})
+
 		updated, err := reg.Update(ctx, &ttnpb.UpdateClientRequest{
 			Client: &ttnpb.Client{
 				Ids:  created.GetIds(),

--- a/pkg/identityserver/gateway_registry_test.go
+++ b/pkg/identityserver/gateway_registry_test.go
@@ -198,6 +198,32 @@ func TestGatewaysCRUD(t *testing.T) {
 			a.So(errors.IsPermissionDenied(err), should.BeTrue)
 		}
 
+		// TODO: Remove (https://github.com/TheThingsNetwork/lorawan-stack/issues/6804)
+		t.Run("Contact_info fieldmask", func(t *testing.T) { // nolint:paralleltest
+			a, ctx := test.New(t)
+			got, err := reg.Get(ctx, &ttnpb.GetGatewayRequest{
+				GatewayIds: created.GetIds(),
+				FieldMask:  ttnpb.FieldMask("contact_info"),
+			}, creds)
+			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+				a.So(got.ContactInfo, should.HaveLength, 2)
+				a.So(got.ContactInfo[0].Value, should.Equal, usr1.PrimaryEmailAddress)
+				a.So(got.ContactInfo[0].ContactType, should.Equal, ttnpb.ContactType_CONTACT_TYPE_OTHER)
+				a.So(got.ContactInfo[1].Value, should.Equal, usr1.PrimaryEmailAddress)
+				a.So(got.ContactInfo[1].ContactType, should.Equal, ttnpb.ContactType_CONTACT_TYPE_TECHNICAL)
+			}
+
+			// Testing the `PublicSafe` method, which should not return the contact_info's email address when the caller
+			// does not have the appropriate rights.
+			got, err = reg.Get(ctx, &ttnpb.GetGatewayRequest{
+				GatewayIds: created.GetIds(),
+				FieldMask:  ttnpb.FieldMask("contact_info"),
+			}, credsWithoutRights)
+			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+				a.So(got.ContactInfo, should.HaveLength, 0)
+			}
+		})
+
 		updated, err := reg.Update(ctx, &ttnpb.UpdateGatewayRequest{
 			Gateway: &ttnpb.Gateway{
 				Ids:  created.GetIds(),

--- a/pkg/identityserver/registry_search_test.go
+++ b/pkg/identityserver/registry_search_test.go
@@ -320,6 +320,21 @@ func TestRegistrySearchDeletedEntities(t *testing.T) { // nolint:gocyclo
 					a.So(got.Users, should.HaveLength, deletedAmount)
 				}
 			})
+			t.Run("Read ContactInfo", func(t *testing.T) { // nolint:paralleltest
+				a, ctx := test.New(t)
+				got, err := cli.SearchUsers(ctx, &ttnpb.SearchUsersRequest{
+					FieldMask: ttnpb.FieldMask("contact_info"),
+				}, adminUsrCreds)
+				if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+					// The `+2` refers to the two non-deleted users created at the beginning of the test.
+					a.So(got.Users, should.HaveLength, (notDeletedAmount + 2))
+					for _, user := range got.Users {
+						a.So(user.ContactInfo, should.HaveLength, 1)
+						a.So(user.ContactInfo[0].Value, should.Equal, user.Ids.UserId+"@example.com")
+					}
+				}
+			})
+
 		})
 	}, withPrivateTestDatabase(p))
 }

--- a/pkg/identityserver/registry_search_test.go
+++ b/pkg/identityserver/registry_search_test.go
@@ -334,7 +334,6 @@ func TestRegistrySearchDeletedEntities(t *testing.T) { // nolint:gocyclo
 					}
 				}
 			})
-
 		})
 	}, withPrivateTestDatabase(p))
 }

--- a/pkg/identityserver/store/migrations/20240100200000_contact_info_removal.up.sql
+++ b/pkg/identityserver/store/migrations/20240100200000_contact_info_removal.up.sql
@@ -1,0 +1,23 @@
+delete from contact_infos
+where entity_type = 'application'
+;
+--bun:split
+delete from contact_infos
+where entity_type = 'client'
+;
+--bun:split
+delete from contact_infos
+where entity_type = 'end_device'
+;
+--bun:split
+delete from contact_infos
+where entity_type = 'gateway'
+;
+--bun:split
+delete from contact_infos
+where entity_type = 'organization'
+;
+--bun:split
+delete from contact_infos
+where entity_type = 'user'
+;

--- a/pkg/identityserver/storetest/application_store.go
+++ b/pkg/identityserver/storetest/application_store.go
@@ -41,7 +41,7 @@ func (st *StoreTest) TestApplicationStoreCRUD(t *T) {
 	}
 	defer s.Close()
 
-	mask := fieldMask(ttnpb.ApplicationFieldPathsTopLevel...)
+	mask := ttnpb.ExcludeFields(fieldMask(ttnpb.ApplicationFieldPathsTopLevel...), "contact_info")
 
 	var created *ttnpb.Application
 
@@ -335,6 +335,8 @@ func (st *StoreTest) TestApplicationStorePagination(t *T) {
 	}
 	defer s.Close()
 
+	mask := ttnpb.ExcludeFields(fieldMask(ttnpb.ApplicationFieldPathsTopLevel...), "contact_info")
+
 	t.Run("FindApplications_Paginated", func(t *T) {
 		a, ctx := test.New(t)
 
@@ -342,7 +344,7 @@ func (st *StoreTest) TestApplicationStorePagination(t *T) {
 		for _, page := range []uint32{1, 2, 3, 4} {
 			paginateCtx := store.WithPagination(ctx, 2, page, &total)
 
-			got, err := s.FindApplications(paginateCtx, nil, fieldMask(ttnpb.ApplicationFieldPathsTopLevel...))
+			got, err := s.FindApplications(paginateCtx, nil, mask)
 			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
 				if page == 4 {
 					a.So(got, should.HaveLength, 1)

--- a/pkg/identityserver/storetest/client_store.go
+++ b/pkg/identityserver/storetest/client_store.go
@@ -41,7 +41,7 @@ func (st *StoreTest) TestClientStoreCRUD(t *T) {
 	}
 	defer s.Close()
 
-	mask := fieldMask(ttnpb.ClientFieldPathsTopLevel...)
+	mask := ttnpb.ExcludeFields(fieldMask(ttnpb.ClientFieldPathsTopLevel...), "contact_info")
 
 	var created *ttnpb.Client
 
@@ -323,6 +323,8 @@ func (st *StoreTest) TestClientStorePagination(t *T) {
 	}
 	defer s.Close()
 
+	mask := ttnpb.ExcludeFields(fieldMask(ttnpb.ClientFieldPathsTopLevel...), "contact_info")
+
 	t.Run("FindClients_Paginated", func(t *T) {
 		a, ctx := test.New(t)
 
@@ -330,7 +332,7 @@ func (st *StoreTest) TestClientStorePagination(t *T) {
 		for _, page := range []uint32{1, 2, 3, 4} {
 			paginateCtx := store.WithPagination(ctx, 2, page, &total)
 
-			got, err := s.FindClients(paginateCtx, nil, fieldMask(ttnpb.ClientFieldPathsTopLevel...))
+			got, err := s.FindClients(paginateCtx, nil, mask)
 			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
 				if page == 4 {
 					a.So(got, should.HaveLength, 1)

--- a/pkg/identityserver/storetest/gateway_store.go
+++ b/pkg/identityserver/storetest/gateway_store.go
@@ -47,7 +47,7 @@ func (st *StoreTest) TestGatewayStoreCRUD(t *T) {
 	defer s.Close()
 
 	start := time.Now().Truncate(time.Second)
-	mask := fieldMask(ttnpb.GatewayFieldPathsTopLevel...)
+	mask := ttnpb.ExcludeFields(fieldMask(ttnpb.GatewayFieldPathsTopLevel...), "contact_info")
 
 	eui := &types.EUI64{1, 2, 3, 4, 5, 6, 7, 8}
 	antenna := &ttnpb.GatewayAntenna{
@@ -519,6 +519,8 @@ func (st *StoreTest) TestGatewayStorePagination(t *T) {
 	}
 	defer s.Close()
 
+	mask := ttnpb.ExcludeFields(fieldMask(ttnpb.GatewayFieldPathsTopLevel...), "contact_info")
+
 	t.Run("FindGateways_Paginated", func(t *T) {
 		a, ctx := test.New(t)
 
@@ -526,7 +528,7 @@ func (st *StoreTest) TestGatewayStorePagination(t *T) {
 		for _, page := range []uint32{1, 2, 3, 4} {
 			paginateCtx := store.WithPagination(ctx, 2, page, &total)
 
-			got, err := s.FindGateways(paginateCtx, nil, fieldMask(ttnpb.GatewayFieldPathsTopLevel...))
+			got, err := s.FindGateways(paginateCtx, nil, mask)
 			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
 				if page == 4 {
 					a.So(got, should.HaveLength, 1)

--- a/pkg/identityserver/storetest/organization_store.go
+++ b/pkg/identityserver/storetest/organization_store.go
@@ -41,7 +41,7 @@ func (st *StoreTest) TestOrganizationStoreCRUD(t *T) {
 	}
 	defer s.Close()
 
-	mask := fieldMask(ttnpb.OrganizationFieldPathsTopLevel...)
+	mask := ttnpb.ExcludeFields(fieldMask(ttnpb.OrganizationFieldPathsTopLevel...), "contact_info")
 
 	var created *ttnpb.Organization
 
@@ -325,6 +325,8 @@ func (st *StoreTest) TestOrganizationStorePagination(t *T) {
 	}
 	defer s.Close()
 
+	mask := ttnpb.ExcludeFields(fieldMask(ttnpb.OrganizationFieldPathsTopLevel...), "contact_info")
+
 	t.Run("FindOrganizations_Paginated", func(t *T) {
 		a, ctx := test.New(t)
 
@@ -332,7 +334,7 @@ func (st *StoreTest) TestOrganizationStorePagination(t *T) {
 		for _, page := range []uint32{1, 2, 3, 4} {
 			paginateCtx := store.WithPagination(ctx, 2, page, &total)
 
-			got, err := s.FindOrganizations(paginateCtx, nil, fieldMask(ttnpb.OrganizationFieldPathsTopLevel...))
+			got, err := s.FindOrganizations(paginateCtx, nil, mask)
 			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
 				if page == 4 {
 					a.So(got, should.HaveLength, 1)

--- a/pkg/identityserver/storetest/user_store.go
+++ b/pkg/identityserver/storetest/user_store.go
@@ -39,7 +39,7 @@ func (st *StoreTest) TestUserStoreCRUD(t *T) {
 	}
 	defer s.Close()
 
-	mask := fieldMask(ttnpb.UserFieldPathsTopLevel...)
+	mask := ttnpb.ExcludeFields(fieldMask(ttnpb.UserFieldPathsTopLevel...), "contact_info")
 
 	picture := &ttnpb.Picture{
 		Embedded: &ttnpb.Picture_Embedded{
@@ -423,6 +423,8 @@ func (st *StoreTest) TestUserStorePagination(t *T) {
 	}
 	defer s.Close()
 
+	mask := ttnpb.ExcludeFields(fieldMask(ttnpb.UserFieldPathsTopLevel...), "contact_info")
+
 	t.Run("FindUsers_Paginated", func(t *T) {
 		a, ctx := test.New(t)
 
@@ -430,7 +432,7 @@ func (st *StoreTest) TestUserStorePagination(t *T) {
 		for _, page := range []uint32{1, 2, 3, 4} {
 			paginateCtx := store.WithPagination(ctx, 2, page, &total)
 
-			got, err := s.FindUsers(paginateCtx, nil, fieldMask(ttnpb.UserFieldPathsTopLevel...))
+			got, err := s.FindUsers(paginateCtx, nil, mask)
 			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
 				if page == 4 {
 					a.So(got, should.HaveLength, 1)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

OS counterpart of https://github.com/TheThingsIndustries/lorawan-stack/pull/4023

#### Changes

<!-- What are the changes made in this pull request? -->

- Remove calls to contact info store in the following entities: [gateway,organization,user,application,client].
- Add contact_info GET test, matches the values in the administrative/technical contacts.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->


Manual test, unit tests.

<details>
<summary> Test Steps </summary>

Follow the steps below:
1. Login into Console
2. Create one of each entity: `user`,`application`,`gateway`,`client`,`organization`.
2.1. The `administrative_contact` and `technical_contact` are the user who created the entity.
2.2. Command example: `ttn-lw-cli <entity> create --<entity>-id <entity_name> --user-id <user_id>`
3. Perform the following steps for each entity:
3.1. Get entity with `--contact-info` fieldmask. Command: `ttn-lw-cli <entity> get <entity_id> --contact-info`
3.2. List entity with `--contact-info` fieldmask. Command: `ttn-lw-cli <entity> list --contact-info`
3.3. Search entity with `--contact-info` fieldmask. Command: `ttn-lw-cli <entity> search --contact-info`
3.4. Attempt to create an entity with a specified `contact_info`. 
    - Contact Info should still be filled with admin/tech contacts when fetched. (same as step 3.1)

Example of an application with a different contact_info for the step `3.4`:
```json
{
  "ids": {
    "application_id": "app-1"
  },
  "contact_info": [
    {
      "contact_type": "CONTACT_TYPE_TECHNICAL",
      "contact_method": "CONTACT_METHOD_EMAIL",
      "value": "test-1@email.com"
    }
  ]
}
```

Observation:
For the `user` entity the `ContactInfo` returned is only composed of the user's primary email address.

</details>

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

This removes the contact_info operations for all entities. Replacing the contact_info registry with the email_validation registry. 

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->


#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
