### PR TITLE
Add copyright header year check for new files

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Fetch base ref
+        run: git fetch origin ${{ github.base_ref }}
       - name: Install Go and Dependencies
         uses: ./.github/actions/install-go-and-deps
       - name: Build Mage
@@ -17,7 +19,7 @@ jobs:
       - name: Install Node and Dependencies
         uses: ./.github/actions/install-node-and-deps
       - name: Check headers
-        run: tools/bin/mage headers:check
+        run: tools/bin/mage headers:check headers:checkNewFiles
       - name: Fix common spelling mistakes
         run: tools/bin/mage dev:misspell
       - name: Format SQL files


### PR DESCRIPTION
#### Summary

This PR adds a new mage target and amends the code-quality workflow file to make sure that all newly introduced files use the copyright header with the correct year.

#### Changes

- Add mage target `mage headers:checkNewFiles`
- Improve error logging of header targets so they can appear in the PR diff directly
- Add target to the code quality workflow so that it runs for each new PR

#### Notes for Reviewers

I'm getting tired of annotating this every other PR. We could even add a target that automatically fixes this, but that would result in an additional commit.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
