### PR TITLE
Add `admin|tech` contact validation on collaborator removal

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -5903,6 +5903,15 @@
       "file": "client_access.go"
     }
   },
+  "error:pkg/identityserver:collaborator_is_contact": {
+    "translations": {
+      "en": "collaborator `{collaborator_id}` is used as a contact"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/identityserver:common_password": {
     "translations": {
       "en": "must not be too common"

--- a/pkg/identityserver/application_access.go
+++ b/pkg/identityserver/application_access.go
@@ -23,6 +23,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -448,8 +449,8 @@ func (is *IdentityServer) deleteApplicationCollaborator(
 		if err != nil {
 			return err
 		}
-		if app.GetAdministrativeContact().IDString() == req.GetCollaboratorIds().IDString() ||
-			app.GetTechnicalContact().IDString() == req.GetCollaboratorIds().IDString() {
+		if proto.Equal(app.GetAdministrativeContact(), req.GetCollaboratorIds()) ||
+			proto.Equal(app.GetTechnicalContact(), req.GetCollaboratorIds()) {
 			return errCollaboratorIsContact.WithAttributes("collaborator_id", req.GetCollaboratorIds().IDString())
 		}
 		if removedRights.Implied().IncludesAll(ttnpb.Right_RIGHT_APPLICATION_ALL) {

--- a/pkg/identityserver/client_access.go
+++ b/pkg/identityserver/client_access.go
@@ -241,6 +241,18 @@ func (is *IdentityServer) deleteClientCollaborator(
 		if err != nil {
 			return err
 		}
+		clt, err := st.GetClient(
+			ctx,
+			req.GetClientIds(),
+			store.FieldMask([]string{"administrative_contact", "technical_contact"}),
+		)
+		if err != nil {
+			return err
+		}
+		if clt.GetAdministrativeContact().IDString() == req.GetCollaboratorIds().IDString() ||
+			clt.GetTechnicalContact().IDString() == req.GetCollaboratorIds().IDString() {
+			return errCollaboratorIsContact.WithAttributes("collaborator_id", req.GetCollaboratorIds().IDString())
+		}
 		if removedRights.Implied().IncludesAll(ttnpb.Right_RIGHT_CLIENT_ALL) {
 			memberRights, err := st.FindMembers(ctx, req.GetClientIds().GetEntityIdentifiers())
 			if err != nil {

--- a/pkg/identityserver/client_access.go
+++ b/pkg/identityserver/client_access.go
@@ -23,6 +23,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -249,8 +250,8 @@ func (is *IdentityServer) deleteClientCollaborator(
 		if err != nil {
 			return err
 		}
-		if clt.GetAdministrativeContact().IDString() == req.GetCollaboratorIds().IDString() ||
-			clt.GetTechnicalContact().IDString() == req.GetCollaboratorIds().IDString() {
+		if proto.Equal(clt.GetAdministrativeContact(), req.GetCollaboratorIds()) ||
+			proto.Equal(clt.GetTechnicalContact(), req.GetCollaboratorIds()) {
 			return errCollaboratorIsContact.WithAttributes("collaborator_id", req.GetCollaboratorIds().IDString())
 		}
 		if removedRights.Implied().IncludesAll(ttnpb.Right_RIGHT_CLIENT_ALL) {

--- a/pkg/identityserver/client_access_test.go
+++ b/pkg/identityserver/client_access_test.go
@@ -246,3 +246,54 @@ func TestClientAccessClusterAuth(t *testing.T) {
 		}
 	}, withPrivateTestDatabase(p))
 }
+
+func TestClientContactRestrictions(t *testing.T) {
+	p := &storetest.Population{}
+
+	usr1 := p.NewUser()
+	usr1Key, _ := p.NewAPIKey(usr1.GetEntityIdentifiers(), ttnpb.Right_RIGHT_ALL)
+	usr1Creds := rpcCreds(usr1Key)
+
+	gtw1 := p.NewClient(usr1.GetOrganizationOrUserIdentifiers())
+
+	usr2 := p.NewUser()
+	p.NewMembership(
+		usr2.GetOrganizationOrUserIdentifiers(),
+		gtw1.GetEntityIdentifiers(),
+		ttnpb.Right_RIGHT_CLIENT_INFO,
+	)
+	// Set the user as administrative contact for the client.
+	gtw1.AdministrativeContact = usr2.GetOrganizationOrUserIdentifiers()
+
+	t.Parallel()
+	a, ctx := test.New(t)
+
+	testWithIdentityServer(t, func(is *IdentityServer, cc *grpc.ClientConn) {
+		regClt := ttnpb.NewClientRegistryClient(cc)
+		accessClt := ttnpb.NewClientAccessClient(cc)
+
+		// Attempt to delete a collaborator that is an administrative contact.
+		_, err := accessClt.DeleteCollaborator(ctx, &ttnpb.DeleteClientCollaboratorRequest{
+			ClientIds:       gtw1.Ids,
+			CollaboratorIds: usr2.GetOrganizationOrUserIdentifiers(),
+		}, usr1Creds)
+		a.So(errors.IsFailedPrecondition(err), should.BeTrue)
+
+		// Change the administrative contact.
+		_, err = regClt.Update(ctx, &ttnpb.UpdateClientRequest{
+			Client: &ttnpb.Client{
+				Ids:                   gtw1.Ids,
+				AdministrativeContact: usr1.GetOrganizationOrUserIdentifiers(),
+			},
+			FieldMask: ttnpb.FieldMask("administrative_contact"),
+		}, usr1Creds)
+		a.So(err, should.BeNil)
+
+		// Attempt to delete a collaborator that is an administrative contact.
+		_, err = accessClt.DeleteCollaborator(ctx, &ttnpb.DeleteClientCollaboratorRequest{
+			ClientIds:       gtw1.Ids,
+			CollaboratorIds: usr2.GetOrganizationOrUserIdentifiers(),
+		}, usr1Creds)
+		a.So(err, should.BeNil)
+	}, withPrivateTestDatabase(p))
+}

--- a/pkg/identityserver/errors.go
+++ b/pkg/identityserver/errors.go
@@ -1,0 +1,21 @@
+// Copyright © 2024 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identityserver
+
+import "go.thethings.network/lorawan-stack/v3/pkg/errors"
+
+var errCollaboratorIsContact = errors.DefineFailedPrecondition(
+	"collaborator_is_contact", "collaborator `{collaborator_id}` is used as a contact",
+)

--- a/pkg/identityserver/gateway_access.go
+++ b/pkg/identityserver/gateway_access.go
@@ -23,6 +23,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -435,8 +436,8 @@ func (is *IdentityServer) deleteGatewayCollaborator(
 		if err != nil {
 			return err
 		}
-		if gtw.GetAdministrativeContact().IDString() == req.GetCollaboratorIds().IDString() ||
-			gtw.GetTechnicalContact().IDString() == req.GetCollaboratorIds().IDString() {
+		if proto.Equal(gtw.GetAdministrativeContact(), req.GetCollaboratorIds()) ||
+			proto.Equal(gtw.GetTechnicalContact(), req.GetCollaboratorIds()) {
 			return errCollaboratorIsContact.WithAttributes("collaborator_id", req.GetCollaboratorIds().IDString())
 		}
 		if removedRights.Implied().IncludesAll(ttnpb.Right_RIGHT_GATEWAY_ALL) {

--- a/pkg/identityserver/gateway_access.go
+++ b/pkg/identityserver/gateway_access.go
@@ -427,6 +427,18 @@ func (is *IdentityServer) deleteGatewayCollaborator(
 		if err != nil {
 			return err
 		}
+		gtw, err := st.GetGateway(
+			ctx,
+			req.GetGatewayIds(),
+			store.FieldMask([]string{"administrative_contact", "technical_contact"}),
+		)
+		if err != nil {
+			return err
+		}
+		if gtw.GetAdministrativeContact().IDString() == req.GetCollaboratorIds().IDString() ||
+			gtw.GetTechnicalContact().IDString() == req.GetCollaboratorIds().IDString() {
+			return errCollaboratorIsContact.WithAttributes("collaborator_id", req.GetCollaboratorIds().IDString())
+		}
 		if removedRights.Implied().IncludesAll(ttnpb.Right_RIGHT_GATEWAY_ALL) {
 			memberRights, err := st.FindMembers(ctx, req.GetGatewayIds().GetEntityIdentifiers())
 			if err != nil {

--- a/pkg/identityserver/organization_access.go
+++ b/pkg/identityserver/organization_access.go
@@ -23,6 +23,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -448,8 +449,8 @@ func (is *IdentityServer) deleteOrganizationCollaborator(
 		if err != nil {
 			return err
 		}
-		if org.GetAdministrativeContact().IDString() == req.GetCollaboratorIds().IDString() ||
-			org.GetTechnicalContact().IDString() == req.GetCollaboratorIds().IDString() {
+		if proto.Equal(org.GetAdministrativeContact(), req.GetCollaboratorIds()) ||
+			proto.Equal(org.GetTechnicalContact(), req.GetCollaboratorIds()) {
 			return errCollaboratorIsContact.WithAttributes("collaborator_id", req.GetCollaboratorIds().IDString())
 		}
 		if r.Implied().IncludesAll(ttnpb.Right_RIGHT_ORGANIZATION_ALL) {

--- a/pkg/identityserver/organization_access_test.go
+++ b/pkg/identityserver/organization_access_test.go
@@ -528,3 +528,54 @@ func TestOrganizationAccessClusterAuth(t *testing.T) {
 		}
 	}, withPrivateTestDatabase(p))
 }
+
+func TestOrganizationContactRestrictions(t *testing.T) {
+	p := &storetest.Population{}
+
+	usr1 := p.NewUser()
+	usr1Key, _ := p.NewAPIKey(usr1.GetEntityIdentifiers(), ttnpb.Right_RIGHT_ALL)
+	usr1Creds := rpcCreds(usr1Key)
+
+	gtw1 := p.NewOrganization(usr1.GetOrganizationOrUserIdentifiers())
+
+	usr2 := p.NewUser()
+	p.NewMembership(
+		usr2.GetOrganizationOrUserIdentifiers(),
+		gtw1.GetEntityIdentifiers(),
+		ttnpb.Right_RIGHT_ORGANIZATION_INFO,
+	)
+	// Set the user as administrative contact for the organization.
+	gtw1.AdministrativeContact = usr2.GetOrganizationOrUserIdentifiers()
+
+	t.Parallel()
+	a, ctx := test.New(t)
+
+	testWithIdentityServer(t, func(is *IdentityServer, cc *grpc.ClientConn) {
+		regClt := ttnpb.NewOrganizationRegistryClient(cc)
+		accessClt := ttnpb.NewOrganizationAccessClient(cc)
+
+		// Attempt to delete a collaborator that is an administrative contact.
+		_, err := accessClt.DeleteCollaborator(ctx, &ttnpb.DeleteOrganizationCollaboratorRequest{
+			OrganizationIds: gtw1.Ids,
+			CollaboratorIds: usr2.GetOrganizationOrUserIdentifiers(),
+		}, usr1Creds)
+		a.So(errors.IsFailedPrecondition(err), should.BeTrue)
+
+		// Change the administrative contact.
+		_, err = regClt.Update(ctx, &ttnpb.UpdateOrganizationRequest{
+			Organization: &ttnpb.Organization{
+				Ids:                   gtw1.Ids,
+				AdministrativeContact: usr1.GetOrganizationOrUserIdentifiers(),
+			},
+			FieldMask: ttnpb.FieldMask("administrative_contact"),
+		}, usr1Creds)
+		a.So(err, should.BeNil)
+
+		// Attempt to delete a collaborator that is an administrative contact.
+		_, err = accessClt.DeleteCollaborator(ctx, &ttnpb.DeleteOrganizationCollaboratorRequest{
+			OrganizationIds: gtw1.Ids,
+			CollaboratorIds: usr2.GetOrganizationOrUserIdentifiers(),
+		}, usr1Creds)
+		a.So(err, should.BeNil)
+	}, withPrivateTestDatabase(p))
+}

--- a/pkg/webui/containers/collaborator-form/hooks.js
+++ b/pkg/webui/containers/collaborator-form/hooks.js
@@ -77,9 +77,8 @@ const useCollaboratorData = (entity, entityId, collaboratorId, tts) => {
   const currentUserId = useSelector(selectUserId)
   const isCurrentUser = isUser && currentUserId === collaboratorId
   const updateCollaborator = patch => tts[sdkServices[entity]].Collaborators.update(entityId, patch)
-  const removeCollaborator = (isUser, collaboratorIds) => {
+  const removeCollaborator = (isUser, collaboratorIds) =>
     tts[sdkServices[entity]].Collaborators.remove(isUser, entityId, collaboratorIds)
-  }
 
   return {
     collaborator,

--- a/pkg/webui/containers/collaborator-select/index.js
+++ b/pkg/webui/containers/collaborator-select/index.js
@@ -223,7 +223,7 @@ const CollaboratorSelect = ({ userId, name, entity, entityId, isResctrictedUser,
         initialOptions={collaboratorOptions}
         entity={entity.toLowerCase()}
         entityId={entityId}
-        disabled={isResctrictedUser || collaboratorsList.length === 1}
+        disabled={isResctrictedUser}
         isResctrictedUser={isResctrictedUser}
       />
     </RequireRequest>

--- a/pkg/webui/locales/ja.json
+++ b/pkg/webui/locales/ja.json
@@ -2151,6 +2151,7 @@
   "error:pkg/identityserver:application_server_address_mismatch": "アプリケーションサーバーのアドレス`{address}`が`{expected}`と一致しません",
   "error:pkg/identityserver:claim_authentication_code": "無効なクレーム認証コードです",
   "error:pkg/identityserver:client_needs_collaborator": "すべてのクライアントには、すべての権限を持つ少なくとも1人のコラボレーターが必要です",
+  "error:pkg/identityserver:collaborator_is_contact": "",
   "error:pkg/identityserver:common_password": "あまり一般的であってはなりません",
   "error:pkg/identityserver:contact_no_collaborator": "`{contact}`はコラボレーターではありません",
   "error:pkg/identityserver:db_needs_migration": "このデータベースは移行が必要です",

--- a/sdk/js/src/util/marshaler.js
+++ b/sdk/js/src/util/marshaler.js
@@ -69,7 +69,7 @@ class Marshaler {
     if (typeof response !== 'object') {
       throw new Error(`Invalid response type: ${typeof response}`)
     }
-    if ('status' in response && response.status > 400) {
+    if ('status' in response && response.status >= 400) {
       throw new Error(`Response status ${response.status}`)
     }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/6909

#### Changes

<!-- What are the changes made in this pull request? -->

- Update `DeleteCollaborator` for [application,client,gateway,organization]. Now checks if collaborator is admin|tech contact.
- Add error informing that collaborator is used as a contact.
- Update conditional to disable the button that sets admin|tech contact.
- Added tests around `DeleteCollaborator` restrictions.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Manual tests and unit tests.


<details>
<summary> test steps </summary>

1. Start the stack
2. Create an extra user
3. create one of: [ application, gateway, client, organization ]
4. Add the extra user as a collaborator to each entity and set it as a admin or tech contact.
5. For each entity attempt to remove the extra user as a collaborator.

</details>


#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x]  Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
