### PR TITLE
Fix table fetching overlay

### DIFF
--- a/pkg/webui/components/table/index.js
+++ b/pkg/webui/components/table/index.js
@@ -162,14 +162,16 @@ const Tabular = ({
 
   return (
     <div className={classnames(style.container, className)}>
-      <Overlay visible={loading} loading={loading}>
+      <Overlay visible={loading} loading={loading} className={style.overlay}>
         <Table minWidth={minWidth}>
           <Table.Head>{columns}</Table.Head>
-          <Table.Body empty={rows.length === 0} emptyMessage={emptyMessage}>
+          <Table.Body loading={loading} empty={rows.length === 0} emptyMessage={emptyMessage}>
             {rows}
           </Table.Body>
         </Table>
-        <Table.Footer>{pagination}</Table.Footer>
+        <Table.Footer loading={loading} empty={rows.length === 0}>
+          {pagination}
+        </Table.Footer>
       </Overlay>
     </div>
   )

--- a/pkg/webui/components/table/table/index.js
+++ b/pkg/webui/components/table/table/index.js
@@ -50,7 +50,11 @@ Head.defaultProps = {
   className: undefined,
 }
 
-const Body = ({ className, empty, emptyMessage, ...props }) => {
+const Body = ({ className, empty, loading, emptyMessage, ...props }) => {
+  if (empty && loading) {
+    return null
+  }
+
   if (empty) {
     return <Empty message={emptyMessage} />
   }
@@ -62,24 +66,31 @@ Body.propTypes = {
   className: PropTypes.string,
   empty: PropTypes.bool,
   emptyMessage: PropTypes.message,
+  loading: PropTypes.bool,
 }
 
 Body.defaultProps = {
   className: undefined,
   empty: false,
   emptyMessage: undefined,
+  loading: false,
 }
 
-const Footer = ({ className, ...props }) => (
-  <div {...props} className={classnames(className, style.sectionFooter)} />
-)
+const Footer = ({ className, loading, empty, ...props }) =>
+  empty && loading ? null : (
+    <div {...props} className={classnames(className, style.sectionFooter)} />
+  )
 
 Footer.propTypes = {
   className: PropTypes.string,
+  empty: PropTypes.bool,
+  loading: PropTypes.bool,
 }
 
 Footer.defaultProps = {
   className: undefined,
+  empty: false,
+  loading: false,
 }
 
 const Table = ({ className, children, minWidth, ...rest }) => {

--- a/pkg/webui/components/table/tabular.styl
+++ b/pkg/webui/components/table/tabular.styl
@@ -23,3 +23,6 @@
   &-cell
     padding-top: 0
     padding-bottom: 0
+
+.overlay
+  min-height: 10rem


### PR DESCRIPTION
#### Summary

This quickfix PR fixes a couple of issues with the loading state of tables.

#### Changes

<!-- What are the changes made in this pull request? -->

- Add a min-height to the fetching overlay
- Do not render `No items found` if the table is still fetching items
- Do not render pagination if the table is empty and fetching
- Enable non-percentage width values for table cells

#### Testing

Purely styling change. No external testing needed.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
