### PR TITLE
Add `complement_collaborators` entry to the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - Option to store rate limits in Redis. When used, the rate limits are applied over the entire cluster instead of per-instance.
+- Field `complement_collaborators` was added to `SearchAccounts`. Allows an user to request the accounts that are not already attached to the entity's collaborator list.
 
 ### Changed
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
References #6908

This just adds an entry to the CHANGELOG, informing the users of the addition of the `complement_collaborators` field in the `SearchAccounts` request. 

Didn't give an example as it seemed overly verbose for the CHANGELOG.