### PR TITLE
Fix redirect loop when explicit ports are used

### DIFF
--- a/pkg/webmiddleware/redirect.go
+++ b/pkg/webmiddleware/redirect.go
@@ -54,6 +54,7 @@ func (c RedirectConfiguration) build(url *url.URL) (*url.URL, bool) {
 		if c.HostName != nil {
 			hostname = c.HostName(hostname)
 		}
+		originalPortStr := portStr
 		if c.Port != nil {
 			port, _ := strconv.ParseUint(portStr, 10, 0)
 			port = uint64(c.Port(uint(port)))
@@ -62,12 +63,15 @@ func (c RedirectConfiguration) build(url *url.URL) (*url.URL, bool) {
 		host := hostname
 		if portStr != "" {
 			switch {
-			case portStr == "0":
+			case portStr == "0" && originalPortStr == "":
 				// Just use the hostname.
+			case portStr == "0" && originalPortStr != "":
+				// Maintain the original port, in order to avoid loops.
+				host = net.JoinHostPort(host, originalPortStr)
 			case target.Scheme == "http" && portStr == "80":
-				// This is the default. Just use the hostame.
+				// This is the default. Just use the hostname.
 			case target.Scheme == "https" && portStr == "443":
-				// This is the default. Just use the hostame.
+				// This is the default. Just use the hostname.
 			default:
 				host = net.JoinHostPort(host, portStr)
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/6960

#### Changes

<!-- What are the changes made in this pull request? -->

- When the caller provides a port, and the redirection table does not attempt to modify it, leave the port as is.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Unit test + local testing. Manual testing should check that `redirect-to-host: host:port` and `redirect-to-host: host` still work.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

N/A. This fixes a loop which occurs when the caller provides a port even though it is implicit from the scheme.

#### Notes for Reviewers

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
