### PR TITLE
Add `UserBookmarks` and `ConsolePreferences` missing entries to the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ For details about compatibility between different releases, see the **Commitment
 - Fine grained NbTrans overrides for the dynamic ADR mode. See the `--mac-settings.adr.mode.dynamic.overrides.data-rate-[index].min-nb-trans` and `--mac-settings.adr.mode.dynamic.overrides.data-rate-[index].max-nb-trans` family of parameters.
 - Support for storing user's bookmarks in the database.
   - This requires a database schema migration (`ttn-lw-stack is-db migrate`) because of the new `user_bookmarks` table.
+- Support for storing user's Console Preferences in the database.
+  - This requires a database schema migration (`ttn-lw-stack is-db migrate`) because of the new `console_preferences` column in the `users` table.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - Fine grained NbTrans overrides for the dynamic ADR mode. See the `--mac-settings.adr.mode.dynamic.overrides.data-rate-[index].min-nb-trans` and `--mac-settings.adr.mode.dynamic.overrides.data-rate-[index].max-nb-trans` family of parameters.
+- Support for storing user's bookmarks in the database.
+  - This requires a database schema migration (`ttn-lw-stack is-db migrate`) because of the new `user_bookmarks` table.
 
 ### Changed
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/6483

Due to my mistake I did not add the necessary entries to the `CHANGELOG`, these refer to both the `UserBookmarks` and the `ConsolePreferences` storage.
