### PR TITLE
Fix session information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Fixes the keys displayed in the session information section of overview tab of an End Device in the Console - for LW 1.1.x, replaces NwkSKey with FNwkSIntKey. For LX 1.0.x display only the NwkSKey and AppSKey.
+
 ### Security
 
 ## [3.30.0] - unreleased

--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -216,34 +216,46 @@ const DeviceInfo = ({ frequencyPlans, device, onExport }) => {
       })
     }
 
-    sessionInfoData.items.push(
-      {
-        key: sharedMessages.devAddr,
-        value: dev_addr,
-        type: 'byte',
-        sensitive: false,
-        enableUint32: true,
-      },
-      {
-        key: sharedMessages.nwkSKey,
-        value: f_nwk_s_int_key.key,
-        type: 'byte',
-        sensitive: true,
-      },
-      {
-        key: sharedMessages.sNwkSIKey,
-        value: s_nwk_s_int_key.key,
-        type: 'byte',
-        sensitive: true,
-      },
-      {
-        key: sharedMessages.nwkSEncKey,
-        value: nwk_s_enc_key.key,
-        type: 'byte',
-        sensitive: true,
-      },
-      { key: sharedMessages.appSKey, value: app_s_key.key, type: 'byte', sensitive: true },
-    )
+    if (lorawanVersion >= 100 && lorawanVersion < 110) {
+      sessionInfoData.items.push(
+        {
+          key: sharedMessages.nwkSKey,
+          value: f_nwk_s_int_key.key,
+          type: 'byte',
+          sensitive: true,
+        },
+        { key: sharedMessages.appSKey, value: app_s_key.key, type: 'byte', sensitive: true },
+      )
+    } else {
+      sessionInfoData.items.push(
+        {
+          key: sharedMessages.devAddr,
+          value: dev_addr,
+          type: 'byte',
+          sensitive: false,
+          enableUint32: true,
+        },
+        {
+          key: lorawanVersion >= 110 ? sharedMessages.fNwkSIntKey : sharedMessages.nwkSKey,
+          value: f_nwk_s_int_key.key,
+          type: 'byte',
+          sensitive: true,
+        },
+        {
+          key: sharedMessages.sNwkSIKey,
+          value: s_nwk_s_int_key.key,
+          type: 'byte',
+          sensitive: true,
+        },
+        {
+          key: sharedMessages.nwkSEncKey,
+          value: nwk_s_enc_key.key,
+          type: 'byte',
+          sensitive: true,
+        },
+        { key: sharedMessages.appSKey, value: app_s_key.key, type: 'byte', sensitive: true },
+      )
+    }
   }
 
   sheetData.push(sessionInfoData)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #7006 

#### Changes

<!-- What are the changes made in this pull request? -->

- Replace NwkSKey label with FNwkSIntKey for LW 1.1.x 
- Display only the NwkSKey and AppSKey for LW 1.0.x

<img width="629" alt="Screenshot 2024-04-05 at 11 25 44" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/56658938/4dae7c43-b477-4966-a70c-8a37e00165dc">

<img width="611" alt="Screenshot 2024-04-05 at 11 26 11" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/56658938/edd74c00-91c5-4cb1-8b7f-9f303bf03ba0">


#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Log into the console.
2. Open the overview of a device with a LW 1.1.x
3. In the Session information you should see the FNwkSIntKey
4. Open the overview of a device with a LW 1.0.x
5. In the Session information you see only only the NwkSKey and AppSKey.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
