### PR TITLE
Fix interop context filler usage

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -213,7 +213,7 @@ func New(logger log.Stack, config *Config, opts ...Option) (c *Component, err er
 	}
 
 	config.Interop.SenderClientCA.BlobConfig = config.Blob
-	c.interop, err = interop.NewServer(c, c.fillers, config.Interop)
+	c.interop, err = interop.NewServer(c, c.FillContext, config.Interop)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fillcontext/fillcontext.go
+++ b/pkg/fillcontext/fillcontext.go
@@ -17,5 +17,10 @@ package fillcontext
 
 import "context"
 
-// Filler extends the context
+// Filler extends the context.
 type Filler func(context.Context) context.Context
+
+// Noop is a filler that does nothing.
+func Noop(ctx context.Context) context.Context {
+	return ctx
+}

--- a/pkg/interop/server.go
+++ b/pkg/interop/server.go
@@ -89,7 +89,7 @@ type Component interface {
 }
 
 // NewServer builds a new server.
-func NewServer(c Component, contextFillers []fillcontext.Filler, conf config.InteropServer) (*Server, error) {
+func NewServer(c Component, contextFiller fillcontext.Filler, conf config.InteropServer) (*Server, error) {
 	ctx := log.NewContextWithField(c.Context(), "namespace", "interop")
 	logger := log.FromContext(ctx)
 
@@ -133,7 +133,7 @@ func NewServer(c Component, contextFillers []fillcontext.Filler, conf config.Int
 	s.router.NotFoundHandler = http.HandlerFunc(webhandlers.NotFound)
 	s.router.Use(
 		mux.MiddlewareFunc(webmiddleware.Recover()),
-		mux.MiddlewareFunc(webmiddleware.FillContext(contextFillers...)),
+		mux.MiddlewareFunc(webmiddleware.FillContext(contextFiller)),
 		mux.MiddlewareFunc(webmiddleware.RequestURL()),
 		mux.MiddlewareFunc(webmiddleware.RequestID()),
 		mux.MiddlewareFunc(webmiddleware.MaxBody(1<<15)), // 32 kB.

--- a/pkg/interop/server_test.go
+++ b/pkg/interop/server_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/smarty/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
+	"go.thethings.network/lorawan-stack/v3/pkg/fillcontext"
 	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 	"go.thethings.network/lorawan-stack/v3/pkg/interop"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
@@ -316,7 +317,7 @@ func TestServer(t *testing.T) { //nolint:gocyclo
 
 				pbIssuer, pbToken := makePacketBrokerTokenIssuer(ctx, "test.packetbroker.io")
 
-				s, err := interop.NewServer(&mockComponent{ctx}, nil, config.InteropServer{
+				s, err := interop.NewServer(&mockComponent{ctx}, fillcontext.Noop, config.InteropServer{
 					SenderClientCA: config.SenderClientCA{
 						Source:    "directory",
 						Directory: "testdata/server",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/pull/4172
References https://the-things-industries.sentry.io/issues/5142078246

#### Changes

<!-- What are the changes made in this pull request? -->

- The interop server now always uses all of the context fillers, including the ones initialized after the interop server.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

To be tested on `staging1`. We should stop seeing the linked panic and joins should work via Packet Broker staging.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

N/A.

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is a bug revealed by https://github.com/TheThingsIndustries/lorawan-stack/pull/4172 - we use `configuration.FromContext` but there is no tenant fetcher in the context, so the configuration is silently lost. Now that we panic when there is a tenant ID but no tenant fetcher in the context, this bug has been revealed.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
