### PR TITLE
Display both AFcntDown and NFcntDown in the Device overview in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Show both AFcntDown and NFcntDown in the Device overview in the Console.
+
 ### Security
 
 ## [3.30.0] - unreleased

--- a/pkg/webui/console/components/entity-title-section/content/messages-count/index.js
+++ b/pkg/webui/console/components/entity-title-section/content/messages-count/index.js
@@ -23,18 +23,22 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 import style from './messages-count.styl'
 
 const MessagesCount = React.forwardRef((props, ref) => {
-  const { className, icon, value, iconClassName } = props
+  const { className, icon, value, iconClassName, helpTooltip } = props
 
   return (
     <div ref={ref} className={classnames(style.container, className)}>
       <Icon className={iconClassName} icon={icon} nudgeUp />
       {typeof value === 'number' ? <FormattedNumber value={value} /> : value}
+      {helpTooltip && (
+        <Icon className="tc-subtle-gray ml-cs-xxs" icon="help_outline" nudgeUp small />
+      )}
     </div>
   )
 })
 
 MessagesCount.propTypes = {
   className: PropTypes.string,
+  helpTooltip: PropTypes.bool,
   icon: PropTypes.string.isRequired,
   iconClassName: PropTypes.string,
   value: PropTypes.node.isRequired,
@@ -43,6 +47,7 @@ MessagesCount.propTypes = {
 MessagesCount.defaultProps = {
   className: undefined,
   iconClassName: undefined,
+  helpTooltip: false,
 }
 
 export default MessagesCount

--- a/pkg/webui/console/containers/device-title-section/index.js
+++ b/pkg/webui/console/containers/device-title-section/index.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
-import { defineMessages } from 'react-intl'
+import { FormattedNumber, defineMessages } from 'react-intl'
 import { useSelector } from 'react-redux'
 
 import deviceIcon from '@assets/misc/end-device.svg'
@@ -72,13 +72,22 @@ const DeviceTitleSection = props => {
   const showNwkDownlinkCount = typeof downlinkNwkFrameCount === 'number'
   const notAvailableElem = <Message content={sharedMessages.notAvailable} />
   const downlinkValue =
-    showAppDownlinkCount && showNwkDownlinkCount
-      ? `${downlinkAppFrameCount} (App) / ${downlinkNwkFrameCount} (Nwk)`
-      : showAppDownlinkCount
-        ? `${downlinkAppFrameCount} (App)`
-        : showNwkDownlinkCount
-          ? `${downlinkNwkFrameCount} (Nwk)`
-          : notAvailableElem
+    showAppDownlinkCount && showNwkDownlinkCount ? (
+      <>
+        <FormattedNumber value={downlinkAppFrameCount} /> {'(App) / '}
+        <FormattedNumber value={downlinkNwkFrameCount} /> {'(Nwk)'},
+      </>
+    ) : showAppDownlinkCount ? (
+      <>
+        <FormattedNumber value={downlinkAppFrameCount} /> {'(App)'}
+      </>
+    ) : showNwkDownlinkCount ? (
+      <>
+        <FormattedNumber value={downlinkNwkFrameCount} /> {'(Nwk)'},
+      </>
+    ) : (
+      notAvailableElem
+    )
   const lastActivityInfo = lastSeen ? <DateTime value={lastSeen} noTitle /> : lastSeen
   const lineBreak = <br />
   const bottomBarLeft = (

--- a/pkg/webui/console/store/selectors/devices.js
+++ b/pkg/webui/console/store/selectors/devices.js
@@ -68,11 +68,17 @@ export const selectDeviceDerivedUplinkFrameCount = (state, appId, devId) => {
 
   return derived.uplinkFrameCount
 }
-export const selectDeviceDerivedDownlinkFrameCount = (state, appId, devId) => {
+export const selectDeviceDerivedAppDownlinkFrameCount = (state, appId, devId) => {
   const derived = selectDeviceDerivedById(state, combineDeviceIds(appId, devId))
   if (!Boolean(derived)) return undefined
 
-  return derived.downlinkFrameCount
+  return derived.downlinkAppFrameCount
+}
+export const selectDeviceDerivedNwkDownlinkFrameCount = (state, appId, devId) => {
+  const derived = selectDeviceDerivedById(state, combineDeviceIds(appId, devId))
+  if (!Boolean(derived)) return undefined
+
+  return derived.downlinkNwkFrameCount
 }
 
 export const selectSelectedDeviceClaimable = state =>

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -506,7 +506,7 @@
   "console.containers.device-profile-section.hints.progress-hint.hintNoSupportMessage": "Cannot find your exact end device? Try <b>enter end device specifics manually</b> option above.",
   "console.containers.device-template-format-select.index.title": "File format",
   "console.containers.device-template-format-select.index.warning": "End device template formats unavailable",
-  "console.containers.device-title-section.index.uplinkDownlinkTooltip": "The number of sent uplinks and received downlinks of this end device since the last frame counter reset.",
+  "console.containers.device-title-section.index.uplinkDownlinkTooltip": "The number of sent uplinks and received downlinks of this end device since the last frame counter reset.{lineBreak}App: frame counter for application downlinks (`FPort >=1`).{lineBreak}Nwk: frame counter for network downlinks (`FPort = 0`)",
   "console.containers.device-title-section.index.lastSeenAvailableTooltip": "The elapsed time since the network registered the last activity of this end device. This is determined from sent uplinks, confirmed downlinks or (re)join requests.{lineBreak}The last activity was received at {lastActivityInfo}",
   "console.containers.device-title-section.index.noActivityTooltip": "The network has not registered any activity from this end device yet. This could mean that your end device has not sent any messages yet or only messages that cannot be handled by the network, e.g. due to a mismatch of EUIs or frequencies.",
   "console.containers.devices-table.index.otherClusterTooltip": "This end device is registered on a different cluster (`{host}`). To access this device, use the Console of the cluster that this end device was registered on.",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #6946 

#### Changes

<!-- What are the changes made in this pull request? -->

- Store both counters in the state
- Show both counters when available
- Show `help` icon for tooltip

<img width="705" alt="Screenshot 2024-04-05 at 12 12 17" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/56658938/ca593978-80e4-4182-8d09-e7ea347764e9">


#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Log into the Console
2. Go to the overview of an end device with LW 1.1.x
3. See two downlink counters if both the network and the app have downlinks and only one of the counters of only the app/network has downlinks.
4. See also a description about this in the tooltip

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
