### PR TITLE
Backport of docker and tools changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,6 @@ services:
       TTN_LW_BLOB_LOCAL_DIRECTORY: /srv/ttn-lorawan/public/blob
       TTN_LW_REDIS_ADDRESS: redis:6379
       TTN_LW_IS_DATABASE_URI: postgres://root:root@postgres:5432/ttn_lorawan_dev?sslmode=disable
-
     ports:
       # If deploying on a public server:
       # - "80:1885"
@@ -57,12 +56,13 @@ services:
       - "1887:1887"
       - "8887:8887"
       - "1700:1700/udp"
-
     # If using custom certificates:
     secrets:
       - ca.pem
       - cert.pem
       - key.pem
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
 # If using custom certificates:
 secrets:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Backport changes made in https://github.com/TheThingsIndustries/lorawan-stack/pull/4164

#### Changes

<!-- What are the changes made in this pull request? -->

- Add host-gateway to docker-compose stack service, done in order to be able to use host.docker.internal in Linux machines
- Update `sql:fmt` mage command to skip path if a permission error is found. 

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

For testing the change in the mage command simply do the following:
1. start the stack with `tools/bin/mage dev:dbStart dev:initStack`
2. create a folder `mkdir -p .env/test_perm_err`
3. make it so only root can access it `sudo chmod 0007 -R .env/test_perm_err`
4. run `tools/bin/mage -v sql:fmt`
4.1. `skipping '<repo_path>/.env/test_perm_err' file due to permission denied` should show up on the output


##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

small changes that only impact development, there is no impact on features

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
