### PR TITLE
Show JoinEUI and DevEUI only for activation events

### DIFF
--- a/pkg/webui/console/components/events/previews/application-downlink.js
+++ b/pkg/webui/console/components/events/previews/application-downlink.js
@@ -29,7 +29,6 @@ const ApplicationDownlinkPreview = React.memo(({ event }) => {
   return (
     <DescriptionList>
       <DescriptionList.Byte title={messages.devAddr} data={deviceIds.dev_addr} />
-      <DescriptionList.Byte title={sharedMessages.joinEUI} data={deviceIds.join_eui} />
       {'decoded_payload' in data ? (
         <DescriptionList.Item title={sharedMessages.payload}>
           <JSONPayload data={data.decoded_payload} />

--- a/pkg/webui/console/components/events/previews/application-uplink-normalized.js
+++ b/pkg/webui/console/components/events/previews/application-uplink-normalized.js
@@ -17,19 +17,26 @@ import React from 'react'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
+import { activationEvent } from '@console/lib/regexp'
+
 import messages from '../messages'
 
 import DescriptionList from './shared/description-list'
 import JSONPayload from './shared/json-payload'
 
 const ApplicationUplinkNormalizedPreview = React.memo(({ event }) => {
-  const { data, identifiers } = event
+  const { data, identifiers, name } = event
   const deviceIds = identifiers[0].device_ids
 
   return (
     <DescriptionList>
       <DescriptionList.Byte title={messages.devAddr} data={deviceIds.dev_addr} />
-      <DescriptionList.Byte title={sharedMessages.joinEUI} data={deviceIds.join_eui} />
+      {activationEvent.test(name) && (
+        <>
+          <DescriptionList.Byte title={sharedMessages.joinEUI} data={deviceIds.join_eui} />
+          <DescriptionList.Byte title={sharedMessages.devEUI} data={deviceIds.dev_eui} />
+        </>
+      )}
       {data.normalized_payload.soil && (
         <DescriptionList.Item title={sharedMessages.normalizedPayloadSoil}>
           <JSONPayload data={data.normalized_payload.soil} />

--- a/pkg/webui/console/components/events/previews/application-uplink-normalized.js
+++ b/pkg/webui/console/components/events/previews/application-uplink-normalized.js
@@ -17,26 +17,18 @@ import React from 'react'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
-import { activationEvent } from '@console/lib/regexp'
-
 import messages from '../messages'
 
 import DescriptionList from './shared/description-list'
 import JSONPayload from './shared/json-payload'
 
 const ApplicationUplinkNormalizedPreview = React.memo(({ event }) => {
-  const { data, identifiers, name } = event
+  const { data, identifiers } = event
   const deviceIds = identifiers[0].device_ids
 
   return (
     <DescriptionList>
       <DescriptionList.Byte title={messages.devAddr} data={deviceIds.dev_addr} />
-      {activationEvent.test(name) && (
-        <>
-          <DescriptionList.Byte title={sharedMessages.joinEUI} data={deviceIds.join_eui} />
-          <DescriptionList.Byte title={sharedMessages.devEUI} data={deviceIds.dev_eui} />
-        </>
-      )}
       {data.normalized_payload.soil && (
         <DescriptionList.Item title={sharedMessages.normalizedPayloadSoil}>
           <JSONPayload data={data.normalized_payload.soil} />

--- a/pkg/webui/console/components/events/previews/application-uplink.js
+++ b/pkg/webui/console/components/events/previews/application-uplink.js
@@ -20,6 +20,7 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
 import getDataRate from '@console/lib/data-rate-utils'
+import { activationEvent } from '@console/lib/regexp'
 
 import messages from '../messages'
 
@@ -27,7 +28,7 @@ import DescriptionList from './shared/description-list'
 import JSONPayload from './shared/json-payload'
 
 const ApplicationUplinkPreview = React.memo(({ event }) => {
-  const { data, identifiers } = event
+  const { data, identifiers, name } = event
   const deviceIds = identifiers[0].device_ids
   const { snr, rssi } = getSignalInformation(data)
   const dataRate = getDataRate(data)
@@ -35,7 +36,12 @@ const ApplicationUplinkPreview = React.memo(({ event }) => {
   return (
     <DescriptionList>
       <DescriptionList.Byte title={messages.devAddr} data={deviceIds.dev_addr} />
-      <DescriptionList.Byte title={sharedMessages.joinEUI} data={deviceIds.join_eui} />
+      {activationEvent.test(name) && (
+        <>
+          <DescriptionList.Byte title={sharedMessages.joinEUI} data={deviceIds.join_eui} />
+          <DescriptionList.Byte title={sharedMessages.devEUI} data={deviceIds.dev_eui} />
+        </>
+      )}
       {'decoded_payload' in data ? (
         <DescriptionList.Item title={sharedMessages.payload}>
           <JSONPayload data={data.decoded_payload} />

--- a/pkg/webui/console/components/events/previews/default.js
+++ b/pkg/webui/console/components/events/previews/default.js
@@ -17,25 +17,31 @@ import React from 'react'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
+import { activationEvent } from '@console/lib/regexp'
+
 import messages from '../messages'
 
 import DescriptionList from './shared/description-list'
 
 const DefaultPreview = React.memo(({ event }) => {
-  const { identifiers } = event
+  const { identifiers, name } = event
 
   if (identifiers && 'device_ids' in identifiers[0]) {
     return (
       <DescriptionList>
         <DescriptionList.Byte title={messages.devAddr} data={identifiers[0].device_ids.dev_addr} />
-        <DescriptionList.Byte
-          title={sharedMessages.joinEUI}
-          data={identifiers[0].device_ids.join_eui}
-        />
-        <DescriptionList.Byte
-          title={sharedMessages.devEUI}
-          data={identifiers[0].device_ids.dev_eui}
-        />
+        {activationEvent.test(name) && (
+          <>
+            <DescriptionList.Byte
+              title={sharedMessages.joinEUI}
+              data={identifiers[0].device_ids.join_eui}
+            />
+            <DescriptionList.Byte
+              title={sharedMessages.devEUI}
+              data={identifiers[0].device_ids.dev_eui}
+            />
+          </>
+        )}
       </DescriptionList>
     )
   }

--- a/pkg/webui/console/components/events/previews/downlink-message.js
+++ b/pkg/webui/console/components/events/previews/downlink-message.js
@@ -20,7 +20,6 @@ import { getDataRate } from '@console/components/events/utils'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 import getByPath from '@ttn-lw/lib/get-by-path'
-import sharedMessages from '@ttn-lw/lib/shared-messages'
 
 import messages from '../messages'
 
@@ -62,8 +61,6 @@ const DownLinkMessagePreview = React.memo(({ event }) => {
       )
     }
     const devAddr = event.identifiers[0].device_ids.dev_addr
-    const joinEui = event.identifiers[0].device_ids.join_eui
-    const devEui = event.identifiers[0].device_ids.dev_eui
     const frmPayload = getByPath(data, 'payload.mac_payload.frm_payload')
     const rx1Delay = getByPath(data, 'request.rx1_delay')
     const fPort = getByPath(data, 'payload.mac_payload.f_port')
@@ -72,8 +69,6 @@ const DownLinkMessagePreview = React.memo(({ event }) => {
     return (
       <DescriptionList>
         <DescriptionList.Byte title={messages.devAddr} data={devAddr} />
-        <DescriptionList.Byte title={sharedMessages.joinEUI} data={joinEui} />
-        <DescriptionList.Byte title={sharedMessages.devEUI} data={devEui} />
         <DescriptionList.Item title={messages.fPort} data={fPort} />
         {isConfirmed && (
           <DescriptionList.Item>

--- a/pkg/webui/console/components/events/previews/gateway-uplink-message.js
+++ b/pkg/webui/console/components/events/previews/gateway-uplink-message.js
@@ -55,8 +55,6 @@ const GatewayUplinkMessagePreview = React.memo(({ event }) => {
   return (
     <DescriptionList>
       <DescriptionList.Byte title={messages.devAddr} data={devAddr} />
-      <DescriptionList.Byte title={sharedMessages.joinEUI} data={joinEui} />
-      <DescriptionList.Byte title={sharedMessages.devEUI} data={devEui} />
       <DescriptionList.Item title={messages.fCnt} data={fCnt} highlight />
       <DescriptionList.Item title={messages.fPort} data={fPort} />
       {isConfirmed && (

--- a/pkg/webui/console/lib/regexp.js
+++ b/pkg/webui/console/lib/regexp.js
@@ -32,3 +32,4 @@ export const emptyDuration = /^[a-zA-z]+$/
 export const delay = new RegExp('^[0-9]{1,}[.]?([0-9]{1,})?[a-zA-Z]{1,2}$')
 export const apiKeyPath = /([A-Z0-9]{39})/
 export const duration = /^[0-9]+([a-z])$/
+export const activationEvent = /.*\.join\..*/


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

References #6981 

#### Changes

<!-- What are the changes made in this pull request? -->

- Show `JoinEUI` and `DevEUI` only for activation events.

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Login to console.
2. Go to applications.
3. Select an application.
4. Check live data.
5. Activation events containing `*.join.*` in the name should have `JoinEUI` and `DevEUI` fields present.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
