### PR TITLE
Give Basic Station gateways more time for the TLS handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Increased the timeout for Basic Station gateways sending HTTP headers. There should now be enough time for embedded devices with little to no hardware acceleration to perform a TLS handshake. In particular, The Things Indoor Gateway can now connect to The Things Stack presenting a ECDSA certificate.
+
 ### Security
 
 ## [3.30.1] - unreleased
@@ -26,7 +28,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - Support fine-grained NbTrans controls while using Dynamic ADR mode in the Console.
-- User bookmark listing now supports filtering bookmarks by entity type. 
+- User bookmark listing now supports filtering bookmarks by entity type.
   - This can be specified by setting `entity_types` field in `ListUserBookmarksRequest`.
 
 ### Fixed

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -335,9 +335,14 @@ func New(c *component.Component, conf *Config, opts ...Option) (gs *GatewayServe
 					defer lis.Close()
 
 					srv := http.Server{
-						Handler:           web,
-						ReadTimeout:       120 * time.Second,
-						ReadHeaderTimeout: 5 * time.Second,
+						Handler:     web,
+						ReadTimeout: 120 * time.Second,
+						// The ReadHeaderTimeout should be sufficiently long for embedded devices to perform the TLS handshake
+						// before headers can be sent.
+						// For example, The Things Indoor Gateway connecting via HTTPS to The Things Stack presenting a TLS server
+						// certificate using ECDSA, the TLS handshake typically takes up to 10 seconds because there is limited
+						// hardware acceleration as compared to RSA.
+						ReadHeaderTimeout: 30 * time.Second,
 						ErrorLog:          stdlog.New(stdio.Discard, "", 0),
 					}
 					go func() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

This gives Basic Station gateways more time for the TLS handshake.

#### Changes

<!-- What are the changes made in this pull request? -->

- Increased the timeout to read headers from 5 to 30 seconds. 

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

This has been tested with The Things Indoor Gateway in a normal production-like environment with a Let's Encrypt ECDSA certificate.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

None expected

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

What's materially between the connection setup and reading headers is the TLS handshake.

We can also manually accept TLS connections and perform the [handshake with a deadlined context](https://pkg.go.dev/crypto/tls#Conn.HandshakeContext) so that we can separate the TLS handshake time from the HTTP read (headers) timeout. I don't think we need that now.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
