### PR TITLE
Add back devAddr in device session information

### DIFF
--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -216,15 +216,18 @@ const DeviceInfo = ({ frequencyPlans, device, onExport }) => {
       })
     }
 
+    sessionInfoData.items.push(
+      {
+        key: sharedMessages.devAddr,
+        value: dev_addr,
+        type: 'byte',
+        sensitive: false,
+        enableUint32: true,
+      }
+    )
+
     if (lorawanVersion >= 100 && lorawanVersion < 110) {
       sessionInfoData.items.push(
-        {
-          key: sharedMessages.devAddr,
-          value: dev_addr,
-          type: 'byte',
-          sensitive: false,
-          enableUint32: true,
-        },
         {
           key: sharedMessages.nwkSKey,
           value: f_nwk_s_int_key.key,
@@ -235,13 +238,6 @@ const DeviceInfo = ({ frequencyPlans, device, onExport }) => {
       )
     } else {
       sessionInfoData.items.push(
-        {
-          key: sharedMessages.devAddr,
-          value: dev_addr,
-          type: 'byte',
-          sensitive: false,
-          enableUint32: true,
-        },
         {
           key: lorawanVersion >= 110 ? sharedMessages.fNwkSIntKey : sharedMessages.nwkSKey,
           value: f_nwk_s_int_key.key,

--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -216,15 +216,13 @@ const DeviceInfo = ({ frequencyPlans, device, onExport }) => {
       })
     }
 
-    sessionInfoData.items.push(
-      {
-        key: sharedMessages.devAddr,
-        value: dev_addr,
-        type: 'byte',
-        sensitive: false,
-        enableUint32: true,
-      }
-    )
+    sessionInfoData.items.push({
+      key: sharedMessages.devAddr,
+      value: dev_addr,
+      type: 'byte',
+      sensitive: false,
+      enableUint32: true,
+    })
 
     if (lorawanVersion >= 100 && lorawanVersion < 110) {
       sessionInfoData.items.push(

--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -219,6 +219,13 @@ const DeviceInfo = ({ frequencyPlans, device, onExport }) => {
     if (lorawanVersion >= 100 && lorawanVersion < 110) {
       sessionInfoData.items.push(
         {
+          key: sharedMessages.devAddr,
+          value: dev_addr,
+          type: 'byte',
+          sensitive: false,
+          enableUint32: true,
+        },
+        {
           key: sharedMessages.nwkSKey,
           value: f_nwk_s_int_key.key,
           type: 'byte',


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

This PR adds back the devAddress to the device session information as noted here: [https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1064#issuecomment-2082228545](https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1064#issuecomment-2082228545)

#### Changes

<!-- What are the changes made in this pull request? -->

- Add devAddress

#### Testing

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Log into the console.
2. Open the overview of a device with a LW 1.0.x
3. In the Session information you see only the Dev Address, NwkSKey and AppSKey.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
