### PR TITLE
Improve Gateway Server throughput

### DIFF
--- a/pkg/gatewayserver/io/udp/observability.go
+++ b/pkg/gatewayserver/io/udp/observability.go
@@ -27,14 +27,14 @@ import (
 const subsystem = "gs_io_udp"
 
 var udpMetrics = &messageMetrics{
-	messageReceived: prometheus.NewCounter(
+	messageReceived: metrics.NewCounter(
 		prometheus.CounterOpts{
 			Subsystem: subsystem,
 			Name:      "message_received_total",
 			Help:      "Total number of received UDP messages",
 		},
 	),
-	messageForwarded: prometheus.NewCounterVec(
+	messageForwarded: metrics.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: subsystem,
 			Name:      "message_forwarded_total",
@@ -42,7 +42,7 @@ var udpMetrics = &messageMetrics{
 		},
 		[]string{"type"},
 	),
-	messageDropped: prometheus.NewCounterVec(
+	messageDropped: metrics.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: subsystem,
 			Name:      "message_dropped_total",
@@ -51,7 +51,7 @@ var udpMetrics = &messageMetrics{
 		[]string{"error"},
 	),
 
-	unmarshalTypeErrors: prometheus.NewCounterVec(
+	unmarshalTypeErrors: metrics.NewCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: subsystem,
 			Name:      "unmarshal_type_errors_total",

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -56,7 +56,7 @@ func (*srv) DutyCycleStyle() scheduling.DutyCycleStyle { return scheduling.Defau
 
 var (
 	limitLogsConfig      = config.RateLimitingProfile{MaxPerMin: 1}
-	limitLogsSize   uint = 1 << 13
+	limitLogsStoreConfig = ratelimit.StoreConfig{Memory: config.RateLimitingMemory{MaxSize: 1 << 13}}
 )
 
 // Serve serves the UDP frontend.
@@ -71,10 +71,7 @@ func Serve(ctx context.Context, server io.Server, conn *net.UDPConn, conf Config
 	if conf.RateLimiting.Enable {
 		firewall = NewRateLimitingFirewall(firewall, conf.RateLimiting.Messages, conf.RateLimiting.Threshold)
 	}
-	limitLogs, err := ratelimit.NewProfile(ctx, limitLogsConfig, ratelimit.StoreConfig{
-		Provider: conf.RateLimiting.Provider,
-		Redis:    conf.RateLimiting.Redis.Client,
-	})
+	limitLogs, err := ratelimit.NewProfile(ctx, limitLogsConfig, limitLogsStoreConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

This PR is a follow up of some issues observed while deploying Redis-based rate limiting.

#### Changes

<!-- What are the changes made in this pull request? -->

- Make the source address firewall concurrency safer.
  - The protocol used to store the latest last seen timestamp is now concurrency safe.
- Do not put extra pressure on Redis when the rate limiting is triggered, by rate limiting logs in memory always.
- Make packet filtering (rate limiting and firewalling) parallel.
  - Currently, this is 'single goroutined'. This means that any throughput limitations here (like the rate limiting going from in memory to Redis, introducing roundtrip latency) lead to packet loss, as UDP has no retransmissions in case the socket buffer is full.
  - Now, we actually run the firewalls and packet filtering in a worker pool. This has the added advantage of actually making the packet loss visible in the worker pool metrics (because if we receive packets faster than we can filter them, we register a drop).

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

This will be tested on `staging1` and other environments. There are no actual tests to be done manually, as this is mainly an optimization PR. 

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

We've been able to heavily reduce the number of Gateway Servers used due to the relief of the single packet processing bottleneck.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

N/A.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
