### PR TITLE
Linearize UDP packet filtering

### DIFF
--- a/pkg/gatewayserver/io/udp/config.go
+++ b/pkg/gatewayserver/io/udp/config.go
@@ -16,18 +16,14 @@ package udp
 
 import (
 	"time"
-
-	"go.thethings.network/lorawan-stack/v3/pkg/config"
 )
 
 // RateLimitingConfig contains configuration settings for the rate limiting
 // capabilities of the UDP gateway frontend firewall.
 type RateLimitingConfig struct {
-	Enable    bool                     `name:"enable" description:"Enable rate limiting for gateways"`
-	Messages  int                      `name:"messages" description:"Number of past messages to check timestamp for"`
-	Threshold time.Duration            `name:"threshold" description:"Filter packet if timestamp is not newer than the older timestamps of the previous messages by this threshold"` //nolint:lll
-	Provider  string                   `name:"provider" description:"Rate limiting store provider (memory, redis)"`
-	Redis     config.RateLimitingRedis `name:"redis" description:"In-Redis rate limiting store configuration"`
+	Enable    bool          `name:"enable" description:"Enable rate limiting for gateways"`
+	Messages  int           `name:"messages" description:"Number of past messages to check timestamp for"`
+	Threshold time.Duration `name:"threshold" description:"Filter packet if timestamp is not newer than the older timestamps of the previous messages by this threshold"` //nolint:lll
 }
 
 // Config contains configuration settings for the UDP gateway frontend.

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -55,8 +55,9 @@ type srv struct {
 
 	limitLogs ratelimit.Interface
 
-	filterPool  workerpool.WorkerPool[filteringItem]
-	processPool workerpool.WorkerPool[encoding.Packet]
+	filterQueues sync.Map // netip.AddrPort -> filterQueue
+	filterPool   workerpool.WorkerPool[filteringItem]
+	processPool  workerpool.WorkerPool[encoding.Packet]
 }
 
 func (*srv) Protocol() string                          { return "udp" }
@@ -105,7 +106,7 @@ func Serve(ctx context.Context, server io.Server, conn *net.UDPConn, conf Config
 		Component:  server,
 		Context:    ctx,
 		Name:       "udp_filter",
-		Handler:    s.filterPacket,
+		Handler:    s.preFilterPacket,
 		MaxWorkers: conf.PacketHandlers,
 		QueueSize:  conf.PacketBuffer,
 	})
@@ -139,6 +140,65 @@ func (s *srv) read() error {
 			log.FromContext(ctx).WithError(err).Warn("Drop packet")
 			registerMessageDropped(ctx, err)
 			continue
+		}
+	}
+}
+
+func (s *srv) preFilterPacket(ctx context.Context, item filteringItem) {
+	addrPort := item.addr.AddrPort()
+
+	type filterQueue struct {
+		items  chan filteringItem
+		closed chan struct{}
+	}
+	q := filterQueue{
+		items:  make(chan filteringItem),
+		closed: make(chan struct{}),
+	}
+
+	for {
+		actual, loaded := s.filterQueues.LoadOrStore(addrPort, q)
+		if loaded {
+			// At this point we're not the goroutine which handles this address.
+			// As such, we attempt to send the item to the channel.
+			q := actual.(filterQueue) // nolint: revive
+			select {
+			case <-ctx.Done():
+				return
+			case q.items <- item:
+				// The goroutine which handles this address has received the item.
+				return
+			case <-q.closed:
+				// Between the actual load and store, and the channel write, the channel might have been closed.
+				continue
+			}
+		}
+		break
+	}
+
+	defer func() {
+		if !s.filterQueues.CompareAndDelete(addrPort, q) {
+			panic("unreachable")
+		}
+		close(q.closed)
+	}()
+
+	// At this point we are the goroutine which handles this address.
+	// As such, we start by handling our own item.
+	s.filterPacket(ctx, item)
+	// Clear the item to allow GC to collect it.
+	item = filteringItem{}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case item := <-q.items:
+			// We have received an item from another goroutine which we need to handle.
+			s.filterPacket(ctx, item)
+		default:
+			// We don't have any more work items.
+			return
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

Fixes https://the-things-industries.sentry.io/issues/5353455597

This PR makes the filtering of packets to be 'linear' for the same source address. This means that different source addresses are evaluated in parallel, but individual addresses (so gateways) are evaluated serially.

#### Changes

<!-- What are the changes made in this pull request? -->

- Make the packet filtering linear for individual gateway addresses.
- Move the firewall filtering next to the rate limiting filtering and packet unmarshaling.
- Remove unused configuration options (which had no real effect after https://github.com/TheThingsNetwork/lorawan-stack/pull/7077).

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

This change has been tested on `staging1` and other environments. As this is mainly technical debt and performance improvements, there are no manual testing steps to be done.

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

Errors such as `Failed to store updated rate limit data for key gs:up:udp:addr:x.x.x.x:y after 10 attempts` are no longer encountered.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

N/A.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
