### PR TITLE
Fix ListEndDevicesRequest rate limiting key

### DIFF
--- a/pkg/ttnpb/end_device.go
+++ b/pkg/ttnpb/end_device.go
@@ -2910,6 +2910,10 @@ func (m *GetEndDeviceRequest) EntityType() string {
 	return m.GetEndDeviceIds().EntityType()
 }
 
+func (m *ListEndDevicesRequest) EntityType() string {
+	return m.GetApplicationIds().EntityType()
+}
+
 func (m *EndDevice) EntityType() string {
 	return m.GetIds().EntityType()
 }
@@ -2940,6 +2944,10 @@ func (m *GetEndDeviceRequest) IDString() string {
 	return m.GetEndDeviceIds().IDString()
 }
 
+func (m *ListEndDevicesRequest) IDString() string {
+	return m.GetApplicationIds().IDString()
+}
+
 func (m *EndDevice) IDString() string {
 	return m.GetIds().IDString()
 }
@@ -2968,6 +2976,10 @@ func (m *EndDeviceTemplate) ExtractRequestFields(dst map[string]interface{}) {
 
 func (m *GetEndDeviceRequest) ExtractRequestFields(dst map[string]interface{}) {
 	m.GetEndDeviceIds().ExtractRequestFields(dst)
+}
+
+func (m *ListEndDevicesRequest) ExtractRequestFields(dst map[string]interface{}) {
+	m.GetApplicationIds().ExtractRequestFields(dst)
 }
 
 func (m *EndDevice) ExtractRequestFields(dst map[string]interface{}) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

Fixes https://the-things-industries.sentry.io/issues/5359002052

#### Changes

<!-- What are the changes made in this pull request? -->

- Add `EntityType` / `IDString` / `ExtractRequestFields` to `ListEndDevicesRequest` in order to make it be rate limited on a per application basis instead of globally.

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

N/A.

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

N/A.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

In short, this will allow more `ListEndDevicesRequest` calls to be done in parallel as now they are rate limited on a per application basis, but that should be fine and was the originally intended use anyway.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
