### PR TITLE
Fix redux selectors to address warnings

### DIFF
--- a/pkg/webui/account/store/selectors/authorizations.js
+++ b/pkg/webui/account/store/selectors/authorizations.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { createSelector } from 'reselect'
+
 import { createFetchingSelector } from '@ttn-lw/lib/store/selectors/fetching'
 import { createErrorSelector } from '@ttn-lw/lib/store/selectors/error'
 
@@ -23,23 +25,27 @@ import {
 const selectAuthorizationsStore = state => state.authorizations
 
 export const selectAuthorizations = state => selectAuthorizationsStore(state).authorizations
-export const selectSelectedAuthorization = (state, clientId) => {
-  const authorizations = selectAuthorizationsStore(state).authorizations.reduce((acc, cur) => {
-    const id = cur.client_ids.client_id
-    acc[id] = cur
 
-    return acc
-  }, {})
-
-  return authorizations[clientId]
-}
+export const selectSelectedAuthorization = createSelector(
+  [selectAuthorizationsStore, (_, clientId) => clientId],
+  (authorizationsStore, clientId) => {
+    const authorizations = authorizationsStore.authorizations.reduce((acc, cur) => {
+      const id = cur.client_ids.client_id
+      acc[id] = cur
+      return acc
+    }, {})
+    return authorizations[clientId]
+  },
+)
 export const selectAuthorizationsTotalCount = state =>
   selectAuthorizationsStore(state).authorizationsTotalCount
 export const selectAuthorizationsFetching = createFetchingSelector(GET_AUTHORIZATIONS_LIST_BASE)
 export const selectAuthorizationsError = createErrorSelector(GET_AUTHORIZATIONS_LIST_BASE)
 
 export const selectTokens = state => selectAuthorizationsStore(state).tokens
-export const selectTokenIds = state => selectTokens(state).map(token => token.id)
+export const selectTokenIds = createSelector([selectTokens], tokens =>
+  tokens.map(token => token.id),
+)
 export const selectTokensTotalCount = state => selectAuthorizationsStore(state).tokensTotalCount
 export const selectTokensFetching = createFetchingSelector(GET_ACCESS_TOKENS_LIST_BASE)
 export const selectTokensError = createErrorSelector(GET_ACCESS_TOKENS_LIST_BASE)

--- a/pkg/webui/account/store/selectors/clients.js
+++ b/pkg/webui/account/store/selectors/clients.js
@@ -37,8 +37,10 @@ const selectClientsError = createErrorSelector(GET_CLIENTS_LIST_BASE)
 export const selectClientFetching = createFetchingSelector(GET_CLIENT_BASE)
 export const selectClientError = createErrorSelector(GET_CLIENT_BASE)
 
-export const selectOAuthClients = state =>
-  selectClientsIds(state).map(id => selectClientById(state, id))
+export const selectOAuthClients = createSelector(
+  [selectClientsIds, selectClientEntitiesStore],
+  (ids, entities) => ids.map(id => entities[id]),
+)
 export const selectOAuthClientsTotalCount = state => selectClientsStore(state).totalCount
 export const selectOAuthClientsFetching = state => selectClientsFetching(state)
 export const selectOAuthClientsError = state => selectClientsError(state)

--- a/pkg/webui/account/store/selectors/identity-server.js
+++ b/pkg/webui/account/store/selectors/identity-server.js
@@ -17,18 +17,21 @@ import { createErrorSelector } from '@ttn-lw/lib/store/selectors/error'
 
 import { GET_IS_CONFIGURATION_BASE } from '@console/store/actions/identity-server'
 
+const EMPTY_OBJ = {}
+
 const selectIsStore = state => state.is
 
 export const selectIsConfiguration = state => selectIsStore(state).configuration
 export const selectIsConfigurationFetching = createFetchingSelector(GET_IS_CONFIGURATION_BASE)
 export const selectIsConfigurationError = createErrorSelector(GET_IS_CONFIGURATION_BASE)
 
-export const selectUserRegistration = state => selectIsConfiguration(state).user_registration || {}
+export const selectUserRegistration = state =>
+  selectIsConfiguration(state).user_registration || EMPTY_OBJ
 export const selectPasswordRequirements = state =>
-  selectUserRegistration(state).password_requirements || {}
+  selectUserRegistration(state).password_requirements || EMPTY_OBJ
 
 export const selectProfilePictureConfiguration = state =>
-  selectIsConfiguration(state).profile_picture || {}
+  selectIsConfiguration(state).profile_picture || EMPTY_OBJ
 export const selectUseGravatarConfiguration = state =>
   selectProfilePictureConfiguration(state).use_gravatar
 export const selectDisableUploadConfiguration = state =>

--- a/pkg/webui/console/store/reducers/configuration.js
+++ b/pkg/webui/console/store/reducers/configuration.js
@@ -19,9 +19,9 @@ import {
 } from '@console/store/actions/configuration'
 
 const defaultState = {
-  nsFrequencyPlans: undefined,
-  gsFrequencyPlans: undefined,
-  bandDefinitions: undefined,
+  nsFrequencyPlans: [],
+  gsFrequencyPlans: [],
+  bandDefinitions: [],
 }
 
 const configuration = (state = defaultState, { type, payload }) => {

--- a/pkg/webui/console/store/reducers/device-template-formats.js
+++ b/pkg/webui/console/store/reducers/device-template-formats.js
@@ -15,7 +15,7 @@
 import { GET_DEVICE_TEMPLATE_FORMATS_SUCCESS } from '@console/store/actions/device-template-formats'
 
 const defaultState = {
-  formats: undefined,
+  formats: {},
 }
 
 const deviceTemplateFormats = (state = defaultState, { type, payload }) => {

--- a/pkg/webui/console/store/reducers/gateways.js
+++ b/pkg/webui/console/store/reducers/gateways.js
@@ -30,7 +30,7 @@ import {
 
 const defaultStatisticsState = {
   error: undefined,
-  stats: undefined,
+  stats: {},
 }
 
 const defaultState = {

--- a/pkg/webui/console/store/reducers/pubsub-formats.js
+++ b/pkg/webui/console/store/reducers/pubsub-formats.js
@@ -15,7 +15,7 @@
 import { GET_PUBSUB_FORMATS_SUCCESS } from '@console/store/actions/pubsub-formats'
 
 const defaultState = {
-  formats: undefined,
+  formats: {},
 }
 
 const pubsubs = (state = defaultState, { type, payload }) => {

--- a/pkg/webui/console/store/reducers/tests/gateways_test.js
+++ b/pkg/webui/console/store/reducers/tests/gateways_test.js
@@ -29,10 +29,14 @@ import {
 } from '../../actions/gateways'
 
 describe('Gateways reducer', () => {
+  const defaultStatisticsState = {
+    error: undefined,
+    stats: {},
+  }
   const defaultState = {
     entities: {},
     selectedGateway: null,
-    statistics: {},
+    statistics: defaultStatisticsState,
   }
 
   it('returns the initial state', () => {

--- a/pkg/webui/console/store/reducers/webhook-formats.js
+++ b/pkg/webui/console/store/reducers/webhook-formats.js
@@ -15,7 +15,7 @@
 import { GET_WEBHOOK_FORMATS_SUCCESS } from '@console/store/actions/webhook-formats'
 
 const defaultState = {
-  formats: undefined,
+  formats: {},
 }
 
 const webhooks = (state = defaultState, { type, payload }) => {

--- a/pkg/webui/console/store/selectors/api-keys.js
+++ b/pkg/webui/console/store/selectors/api-keys.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { createSelector } from 'reselect'
+
 import {
   createPaginationIdsSelectorByEntity,
   createPaginationTotalCountSelectorByEntity,
@@ -30,6 +32,8 @@ export const selectSelectedApiKey = state => selectApiKeyById(state, selectSelec
 const createSelectApiKeysIdsSelector = createPaginationIdsSelectorByEntity(ENTITY)
 const createSelectApiKeysTotalCountSelector = createPaginationTotalCountSelectorByEntity(ENTITY)
 
-export const selectApiKeys = state =>
-  createSelectApiKeysIdsSelector(state).map(id => selectApiKeyById(state, id))
+export const selectApiKeys = createSelector(
+  [createSelectApiKeysIdsSelector, selectApiKeysEntitiesStore],
+  (ids, entities) => ids.map(id => entities[id]),
+)
 export const selectApiKeysTotalCount = state => createSelectApiKeysTotalCountSelector(state)

--- a/pkg/webui/console/store/selectors/application-packages.js
+++ b/pkg/webui/console/store/selectors/application-packages.js
@@ -21,7 +21,7 @@ const selectApplicationPackagesStore = state => state.applicationPackages
 export const selectApplicationPackageDefaultAssociations = state => {
   const store = selectApplicationPackagesStore(state)
 
-  return store.default || {}
+  return store.default
 }
 export const selectApplicationPackageDefaultAssociation = (state, fPort) =>
   selectApplicationPackageDefaultAssociations(state)[fPort]

--- a/pkg/webui/console/store/selectors/application-server.js
+++ b/pkg/webui/console/store/selectors/application-server.js
@@ -14,12 +14,14 @@
 
 import { get } from 'lodash'
 
+const EMPTY_OBJ = {}
+
 const selectAsStore = state => state.as
 
 export const selectAsConfiguration = state => selectAsStore(state).configuration
 
 export const selectPubSubProviders = state =>
-  get(selectAsConfiguration(state), 'pubsub.providers') || {}
+  get(selectAsConfiguration(state), 'pubsub.providers') || EMPTY_OBJ
 export const selectNatsProviderDisabled = state =>
   selectPubSubProviders(state).nats === 'DISABLED' || false
 export const selectMqttProviderDisabled = state =>

--- a/pkg/webui/console/store/selectors/applications.js
+++ b/pkg/webui/console/store/selectors/applications.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { createSelector } from 'reselect'
+
 import {
   createPaginationIdsSelectorByEntity,
   createPaginationTotalCountSelectorByEntity,
@@ -66,14 +68,19 @@ export const selectApplicationDevEUICount = state =>
 const selectAppsIds = createPaginationIdsSelectorByEntity(ENTITY)
 const selectAppsTotalCount = createPaginationTotalCountSelectorByEntity(ENTITY)
 
-export const selectApplications = state =>
-  selectAppsIds(state).map(id => selectApplicationById(state, id))
+export const selectApplications = createSelector(
+  [selectAppsIds, selectApplicationEntitiesStore],
+  (ids, entities) => ids.map(id => entities[id]),
+)
 export const selectApplicationsTotalCount = state => selectAppsTotalCount(state)
-export const selectApplicationsWithDeviceCounts = state =>
-  selectApplications(state).map(app => ({
-    ...app,
-    _devices: selectApplicationDeviceCount(state, app.ids.application_id),
-  }))
+export const selectApplicationsWithDeviceCounts = createSelector(
+  [selectApplications, selectApplicationStore],
+  (applications, store) =>
+    applications.map(app => ({
+      ...app,
+      _devices: store.applicationDeviceCounts[app.ids.application_id],
+    })),
+)
 
 // Events.
 export const selectApplicationEvents = createEventsSelector(ENTITY)

--- a/pkg/webui/console/store/selectors/configuration.js
+++ b/pkg/webui/console/store/selectors/configuration.js
@@ -20,18 +20,20 @@ import {
   GET_GS_FREQUENCY_PLANS_BASE,
 } from '@console/store/actions/configuration'
 
+const EMPTY_ARRAY = []
+
 const selectConfigurationStore = state => state.configuration
 
 export const selectGsFrequencyPlans = state => {
   const store = selectConfigurationStore(state)
 
-  return store.gsFrequencyPlans || []
+  return store.gsFrequencyPlans
 }
 
 export const selectNsFrequencyPlans = state => {
   const store = selectConfigurationStore(state)
 
-  return store.nsFrequencyPlans || []
+  return store.nsFrequencyPlans
 }
 
 export const selectFrequencyPlansError = createErrorSelector([
@@ -47,11 +49,11 @@ export const selectFrequencyPlansFetching = createFetchingSelector([
 export const selectBandDefinitions = state => {
   const store = selectConfigurationStore(state)
 
-  return store?.bandDefinitions || []
+  return store.bandDefinitions
 }
 
 export const selectDataRates = (state, bandId, phyVersion) => {
   const bandDefinitions = selectBandDefinitions(state)
 
-  return bandDefinitions[bandId]?.band[phyVersion]?.data_rates || []
+  return bandDefinitions[bandId]?.band[phyVersion]?.data_rates || EMPTY_ARRAY
 }

--- a/pkg/webui/console/store/selectors/device-repository.js
+++ b/pkg/webui/console/store/selectors/device-repository.js
@@ -17,6 +17,9 @@ import { createErrorSelector } from '@ttn-lw/lib/store/selectors/error'
 
 import { LIST_BRANDS_BASE, LIST_MODELS_BASE } from '@console/store/actions/device-repository'
 
+const EMPTY_MODEL = { list: [] }
+const EMPTY_ARRAY = []
+
 const selectDRStore = store => store.deviceRepository
 
 // Brands.
@@ -28,7 +31,7 @@ export const selectDeviceBrandsError = createErrorSelector(LIST_BRANDS_BASE)
 // Models.
 
 export const selectDeviceModelsByBrandId = (state, brandId) => {
-  const models = selectDRStore(state).models[brandId] || { list: [] }
+  const models = selectDRStore(state).models[brandId] || EMPTY_MODEL
 
   return models.list
 }
@@ -42,7 +45,7 @@ export const selectDeviceModelById = (state, brandId, modelId) => {
 export const selectDeviceModelHardwareVersions = (state, brandId, modelId) => {
   const model = selectDeviceModelById(state, brandId, modelId) || {}
   if (!model.hardware_versions) {
-    return []
+    return EMPTY_ARRAY
   }
 
   return model.hardware_versions
@@ -50,7 +53,7 @@ export const selectDeviceModelHardwareVersions = (state, brandId, modelId) => {
 export const selectDeviceModelFirmwareVersions = (state, brandId, modelId) => {
   const model = selectDeviceModelById(state, brandId, modelId) || {}
   if (!model.firmware_versions) {
-    return []
+    return EMPTY_ARRAY
   }
 
   return model.firmware_versions

--- a/pkg/webui/console/store/selectors/device-template-formats.js
+++ b/pkg/webui/console/store/selectors/device-template-formats.js
@@ -22,7 +22,7 @@ const selectDeviceTemplateFormatsStore = state => state.deviceTemplateFormats
 export const selectDeviceTemplateFormats = state => {
   const store = selectDeviceTemplateFormatsStore(state)
 
-  return store.formats || {}
+  return store.formats
 }
 
 export const selectDeviceTemplateFormatsError = createErrorSelector(

--- a/pkg/webui/console/store/selectors/devices.js
+++ b/pkg/webui/console/store/selectors/devices.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { createSelector } from 'reselect'
+
 import getHostnameFromUrl from '@ttn-lw/lib/host-from-url'
 import { combineDeviceIds, extractDeviceIdFromCombinedId } from '@ttn-lw/lib/selectors/id'
 import {
@@ -97,7 +99,10 @@ export const selectDevicesWithLastSeen = state => {
 const selectDevsIds = createPaginationIdsSelectorByEntity(ENTITY)
 const selectDevsTotalCount = createPaginationTotalCountSelectorByEntity(ENTITY)
 
-export const selectDevices = state => selectDevsIds(state).map(id => selectDeviceById(state, id))
+export const selectDevices = createSelector(
+  [selectDevsIds, selectDeviceEntitiesStore],
+  (ids, entities) => ids.map(id => entities[id]),
+)
 export const selectDevicesTotalCount = state => selectDevsTotalCount(state)
 
 // Events.

--- a/pkg/webui/console/store/selectors/events.js
+++ b/pkg/webui/console/store/selectors/events.js
@@ -21,7 +21,7 @@ const selectEventsStore = (state, entityId) => state[entityId] || {}
 export const createEventsSelector = entity => (state, entityId) => {
   const store = selectEventsStore(state.events[entity], entityId)
 
-  return store.events || []
+  return store.events
 }
 
 export const createEventsStatusSelector = entity => (state, entityId) => {

--- a/pkg/webui/console/store/selectors/gateways.js
+++ b/pkg/webui/console/store/selectors/gateways.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { createSelector } from 'reselect'
+
 import { createFetchingSelector } from '@ttn-lw/lib/store/selectors/fetching'
 import { createErrorSelector } from '@ttn-lw/lib/store/selectors/error'
 import {
@@ -52,7 +54,10 @@ export const selectSelectedGateway = state =>
 const selectGtwsIds = createPaginationIdsSelectorByEntity(ENTITY)
 const selectGtwsTotalCount = createPaginationTotalCountSelectorByEntity(ENTITY)
 
-export const selectGateways = state => selectGtwsIds(state).map(id => selectGatewayById(state, id))
+export const selectGateways = createSelector(
+  [selectGtwsIds, selectGatewayEntitiesStore],
+  (ids, entities) => ids.map(id => entities[id]),
+)
 export const selectGatewaysTotalCount = state => selectGtwsTotalCount(state)
 
 // Events.
@@ -85,7 +90,7 @@ export const selectGatewayStatisticsIsFetching = createFetchingSelector([
   UPDATE_GTW_STATS_BASE,
 ])
 export const selectGatewayStatistics = state => {
-  const statistics = selectGatewayStatisticsStore(state) || {}
+  const statistics = selectGatewayStatisticsStore(state)
 
   return statistics.stats
 }

--- a/pkg/webui/console/store/selectors/identity-server.js
+++ b/pkg/webui/console/store/selectors/identity-server.js
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const EMPTY_OBJ = {}
+
 const selectIsStore = state => state.is
 
 export const selectIsConfiguration = state => selectIsStore(state).configuration
 
-export const selectUserRegistration = state => selectIsConfiguration(state).user_registration || {}
+export const selectUserRegistration = state =>
+  selectIsConfiguration(state).user_registration || EMPTY_OBJ
 export const selectPasswordRequirements = state =>
-  selectUserRegistration(state).password_requirements || {}
+  selectUserRegistration(state).password_requirements || EMPTY_OBJ

--- a/pkg/webui/console/store/selectors/organizations.js
+++ b/pkg/webui/console/store/selectors/organizations.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { createSelector } from 'reselect'
+
 import {
   createPaginationIdsSelectorByEntity,
   createPaginationTotalCountSelectorByEntity,
@@ -54,16 +56,21 @@ const selectOrgsTotalCount = createPaginationTotalCountSelectorByEntity(ENTITY)
 const selectOrgsFetching = createFetchingSelector(GET_ORGS_LIST_BASE)
 const selectOrgsError = createErrorSelector(GET_ORGS_LIST_BASE)
 
-export const selectOrganizations = state =>
-  selectOrgsIds(state).map(id => selectOrganizationById(state, id))
+export const selectOrganizations = createSelector(
+  [selectOrgsIds, selectOrganizationEntitiesStore],
+  (ids, entities) => ids.map(id => entities[id]),
+)
 export const selectOrganizationsTotalCount = state => selectOrgsTotalCount(state)
 export const selectOrganizationsFetching = state => selectOrgsFetching(state)
 export const selectOrganizationsError = state => selectOrgsError(state)
-export const selectOrganizationsWithCollaboratorCount = state =>
-  selectOrganizations(state).map(org => ({
-    ...org,
-    _collaboratorCount: selectOrganizationCollaboratorCount(state, getOrganizationId(org)),
-  }))
+export const selectOrganizationsWithCollaboratorCount = createSelector(
+  [selectOrganizations, selectOrganizationCollaboratorCounts],
+  (orgs, collaboratorCounts) =>
+    orgs.map(org => ({
+      ...org,
+      _collaboratorCount: collaboratorCounts[getOrganizationId(org)] || 0,
+    })),
+)
 
 // Rights.
 export const selectOrganizationRights = createRightsSelector(ENTITY)

--- a/pkg/webui/console/store/selectors/packet-broker.js
+++ b/pkg/webui/console/store/selectors/packet-broker.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { createSelector } from 'reselect'
+
 import {
   createPaginationIdsSelectorByEntity,
   createPaginationTotalCountSelectorByEntity,
@@ -22,13 +24,14 @@ import { combinePacketBrokerIds } from '@ttn-lw/lib/selectors/id'
 
 import { GET_PACKET_BROKER_INFO_BASE } from '@console/store/actions/packet-broker'
 
+const EMPTY_OBJ = {}
 const ENTITY = 'packetBrokerNetworks'
 
 const selectPacketBrokerStore = state => state.packetBroker
 
 // General.
 export const selectInfo = state => selectPacketBrokerStore(state).info
-export const selectRegistration = state => selectInfo(state).registration || {}
+export const selectRegistration = state => selectInfo(state).registration || EMPTY_OBJ
 export const selectPacketBrokerOwnCombinedId = state =>
   combinePacketBrokerIds(selectRegistration(state).id)
 export const selectInfoFetching = createFetchingSelector(GET_PACKET_BROKER_INFO_BASE)
@@ -55,8 +58,10 @@ export const selectPacketBrokerNetworkById = (state, combinedId) =>
 const selectPBNetworksIds = createPaginationIdsSelectorByEntity(ENTITY)
 const selectPBNetworksTotalCount = createPaginationTotalCountSelectorByEntity(ENTITY)
 
-export const selectPacketBrokerNetworks = state =>
-  selectPBNetworksIds(state).map(netId => selectPacketBrokerNetworkById(state, netId))
+export const selectPacketBrokerNetworks = createSelector(
+  [selectPBNetworksIds, state => state],
+  (netIds, state) => netIds.map(netId => selectPacketBrokerNetworkById(state, netId)),
+)
 export const selectPacketBrokerNetworksTotalCount = state => selectPBNetworksTotalCount(state)
 
 // Policies.

--- a/pkg/webui/console/store/selectors/pubsub-formats.js
+++ b/pkg/webui/console/store/selectors/pubsub-formats.js
@@ -22,7 +22,7 @@ const selectPubsubFormatsStore = state => state.pubsubFormats
 export const selectPubsubFormats = state => {
   const store = selectPubsubFormatsStore(state)
 
-  return store.formats || {}
+  return store.formats
 }
 
 export const selectPubsubFormatsError = createErrorSelector(GET_PUBSUB_FORMATS_BASE)

--- a/pkg/webui/console/store/selectors/users.js
+++ b/pkg/webui/console/store/selectors/users.js
@@ -28,7 +28,7 @@ const ENTITY = 'users'
 const selectUserStore = state => state.users
 
 // User.
-export const selectUserEntitiesStore = state => selectUserStore(state)?.entities || {}
+export const selectUserEntitiesStore = state => selectUserStore(state)?.entities
 export const selectUserById = (state, id) => selectUserEntitiesStore(state)[id]
 export const selectSelectedUserId = state => selectUserStore(state).selectedUser
 export const selectSelectedUser = state => selectUserById(state, selectSelectedUserId(state))

--- a/pkg/webui/console/store/selectors/webhook-formats.js
+++ b/pkg/webui/console/store/selectors/webhook-formats.js
@@ -22,7 +22,7 @@ const selectWebhookFormatsStore = state => state.webhookFormats
 export const selectWebhookFormats = state => {
   const store = selectWebhookFormatsStore(state)
 
-  return store.formats || {}
+  return store.formats
 }
 
 export const selectWebhookFormatsError = createErrorSelector(GET_WEBHOOK_FORMATS_BASE)


### PR DESCRIPTION
#### Summary
This PR fixes all selectors to address warnings like these:
![image](https://github.com/TheThingsNetwork/lorawan-stack/assets/5710611/fbe603af-c2bf-4730-b187-a8d7a43dcef9)

#### Changes

- Make sure to maintain referential equality between selector calls with same arguments
  
#### Testing

This is purely an internal fix that does not affect the user experience. It should however slightly increase the performance as it will avoid unnecessary rerenders.

##### Regressions

There's a possibility that the changed default values for reducers can cause issues in some edge cases, however these should be caught by the end-to-end tests.

#### Notes for Reviewers

When building selectors, make sure to not use expressions like:
```
return property.foo || {}
```
Since these can cause the above warnings since it will potentially create a new object on each call. There's two ways to fix this:
1. Update the default values in the reducer to default to the empty object (not always possible)
2. Use a preassigned global empty value constant, `const EMPTY_OBJ = {}`, which will maintain referential equality.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
