### PR TITLE
Fix device downlink frame counter shown as `n/a`

### DIFF
--- a/pkg/webui/console/containers/device-title-section/index.js
+++ b/pkg/webui/console/containers/device-title-section/index.js
@@ -70,6 +70,7 @@ const DeviceTitleSection = props => {
   const showUplinkCount = typeof uplinkFrameCount === 'number'
   const showAppDownlinkCount = typeof downlinkAppFrameCount === 'number'
   const showNwkDownlinkCount = typeof downlinkNwkFrameCount === 'number'
+
   const notAvailableElem = <Message content={sharedMessages.notAvailable} />
   const downlinkValue =
     showAppDownlinkCount && showNwkDownlinkCount ? (
@@ -83,7 +84,7 @@ const DeviceTitleSection = props => {
       </>
     ) : showNwkDownlinkCount ? (
       <>
-        <FormattedNumber value={downlinkNwkFrameCount} /> {'(Nwk)'},
+        <FormattedNumber value={downlinkNwkFrameCount} /> {'(Nwk)'}
       </>
     ) : (
       notAvailableElem

--- a/pkg/webui/console/store/reducers/devices.js
+++ b/pkg/webui/console/store/reducers/devices.js
@@ -102,7 +102,7 @@ const devices = (state = defaultState, { type, payload, event }) => {
       if (session) {
         derived.uplinkFrameCount = session.last_f_cnt_up
         if (parseLorawanMacVersion(lorawanVersion) < 110) {
-          derived.downlinkFrameCount = session.last_n_f_cnt_down
+          derived.downlinkNwkFrameCount = session.last_n_f_cnt_down
         } else {
           // For 1.1+ end devices there are two frame counters.
           derived.downlinkAppFrameCount = session.last_a_f_cnt_down
@@ -166,11 +166,20 @@ const devices = (state = defaultState, { type, payload, event }) => {
         const lorawanVersion = getByPath(state.entities, `${combinedDeviceId}.lorawan_version`)
 
         if (parseLorawanMacVersion(lorawanVersion) < 110) {
-          const downlinkFrameCount = getByPath(event, 'data.payload.mac_payload.full_f_cnt')
-          if (typeof downlinkFrameCount === 'number') {
-            return mergeDerived(state, combinedDeviceId, {
-              downlinkFrameCount,
-            })
+          if (getByPath(event, 'data.payload.mac_payload.f_port') === undefined) {
+            const downlinkNwkFrameCount = getByPath(event, 'data.payload.mac_payload.full_f_cnt')
+            if (typeof downlinkNwkFrameCount === 'number') {
+              return mergeDerived(state, combinedDeviceId, {
+                downlinkNwkFrameCount,
+              })
+            }
+          } else if (getByPath(event, 'data.payload.mac_payload.f_port') > 0) {
+            const downlinkAppFrameCount = getByPath(event, 'data.payload.mac_payload.full_f_cnt')
+            if (typeof downlinkAppFrameCount === 'number') {
+              return mergeDerived(state, combinedDeviceId, {
+                downlinkAppFrameCount,
+              })
+            }
           }
         }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

This PR fixes device downlink frame counter shown as `n/a`

<img width="706" alt="Screenshot 2024-05-27 at 11 02 52" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/56658938/e51bba30-6d10-4b77-a2fe-f479f54bd0b1">

#### Changes

<!-- What are the changes made in this pull request? -->

- Fix variable naming
- Add port distinction for 1.0 devices ([https://thethingsindustries.slack.com/archives/C06UQSMPB/p1716799106056699?thread_ts=1716559985.601459&cid=C06UQSMPB](https://thethingsindustries.slack.com/archives/C06UQSMPB/p1716799106056699?thread_ts=1716559985.601459&cid=C06UQSMPB))

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Log into the console
2. Open a LoRaWAN 1.0 device and if there is a downlink counter it should be displayed.

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

<img width="528" alt="Screenshot 2024-05-27 at 11 11 43" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/56658938/7d06dc02-f243-4ea7-9fee-61a852897a94">

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
