### PR TITLE
Address duplicate key issue

### DIFF
--- a/pkg/webui/lib/components/message/index.js
+++ b/pkg/webui/lib/components/message/index.js
@@ -102,7 +102,7 @@ const Message = ({
     const contentWithMarkdown = formatMessage(content, vals)
     return renderContent(
       reactStringReplace(contentWithMarkdown, /`([^`[]+)`/g, (match, i) => (
-        <code key={i}>{match}</code>
+        <code key={`${match}-${i}`}>{match}</code>
       )),
       component,
       rest,


### PR DESCRIPTION
#### Summary

Small one-line fix for an issue that could potentially lead to duplicate keys, which is seen as warning in the console.

<img width="511" alt="image" src="https://github.com/TheThingsNetwork/lorawan-stack/assets/5710611/379e5791-ddfb-4159-85c0-baa38cc50536">


#### Changes

- Add the message to the key value instead of just the index (this is still not perfect but there's no better way I believe)

#### Notes for Reviewers

Issue can happen when a message uses multiple backtick formated sections that are automatically converted by the message component. This has to do with how `react-intl` interpolates message values (as arrays).

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
