### PR TITLE
Rename rate limit key `ws` to `semtechws/lbslns`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- The rate limit key for LoRa Basics Station has changed from `gs:accept:ws` to `gs:accept:semtechws/lbslns`.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/gatewayserver/io/semtechws/format.go
+++ b/pkg/gatewayserver/io/semtechws/format.go
@@ -37,6 +37,8 @@ type Endpoints struct {
 
 // Formatter abstracts messages to/from websocket based gateways.
 type Formatter interface {
+	// ID returns the ID of the formatter.
+	ID() string
 	// Endpoints fetches the connection endpoints for the protocol.
 	Endpoints() Endpoints
 	// HandleConnectionInfo handles connection information requests from web socket based protocols.

--- a/pkg/gatewayserver/io/semtechws/lbslns/format.go
+++ b/pkg/gatewayserver/io/semtechws/lbslns/format.go
@@ -40,6 +40,8 @@ func NewFormatter(maxRoundTripDelay time.Duration) semtechws.Formatter {
 	}
 }
 
+func (f *lbsLNS) ID() string { return "lbslns" }
+
 func (f *lbsLNS) Endpoints() semtechws.Endpoints {
 	return semtechws.Endpoints{
 		ConnectionInfo: "/router-info",

--- a/pkg/gatewayserver/io/semtechws/ws.go
+++ b/pkg/gatewayserver/io/semtechws/ws.go
@@ -96,7 +96,7 @@ func New(ctx context.Context, server io.Server, formatter Formatter, cfg Config)
 
 	router := w.RootRouter()
 	router.Use(
-		ratelimit.HTTPMiddleware(server.RateLimiter(), "gs:accept:ws"),
+		ratelimit.HTTPMiddleware(server.RateLimiter(), "gs:accept:"+s.Protocol()),
 	)
 
 	eps := s.formatter.Endpoints()

--- a/pkg/gatewayserver/io/semtechws/ws.go
+++ b/pkg/gatewayserver/io/semtechws/ws.go
@@ -61,7 +61,7 @@ type srv struct {
 	formatter Formatter
 }
 
-func (*srv) Protocol() string            { return "ws" }
+func (s *srv) Protocol() string          { return "semtechws/" + s.formatter.ID() }
 func (*srv) SupportsDownlinkClaim() bool { return false }
 func (*srv) DutyCycleStyle() scheduling.DutyCycleStyle {
 	return scheduling.DutyCycleStyleBlockingWindow

--- a/pkg/gatewayserver/io/semtechws/ws_test.go
+++ b/pkg/gatewayserver/io/semtechws/ws_test.go
@@ -1800,7 +1800,7 @@ func TestRateLimit(t *testing.T) {
 				Name:         "accept connections",
 				MaxPerMin:    maxRate,
 				MaxBurst:     maxRate,
-				Associations: []string{"gs:accept:ws"},
+				Associations: []string{"gs:accept:semtechws/lbslns"},
 			}},
 		}
 		withServer(t, defaultConfig, conf, func(t *testing.T, _ *mockis.MockDefinition, serverAddress string) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

Follow up on https://github.com/TheThingsNetwork/lorawan-stack/pull/7110

#### Changes

<!-- What are the changes made in this pull request? -->

This renames the `ws` ratelimit key to `semtechws/lbslns`.

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

N/A

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

N/A

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

This is a config changes. If there is custom rate limit config, there has to be an adjustment made. This is unfortunate but `ws` is just not a good key for Basic Station.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
