### PR TITLE
Fix mutated state in application reducer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Fix potential issue with application event stream stopping after showing initial events.
+
 ### Security
 
 ## [3.30.2] - unreleased

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "react-toastify": "^9.1.3",
     "react-virtualized-auto-sizer": "^1.0.24",
     "react-window": "^1.8.10",
-    "redux": "^4.2.1",
+    "redux": "^5.0.1",
     "redux-actions": "^2.6.5",
     "redux-logic": "^5.0.1",
     "reselect": "^5.1.0",

--- a/pkg/webui/console/store/index.js
+++ b/pkg/webui/console/store/index.js
@@ -49,7 +49,7 @@ const store = configureStore({
         ignoredActionPaths: ['meta._resolve', 'meta._reject'],
       },
     }).concat(middlewares),
-  enhancert: getDefaultEnhancers => getDefaultEnhancers().concat(enhancers),
+  enhancer: getDefaultEnhancers => getDefaultEnhancers().concat(enhancers),
   devTools: dev && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__,
 })
 

--- a/pkg/webui/console/store/reducers/devices.js
+++ b/pkg/webui/console/store/reducers/devices.js
@@ -209,7 +209,7 @@ const devices = (state = defaultState, { type, payload, event }) => {
         const id = getCombinedDeviceId(event.identifiers[0].device_ids)
         const receivedAt = getByPath(event, 'data.received_at')
         if (receivedAt) {
-          const currentEndDevice = state.entities[id]
+          const currentEndDevice = { ...state.entities[id] }
           if (currentEndDevice) {
             // Only update if the event was actually more recent than the current value.
             if (
@@ -217,6 +217,14 @@ const devices = (state = defaultState, { type, payload, event }) => {
               !currentEndDevice.last_seen_at
             ) {
               currentEndDevice.last_seen_at = receivedAt
+            }
+
+            return {
+              ...state,
+              entities: {
+                ...state.entities,
+                [id]: currentEndDevice,
+              },
             }
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1189,7 +1189,7 @@
     core-js "^2.6.12"
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.23.9", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.23.9", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
   integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
@@ -10620,13 +10620,6 @@ redux-thunk@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-3.1.0.tgz#94aa6e04977c30e14e892eae84978c1af6058ff3"
   integrity sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==
-
-redux@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
-  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
 
 redux@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
#### Summary

This quickfix PR will fix an issue that can make the application stream stop after fetching the initial events.

#### Changes

- Fix mutated state object in the `GET_APP_EVENT_MESSAGE_SUCCESS` reducer
- Fix typo in store setup

#### Testing

##### Steps

1. Go to the device list view of an application
2. After around 15 seconds, go to the live data page
3. Observe that the live data has stopped working

#### Notes for Reviewers

The issue is related to the [recent store updates](https://github.com/TheThingsNetwork/lorawan-stack/pull/7083) in that the store is now stricter in preventing reducers that mutate the store object directly.

@PavelJankoski I will fix the storybook setup in a separate PR which targets the redesign branch.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
