### PR TITLE
Fix empty downlink in application layer clock synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Fixed an issue where an downlink message was scheduled by the Application Layer Clock Synchronization (ALCS) implementation when there is no answer to send (i.e. `AnsRequired` is not set and the difference with what the end device reports falls within the threshold).
+
 ### Security
 
 ## [3.31.0] - unreleased

--- a/pkg/applicationserver/io/packages/alcsync/v1/alcsync.go
+++ b/pkg/applicationserver/io/packages/alcsync/v1/alcsync.go
@@ -64,13 +64,13 @@ func newTimeSyncCommand(
 	return cmd, rest, nil
 }
 
-// MakeCommands parses the uplink payload and returns the commands.
-func MakeCommands(up *ttnpb.ApplicationUplink, fPort uint32, data *packageData) ([]Command, events.Builders, error) {
+// parseCommands parses the uplink payload and returns the commands.
+func parseCommands(up *ttnpb.ApplicationUplink, fPort uint32, data *packageData) ([]Command, events.Builders, error) {
 	cID, cPayload := ttnpb.ALCSyncCommandIdentifier(up.FrmPayload[0]), up.FrmPayload[1:]
 	commands := make([]Command, 0)
 	evts := make(events.Builders, 0)
 	for {
-		cmd, rest, err := makeCommand(cID, cPayload, up, fPort, data)
+		cmd, rest, err := parseCommand(cID, cPayload, up, fPort, data)
 		if err != nil {
 			err := errCommandCreationFailed.WithCause(err).WithAttributes(
 				"command_id", cID,
@@ -91,8 +91,8 @@ func MakeCommands(up *ttnpb.ApplicationUplink, fPort uint32, data *packageData) 
 	return commands, evts, nil
 }
 
-// makeCommand parses the payload based on the command ID.
-func makeCommand(
+// parseCommand parses the payload based on the command ID.
+func parseCommand(
 	cID ttnpb.ALCSyncCommandIdentifier,
 	cPayload []byte,
 	up *ttnpb.ApplicationUplink,
@@ -119,8 +119,8 @@ func makeCommand(
 	}
 }
 
-// MakeDownlink builds a single downlink message from the results.
-func MakeDownlink(results []Result, fPort uint32) (*ttnpb.ApplicationDownlink, error) {
+// buildDownlink builds a single downlink message from the results.
+func buildDownlink(results []Result, fPort uint32) (*ttnpb.ApplicationDownlink, error) {
 	frmPayload := make([]byte, 0)
 	for _, result := range results {
 		if result == nil {

--- a/pkg/applicationserver/io/packages/alcsync/v1/alcsync_test.go
+++ b/pkg/applicationserver/io/packages/alcsync/v1/alcsync_test.go
@@ -209,7 +209,7 @@ func TestMakeCommandValidInput(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			a, _ := test.New(t)
-			cmd, rest, err := makeCommand(tc.In.CID, tc.In.CPayload, uplink, fPort, data)
+			cmd, rest, err := parseCommand(tc.In.CID, tc.In.CPayload, uplink, fPort, data)
 			a.So(err, should.BeNil)
 			a.So(cmd.Code(), should.Resemble, tc.Expected.CID)
 			a.So(rest, should.Resemble, tc.Expected.Rest)
@@ -277,7 +277,7 @@ func TestMakeCommandInvalidInput(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			a, _ := test.New(t)
-			cmd, rest, err := makeCommand(tc.In.CID, tc.In.CPayload, uplink, fPort, data)
+			cmd, rest, err := parseCommand(tc.In.CID, tc.In.CPayload, uplink, fPort, data)
 			a.So(cmd, should.BeNil)
 			a.So(rest, should.Resemble, tc.Expected.Rest)
 			a.So(err, should.Resemble, tc.Expected.Err)
@@ -471,7 +471,7 @@ func TestMakeCommandsValidInput(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			a, _ := test.New(t)
-			cmds, _, err := MakeCommands(tc.In.Uplink, tc.In.FPort, tc.In.Data)
+			cmds, _, err := parseCommands(tc.In.Uplink, tc.In.FPort, tc.In.Data)
 			a.So(err, should.Resemble, tc.Expected.Err)
 			a.So(cmds, should.Resemble, tc.Expected.Cmds)
 		})
@@ -593,7 +593,7 @@ func TestMakeDownlinkSerializesAppTimeAns(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			a, _ := test.New(t)
-			downlink, err := MakeDownlink(tc.In.Ans, tc.In.FPort)
+			downlink, err := buildDownlink(tc.In.Ans, tc.In.FPort)
 			a.So(err, should.BeNil)
 			a.So(downlink, should.Resemble, tc.Expected.Downlink)
 		})


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

This resolves an issue where an empty downlink message is sent when there is no answer to `AppTimeReq`.

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1088

#### Changes

<!-- What are the changes made in this pull request? -->

When there there is no answer to send, do not send an empty downlink message.

#### Testing

Let's verify with the customer in https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1088.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

None expected

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
