### PR TITLE
Blurry device network activity panel 

### DIFF
--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -30,6 +30,7 @@ import Message from '@ttn-lw/lib/components/message'
 import DateTime from '@ttn-lw/lib/components/date-time'
 
 import DeviceMap from '@console/components/device-map'
+import BlurryNetworkActivityPanel from '@console/components/blurry-network-activity-panel'
 
 import DeviceEvents from '@console/containers/device-events'
 
@@ -347,6 +348,12 @@ const DeviceOverview = () => {
   }
   return (
     <Require condition={!shouldRedirect} otherwise={otherwise}>
+      <div className="container container--lg grid">
+        <div className="item-12 md:item-12 lg:item-6 sm:item-6" />
+        <div className="item-12 md:item-12 lg:item-6 sm:item-6">
+          <BlurryNetworkActivityPanel />
+        </div>
+      </div>
       <div className="container container--lg grid p-vert-0">
         <IntlHelmet title={sharedMessages.overview} />
         <div className="item-12 lg:item-6">


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

Backport device network activity panel with always showing the blurry version.

