### PR TITLE
Exit early when no MAC version is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,10 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
-- Fix potential issue with application event stream stopping after showing initial events.
-- Fix storybook compiling issue.
-- Fixed an issue where an downlink message was scheduled by the Application Layer Clock Synchronization (ALCS) implementation when there is no answer to send (i.e. `AnsRequired` is not set and the difference with what the end device reports falls within the threshold).
-
+- Potential issue with application event stream stopping after showing initial events.
+- Storybook compiling issue.
+- Issue where an downlink message was scheduled by the Application Layer Clock Synchronization (ALCS) implementation when there is no answer to send (i.e. `AnsRequired` is not set and the difference with what the end device reports falls within the threshold).
+- Error log level and reporting when an end device attempts to join that does not have a MAC version set. Instead, the Network Server now publishes a drop join-request event.
 
 ## [3.30.2] - 2024-06-11
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -8162,6 +8162,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/networkserver:unknown_mac_version": {
+    "translations": {
+      "en": "MAC version is unknown"
+    },
+    "description": {
+      "package": "pkg/networkserver",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/networkserver:unknown_nwk_s_enc_key": {
     "translations": {
       "en": "NwkSEncKey is unknown"

--- a/pkg/networkserver/errors.go
+++ b/pkg/networkserver/errors.go
@@ -49,6 +49,7 @@ var (
 	errRawPayloadTooShort                 = errors.Define("raw_payload_too_short", "length of RawPayload must not be less than 4")
 	errSchedule                           = errors.Define("schedule", "all downlink scheduling attempts failed")
 	errUnknownMACState                    = errors.DefineFailedPrecondition("unknown_mac_state", "MAC state is unknown")
+	errUnknownMACVersion                  = errors.DefineFailedPrecondition("unknown_mac_version", "MAC version is unknown")
 	errUnknownNwkSEncKey                  = errors.DefineNotFound("unknown_nwk_s_enc_key", "NwkSEncKey is unknown")
 	errUnknownSession                     = errors.DefineNotFound("unknown_session", "unknown session")
 	errUnknownSNwkSIntKey                 = errors.DefineNotFound("unknown_s_nwk_s_int_key", "SNwkSIntKey is unknown")

--- a/pkg/networkserver/errors.go
+++ b/pkg/networkserver/errors.go
@@ -19,39 +19,68 @@ import (
 )
 
 var (
-	errABPJoinRequest                     = errors.DefineInvalidArgument("abp_join_request", "received a join-request from ABP device")
-	errApplicationDownlinkTooLong         = errors.DefineInvalidArgument("application_downlink_too_long", "application downlink payload length `{length}` exceeds maximum '{max}'")
-	errDeviceAndFrequencyPlanBandMismatch = errors.DefineInvalidArgument("device_and_frequency_plan_band_mismatch", "device band ID `{dev_band_id}` and frequency plan band ID `{fp_band_id}` do not match")
-	errComputeMIC                         = errors.DefineInvalidArgument("compute_mic", "compute MIC")
-	errConfirmedDownlinkTooSoon           = errors.DefineUnavailable("confirmed_too_soon", "confirmed downlink is scheduled too soon")
-	errConfirmedMulticastDownlink         = errors.DefineInvalidArgument("confirmed_multicast_downlink", "confirmed downlink queued for multicast device")
-	errDataRateNotFound                   = errors.DefineNotFound("data_rate_not_found", "data rate not found", "data_rate")
-	errDataRateIndexNotFound              = errors.DefineNotFound("data_rate_index_not_found", "data rate with index `{index}` not found")
-	errDecodePayload                      = errors.DefineInvalidArgument("decode_payload", "decode payload")
-	errDuplicateUplink                    = errors.DefineAlreadyExists("duplicate_uplink", "duplicate uplink")
-	errDeviceNotFound                     = errors.DefineNotFound("device_not_found", "device not found")
-	errEmptySession                       = errors.DefineFailedPrecondition("empty_session", "session in empty")
-	errEncodeMAC                          = errors.DefineInternal("encode_mac", "encode MAC commands")
-	errEncodePayload                      = errors.Define("encode_payload", "encode payload")
-	errEncryptMAC                         = errors.DefineInternal("encrypt_mac", "encrypt MAC commands")
-	errExpiredDownlink                    = errors.DefineFailedPrecondition("downlink_expired", "queued downlink is expired")
-	errFCntTooLow                         = errors.DefineInvalidArgument("f_cnt_too_low", "FCnt `{f_cnt}` is lower than minimum of `{min_f_cnt}`")
-	errInvalidAbsoluteTime                = errors.DefineInvalidArgument("absolute_time", "invalid absolute time set in application downlink")
-	errInvalidChannelIndex                = errors.DefineInvalidArgument("channel_index", "invalid channel index")
-	errInvalidConfiguration               = errors.DefineInvalidArgument("configuration", "invalid configuration")
-	errInvalidDataRate                    = errors.DefineInvalidArgument("data_rate", "invalid data rate")
-	errInvalidFieldValue                  = errors.DefineInvalidArgument("field_value", "invalid value of field `{field}`")
-	errInvalidFixedPaths                  = errors.DefineInvalidArgument("fixed_paths", "invalid fixed paths set in application downlink")
-	errInvalidPayload                     = errors.DefineInvalidArgument("payload", "invalid payload")
-	errJoinServerNotFound                 = errors.DefineNotFound("join_server_not_found", "Join Server not found")
-	errNoPath                             = errors.DefineNotFound("no_downlink_path", "no downlink path available")
-	errOutdatedData                       = errors.DefineFailedPrecondition("outdated_data", "data is outdated")
-	errRawPayloadTooShort                 = errors.Define("raw_payload_too_short", "length of RawPayload must not be less than 4")
-	errSchedule                           = errors.Define("schedule", "all downlink scheduling attempts failed")
-	errUnknownMACState                    = errors.DefineFailedPrecondition("unknown_mac_state", "MAC state is unknown")
-	errUnknownMACVersion                  = errors.DefineFailedPrecondition("unknown_mac_version", "MAC version is unknown")
-	errUnknownNwkSEncKey                  = errors.DefineNotFound("unknown_nwk_s_enc_key", "NwkSEncKey is unknown")
-	errUnknownSession                     = errors.DefineNotFound("unknown_session", "unknown session")
-	errUnknownSNwkSIntKey                 = errors.DefineNotFound("unknown_s_nwk_s_int_key", "SNwkSIntKey is unknown")
-	errUplinkChannelNotFound              = errors.DefineNotFound("uplink_channel_not_found", "uplink channel not found")
+	errABPJoinRequest = errors.DefineInvalidArgument(
+		"abp_join_request", "received a join-request from ABP device",
+	)
+	errApplicationDownlinkTooLong = errors.DefineInvalidArgument(
+		"application_downlink_too_long", "application downlink payload length `{length}` exceeds maximum '{max}'",
+	)
+	errDeviceAndFrequencyPlanBandMismatch = errors.DefineInvalidArgument(
+		"device_and_frequency_plan_band_mismatch",
+		"device band ID `{dev_band_id}` and frequency plan band ID `{fp_band_id}` do not match",
+	)
+	errComputeMIC               = errors.DefineInvalidArgument("compute_mic", "compute MIC")
+	errConfirmedDownlinkTooSoon = errors.DefineUnavailable(
+		"confirmed_too_soon", "confirmed downlink is scheduled too soon",
+	)
+	errConfirmedMulticastDownlink = errors.DefineInvalidArgument(
+		"confirmed_multicast_downlink", "confirmed downlink queued for multicast device",
+	)
+	errDataRateNotFound = errors.DefineNotFound(
+		"data_rate_not_found", "data rate not found", "data_rate",
+	)
+	errDataRateIndexNotFound = errors.DefineNotFound(
+		"data_rate_index_not_found", "data rate with index `{index}` not found",
+	)
+	errDecodePayload   = errors.DefineInvalidArgument("decode_payload", "decode payload")
+	errDuplicateUplink = errors.DefineAlreadyExists("duplicate_uplink", "duplicate uplink")
+	errDeviceNotFound  = errors.DefineNotFound("device_not_found", "device not found")
+	errEmptySession    = errors.DefineFailedPrecondition("empty_session", "session in empty")
+	errEncodeMAC       = errors.DefineInternal("encode_mac", "encode MAC commands")
+	errEncodePayload   = errors.Define("encode_payload", "encode payload")
+	errEncryptMAC      = errors.DefineInternal("encrypt_mac", "encrypt MAC commands")
+	errExpiredDownlink = errors.DefineFailedPrecondition(
+		"downlink_expired", "queued downlink is expired",
+	)
+	errFCntTooLow = errors.DefineInvalidArgument(
+		"f_cnt_too_low", "FCnt `{f_cnt}` is lower than minimum of `{min_f_cnt}`",
+	)
+	errInvalidAbsoluteTime = errors.DefineInvalidArgument(
+		"absolute_time", "invalid absolute time set in application downlink",
+	)
+	errInvalidChannelIndex  = errors.DefineInvalidArgument("channel_index", "invalid channel index")
+	errInvalidConfiguration = errors.DefineInvalidArgument("configuration", "invalid configuration")
+	errInvalidDataRate      = errors.DefineInvalidArgument("data_rate", "invalid data rate")
+	errInvalidFieldValue    = errors.DefineInvalidArgument(
+		"field_value", "invalid value of field `{field}`",
+	)
+	errInvalidFixedPaths = errors.DefineInvalidArgument(
+		"fixed_paths", "invalid fixed paths set in application downlink",
+	)
+	errInvalidPayload     = errors.DefineInvalidArgument("payload", "invalid payload")
+	errJoinServerNotFound = errors.DefineNotFound("join_server_not_found", "Join Server not found")
+	errNoPath             = errors.DefineNotFound("no_downlink_path", "no downlink path available")
+	errOutdatedData       = errors.DefineFailedPrecondition("outdated_data", "data is outdated")
+	errRawPayloadTooShort = errors.Define(
+		"raw_payload_too_short", "length of RawPayload must not be less than 4",
+	)
+	errSchedule          = errors.Define("schedule", "all downlink scheduling attempts failed")
+	errUnknownMACState   = errors.DefineFailedPrecondition("unknown_mac_state", "MAC state is unknown")
+	errUnknownMACVersion = errors.DefineFailedPrecondition(
+		"unknown_mac_version", "MAC version is unknown",
+	)
+	errUnknownNwkSEncKey     = errors.DefineNotFound("unknown_nwk_s_enc_key", "NwkSEncKey is unknown")
+	errUnknownSession        = errors.DefineNotFound("unknown_session", "unknown session")
+	errUnknownSNwkSIntKey    = errors.DefineNotFound("unknown_s_nwk_s_int_key", "SNwkSIntKey is unknown")
+	errUplinkChannelNotFound = errors.DefineNotFound("uplink_channel_not_found", "uplink channel not found")
 )

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1268,8 +1268,15 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 		publishEvents(ctx, queuedEvents...)
 	}()
 
+	if matched.LorawanVersion == ttnpb.MACVersion_MAC_UNKNOWN {
+		log.FromContext(ctx).Info("Unknown LoRaWAN version")
+		queuedEvents = append(queuedEvents,
+			evtDropJoinRequest.NewWithIdentifiersAndData(ctx, matched.Ids, errUnknownMACVersion),
+		)
+		return nil
+	}
 	if !matched.SupportsJoin {
-		log.FromContext(ctx).Warn("ABP device sent a join-request, drop")
+		log.FromContext(ctx).Info("ABP device sent a join-request, drop")
 		queuedEvents = append(queuedEvents, evtDropJoinRequest.NewWithIdentifiersAndData(ctx, matched.Ids, errABPJoinRequest))
 		return nil
 	}

--- a/pkg/webui/locales/ja.json
+++ b/pkg/webui/locales/ja.json
@@ -2415,6 +2415,7 @@
   "error:pkg/networkserver:schedule": "全てのスケジュールされたダウンリンクが失敗に終わりました",
   "error:pkg/networkserver:transmission": "ダウンリンク伝送が結果 `{result}` で失敗しました",
   "error:pkg/networkserver:unknown_mac_state": "不明なMAC状態",
+  "error:pkg/networkserver:unknown_mac_version": "",
   "error:pkg/networkserver:unknown_nwk_s_enc_key": "不明なNwkSEncKey",
   "error:pkg/networkserver:unknown_s_nwk_s_int_key": "不明なSNwkSIntKey",
   "error:pkg/networkserver:unknown_session": "不明なセッション",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

Fix for panic when handling a join-request for an OTAA device that does not have a MAC version set.

Resolves https://the-things-industries.sentry.io/share/issue/b1df49dad26f49c6946a8d1b8dcb644a/

#### Changes

<!-- What are the changes made in this pull request? -->

Exit early when no MAC version is known.

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Create device, via CLI:

```
$ ttn-lw-cli dev create APP DEVICE --supports-join --join-eui JOINEUI --dev-eui DEVEUI
```

e.g. leave out `--lorawan-version` but indicate OTAA.

2. Send a join-request, you can do this with the uplink simulator or with a physical end device. It doesn't matter that we don't have root keys set:

```
$ ttn-lw-cli simulate gateway-join-request --app-key $(openssl rand -hex 16) --dev-nonce 0001 \
  --join-eui JOINEUI --dev-eui DEVEUI --band-id EU_863_870 --frequency 868100000 \
  --lorawan-version MAC_V1_0_4 --lorawan-phy-version RP002_V1_0_4 \
  --gateway-id GATEWAY
```

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

You should see a join-request dropped event for the end device:

```json
  "data": {
    "@type": "type.googleapis.com/ttn.lorawan.v3.ErrorDetails",
    "namespace": "pkg/networkserver",
    "name": "unknown_mac_version",
    "message_format": "MAC version is unknown",
    "correlation_id": "d894cfcbac544599898ab6faaf51b9a9",
    "code": 9
  },
```

If you have access to infrastructure logs, you should not see an error of a request panic that is recovered:

```
INFO	Unknown LoRaWAN version	{"bandwidth": 125000, "dev_eui": "1122334455667788", "device_uid": "test-otaa.test-device", "frequency": 868100000, "grpc.method": "HandleUplink", "grpc.service": "ttn.lorawan.v3.GsNs", "join_eui": "0000000000000000", "m_type": "JOIN_REQUEST", "major": "LORAWAN_R1", "namespace": "networkserver", "phy_payload_len": 23, "received_at": 1721463455.514845, "request_id": "01J37KFFRTJTQ0T58PYEZ2YTCS", "spreading_factor": 12}
```

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

None

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
