### PR TITLE
Fix interference of entity prefetching data with store state

### DIFF
--- a/pkg/webui/console/store/actions/applications.js
+++ b/pkg/webui/console/store/actions/applications.js
@@ -141,6 +141,22 @@ export const [
   },
 ] = createPaginationRequestActions(SHARED_NAME)
 
+export const FETCH_APPS_LIST_BASE = 'FETCH_APPS_LIST'
+export const [
+  { request: FETCH_APPS_LIST, success: FETCH_APPS_LIST_SUCCESS, failure: FETCH_APPS_LIST_FAILURE },
+  {
+    request: fetchApplicationsList,
+    success: fetchApplicationsListSuccess,
+    failure: fetchApplicationsListFailure,
+  },
+] = createRequestActions(
+  FETCH_APPS_LIST_BASE,
+  ({ page, limit, query, order, deleted } = {}) => ({
+    params: { page, limit, query, order, deleted },
+  }),
+  (_, selectors = [], options = {}) => ({ selectors, options }),
+)
+
 export const GET_APPS_RIGHTS_LIST_BASE = createGetRightsListActionType(SHARED_NAME)
 export const [
   {

--- a/pkg/webui/console/store/actions/devices.js
+++ b/pkg/webui/console/store/actions/devices.js
@@ -84,6 +84,23 @@ export const [
   { request: getDevicesList, success: getDevicesListSuccess, failure: getDevicesListFailure },
 ] = createPaginationByIdRequestActions(SHARED_NAME)
 
+export const FETCH_DEVICES_LIST_BASE = 'FETCH_END_DEVICE_LIST'
+export const [
+  {
+    request: FETCH_DEVICES_LIST,
+    success: FETCH_DEVICES_LIST_SUCCESS,
+    failure: FETCH_DEVICES_LIST_FAILURE,
+  },
+  { request: fetchDevicesList, success: fetchDevicesListSuccess, failure: fetchDevicesListFailure },
+] = createRequestActions(
+  FETCH_DEVICES_LIST_BASE,
+  (id, { page, limit, query, order } = {}) => ({
+    id,
+    params: { page, limit, query, order },
+  }),
+  (id, params, selectors = [], options = {}) => ({ selectors, options }),
+)
+
 export const RESET_DEV_BASE = 'RESET_END_DEVICE'
 export const [
   { request: RESET_DEV, success: RESET_DEV_SUCCESS, failure: RESET_DEV_FAILURE },

--- a/pkg/webui/console/store/actions/gateways.js
+++ b/pkg/webui/console/store/actions/gateways.js
@@ -100,6 +100,22 @@ export const [
   { request: getGatewaysList, success: getGatewaysListSuccess, failure: getGatewaysListFailure },
 ] = createPaginationRequestActions(SHARED_NAME)
 
+export const FETCH_GTWS_LIST_BASE = 'FETCH_GTWS_LIST'
+export const [
+  { request: FETCH_GTWS_LIST, success: FETCH_GTWS_LIST_SUCCESS, failure: FETCH_GTWS_LIST_FAILURE },
+  {
+    request: fetchGatewaysList,
+    success: fetchGatewaysListSuccess,
+    failure: fetchGatewaysListFailure,
+  },
+] = createRequestActions(
+  FETCH_GTWS_LIST_BASE,
+  ({ page, limit, query, order, deleted } = {}) => ({
+    params: { page, limit, query, order, deleted },
+  }),
+  (_, selectors = [], options = {}) => ({ selectors, options }),
+)
+
 export const GET_GTWS_RIGHTS_LIST_BASE = createGetRightsListActionType(SHARED_NAME)
 export const [
   {

--- a/pkg/webui/console/store/middleware/logics/applications.js
+++ b/pkg/webui/console/store/middleware/logics/applications.js
@@ -107,8 +107,7 @@ const restoreApplicationLogic = createRequestLogic({
 })
 
 const getApplicationsLogic = createRequestLogic({
-  type: applications.GET_APPS_LIST,
-  latest: true,
+  type: [applications.GET_APPS_LIST, applications.FETCH_APPS_LIST],
   process: async ({ action }, dispatch) => {
     const {
       params: { page, limit, query, order, deleted },

--- a/pkg/webui/console/store/middleware/logics/devices.js
+++ b/pkg/webui/console/store/middleware/logics/devices.js
@@ -119,7 +119,7 @@ const deleteDeviceLogic = createRequestLogic({
 })
 
 const getDevicesListLogic = createRequestLogic({
-  type: devices.GET_DEVICES_LIST,
+  type: [devices.GET_DEVICES_LIST, devices.FETCH_DEVICES_LIST],
   process: async ({ action }) => {
     const {
       id: appId,

--- a/pkg/webui/console/store/middleware/logics/gateways.js
+++ b/pkg/webui/console/store/middleware/logics/gateways.js
@@ -93,8 +93,7 @@ const restoreGatewayLogic = createRequestLogic({
 })
 
 const getGatewaysLogic = createRequestLogic({
-  type: gateways.GET_GTWS_LIST,
-  latest: true,
+  type: [gateways.GET_GTWS_LIST, gateways.FETCH_GTWS_LIST],
   process: async ({ action }) => {
     const {
       params: { page, limit, query, order, deleted },

--- a/pkg/webui/console/store/middleware/logics/organizations.js
+++ b/pkg/webui/console/store/middleware/logics/organizations.js
@@ -38,7 +38,6 @@ const getOrganizationLogic = createRequestLogic({
 
 const getOrganizationsLogic = createRequestLogic({
   type: organizations.GET_ORGS_LIST,
-  latest: true,
   process: async ({ action }, dispatch) => {
     const {
       params: { page, limit, order, query, deleted },

--- a/pkg/webui/console/store/middleware/logics/top-entities.js
+++ b/pkg/webui/console/store/middleware/logics/top-entities.js
@@ -28,9 +28,9 @@ import { getTypeAndId } from '@console/lib/recency-frequency-entities'
 
 import { GET_TOP_ENTITIES } from '@console/store/actions/top-entities'
 import { getBookmarksList } from '@console/store/actions/user-preferences'
-import { getApplication, getApplicationsList } from '@console/store/actions/applications'
-import { getGateway, getGatewaysList } from '@console/store/actions/gateways'
-import { getDevice, getDevicesList } from '@console/store/actions/devices'
+import { fetchApplicationsList, getApplication } from '@console/store/actions/applications'
+import { fetchGatewaysList, getGateway } from '@console/store/actions/gateways'
+import { fetchDevicesList, getDevice } from '@console/store/actions/devices'
 
 import { selectUserId } from '@account/store/selectors/user'
 import {
@@ -134,11 +134,11 @@ const fetchTopEntities = async (getState, dispatch) => {
     try {
       await Promise.all([
         dispatch(
-          attachPromise(getApplicationsList({ page: 1, limit: prefetchLimit, order }, ['name'])),
+          attachPromise(fetchApplicationsList({ page: 1, limit: prefetchLimit, order }, ['name'])),
         ),
         dispatch(
           attachPromise(
-            getGatewaysList(
+            fetchGatewaysList(
               { page: 1, limit: prefetchLimit, order },
               ['name', 'gateway_server_address'],
               {
@@ -173,7 +173,7 @@ const fetchTopEntities = async (getState, dispatch) => {
         try {
           return await dispatch(
             attachPromise(
-              getDevicesList(entityId, { page: 1, limit: 1000, order }, ['name', 'last_seen_at']),
+              fetchDevicesList(entityId, { page: 1, limit: 1000, order }, ['name', 'last_seen_at']),
             ),
           )
         } catch (error) {

--- a/pkg/webui/console/store/reducers/applications.js
+++ b/pkg/webui/console/store/reducers/applications.js
@@ -27,6 +27,7 @@ import {
   DELETE_APP_SUCCESS,
   GET_APP_EVENT_MESSAGE_SUCCESS,
   GET_MQTT_INFO_SUCCESS,
+  FETCH_APPS_LIST_SUCCESS,
 } from '@console/store/actions/applications'
 
 const application = (state = {}, application) => ({
@@ -52,6 +53,7 @@ const applications = (state = defaultState, { type, payload, event, meta }) => {
         selectedApplication: payload.id,
       }
     case GET_APPS_LIST_SUCCESS:
+    case FETCH_APPS_LIST_SUCCESS:
       const entities = payload.entities.reduce(
         (acc, app) => {
           const id = getApplicationId(app)

--- a/pkg/webui/console/store/reducers/devices.js
+++ b/pkg/webui/console/store/reducers/devices.js
@@ -30,6 +30,7 @@ import {
   RESET_DEV_SUCCESS,
   GET_DEVICE_EVENT_MESSAGE_SUCCESS,
   DELETE_DEV_SUCCESS,
+  FETCH_DEVICES_LIST_SUCCESS,
 } from '@console/store/actions/devices'
 import { GET_APP_EVENT_MESSAGE_SUCCESS } from '@console/store/actions/applications'
 
@@ -156,6 +157,7 @@ const devices = (state = defaultState, { type, payload, event, meta }) => {
       }
 
       return mergeDerived(state, combinedId, defaultDerived)
+    case FETCH_DEVICES_LIST_SUCCESS:
     case GET_DEVICES_LIST_SUCCESS:
       const newEntities = payload.entities.reduce(
         (acc, dev) => {

--- a/pkg/webui/console/store/reducers/gateways.js
+++ b/pkg/webui/console/store/reducers/gateways.js
@@ -26,6 +26,7 @@ import {
   UPDATE_GTW_STATS_FAILURE,
   START_GTW_STATS_SUCCESS,
   START_GTW_STATS_FAILURE,
+  FETCH_GTWS_LIST_SUCCESS,
 } from '@console/store/actions/gateways'
 
 const defaultStatisticsState = {
@@ -123,6 +124,7 @@ const gateways = (state = defaultState, action) => {
         selectedGateway: null,
         entities: rest,
       }
+    case FETCH_GTWS_LIST_SUCCESS:
     case GET_GTWS_LIST_SUCCESS:
       const entities = payload.entities.reduce(
         (acc, gtw) => {

--- a/pkg/webui/lib/store/actions/attach-promise.js
+++ b/pkg/webui/lib/store/actions/attach-promise.js
@@ -68,8 +68,11 @@ export default actionOrActionCreator => {
  * Helper function to retrieve the result action types based
  * on the request action type.
  *
- * @param {string} typeString - The request action type.
+ * @param {string|Array<string>} type - The request action type.
  * @param {string} status - The result type, either `SUCCESS`, `FAILURE` or `ABORT`.
  * @returns {string} - The result action type.
  */
-export const getResultActionFromType = (typeString, status) => typeString.replace('REQUEST', status)
+export const getResultActionFromType = (type, status) =>
+  type instanceof Array
+    ? type.map(t => t.replace('REQUEST', status))
+    : type.replace('REQUEST', status)


### PR DESCRIPTION
#### Summary

This quickfix fixes an issue with the entity fetching store logic in the Console redesign branch, related to how entities are prefetched for the top entities logic.
#### Changes

- Introduce new actions for fetching entities without affecting the pagination store which stores the IDs of a particular pagination request
- Update the create-request-logic middleware to allow for logics with multiple action types.

#### Testing

##### Steps

1. Go to the application list view
2. (As admin) click on the "All" tab
3. Refresh
4. See the correct tab being active and the correct entities being still shown

#### Notes for Reviewers

Some more background:
Previously I was using the regular `GET_XXX_LIST`-actions, which connect to the pagination reducer (`pkg/webui/lib/store/reducers/pagination.js`). This means that they store the list of IDs that are connected to the paginated requests, so that the Console can select them from the global list of entities and show them in the current list view. Currently the list actions run concurrently and whichever resolves last will win (I've also removed `latest` option for this reason), which can sometimes be the prefetch for the top entities. If we just fetch the entities to have them in the store, we don't want to mess with the pagination store, as they are not meant to be displayed the current list view. Hence, creating a new set of `FETCH_XXX_LIST`-actions which do the same as the regular `GET_XXX_LIST` except storing the IDs in the pagination store will resolve this issue.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
