### PR TITLE
Set last gateway location on claim

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	go.packetbroker.org/api/mapping/v2 v2.3.2
 	go.packetbroker.org/api/routing v1.9.2
 	go.packetbroker.org/api/v3 v3.17.1
-	go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240729145607-ea516688afbd
+	go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240823134410-68cd7baab6c5
 	go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df
 	go.thethings.network/lorawan-application-payload v0.0.0-20220125153912-1198ff1e403e
 	go.thethings.network/lorawan-stack-legacy/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -658,8 +658,8 @@ go.packetbroker.org/api/routing v1.9.2 h1:J4+4vYZxa60UWC70Y9yy7sktU7DXaAp9Q13Bfq
 go.packetbroker.org/api/routing v1.9.2/go.mod h1:kd2K7gieDI35YfPA8/zDmLX3qiKPuXia/MA77BEAeUA=
 go.packetbroker.org/api/v3 v3.17.1 h1:LcyFPUGqVubGWMvQ16tZlQIKd+noGx7urzEYhSLiEQA=
 go.packetbroker.org/api/v3 v3.17.1/go.mod h1:6bVbdWAYLnvZ5kgXxA7GBQvZTN7vxI0DoF1Di1NoAT4=
-go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240729145607-ea516688afbd h1:FvD516hdD/iWqoS20SFdcoiUgwRJP3egNXNiN+Ux2d0=
-go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240729145607-ea516688afbd/go.mod h1:2+WsMwIunNLh22oauBzGL56JazE3UY34W1fstqEbacw=
+go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240823134410-68cd7baab6c5 h1:w4NvcBAq7JCwlfthvGw1PRWuI6pCf5TlIjKgFHKml8M=
+go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240823134410-68cd7baab6c5/go.mod h1:2+WsMwIunNLh22oauBzGL56JazE3UY34W1fstqEbacw=
 go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df h1:IMSctPllwEtJLyM/1AWgBiN1NPwBKqEVkCiK0I/MNY4=
 go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df/go.mod h1:89OU623VYKW9i3W4CZgIGFmtgb/jsN8JV2PAuCsj+7w=
 go.thethings.network/lorawan-application-payload v0.0.0-20220125153912-1198ff1e403e h1:TWGQ3lh7gI2W5hnb6qPdpoAa0d7s/XPwvgf2VVCMJaY=

--- a/pkg/deviceclaimingserver/gateways/gateways.go
+++ b/pkg/deviceclaimingserver/gateways/gateways.go
@@ -85,7 +85,9 @@ func ParseGatewayEUIRanges(conf map[string][]string) (map[string][]dcstypes.EUI6
 // Claimer provides methods for claiming Gateways.
 type Claimer interface {
 	// Claim claims a gateway.
-	Claim(ctx context.Context, eui types.EUI64, ownerToken string, clusterAddress string) error
+	Claim(
+		ctx context.Context, eui types.EUI64, ownerToken string, clusterAddress string,
+	) (*dcstypes.GatewayMetadata, error)
 	// Unclaim unclaims a gateway.
 	Unclaim(ctx context.Context, eui types.EUI64) error
 	// IsManagedGateway returns true if the gateway is a managed gateway.

--- a/pkg/deviceclaimingserver/grpc_gateways.go
+++ b/pkg/deviceclaimingserver/grpc_gateways.go
@@ -119,7 +119,8 @@ func (gcls *gatewayClaimingServer) Claim(
 	}
 
 	// Claim the gateway on the upstream.
-	if err := claimer.Claim(ctx, gatewayEUI, string(authCode), req.TargetGatewayServerAddress); err != nil {
+	res, err := claimer.Claim(ctx, gatewayEUI, string(authCode), req.TargetGatewayServerAddress)
+	if err != nil {
 		observability.RegisterFailClaim(ctx, ids.GetEntityIdentifiers(), err)
 		return nil, errClaim.WithCause(err)
 	}
@@ -143,6 +144,7 @@ func (gcls *gatewayClaimingServer) Claim(
 		EnforceDutyCycle:               true,
 		RequireAuthenticatedConnection: true,
 		FrequencyPlanIds:               req.TargetFrequencyPlanIds,
+		Antennas:                       res.Antennas,
 	}
 
 	_, err = gcls.registry.Create(ctx, &ttnpb.CreateGatewayRequest{

--- a/pkg/deviceclaimingserver/grpc_gateways_test.go
+++ b/pkg/deviceclaimingserver/grpc_gateways_test.go
@@ -71,7 +71,7 @@ func TestGatewayClaimingServer(t *testing.T) { // nolint:paralleltest
 		},
 	})
 
-	mockGatewayclaimer := &MockGatewayClaimer{
+	mockGatewayClaimer := &MockGatewayClaimer{
 		IsManagedGatewayFunc: func(_ context.Context, e types.EUI64) (bool, error) {
 			return e.Equal(supportedEUI), nil
 		},
@@ -88,7 +88,7 @@ func TestGatewayClaimingServer(t *testing.T) { // nolint:paralleltest
 					Length: 48,
 				}),
 			},
-			mockGatewayclaimer,
+			mockGatewayClaimer,
 		),
 	)
 	if err != nil {
@@ -180,7 +180,7 @@ func TestGatewayClaimingServer(t *testing.T) { // nolint:paralleltest
 		Name           string
 		Req            *ttnpb.ClaimGatewayRequest
 		CallOpt        grpc.CallOption
-		ClaimFunc      func(context.Context, types.EUI64, string, string) error
+		ClaimFunc      func(context.Context, types.EUI64, string, string) (*dcstypes.GatewayMetadata, error)
 		CreateFunc     func(context.Context, *ttnpb.CreateGatewayRequest) (*ttnpb.Gateway, error)
 		UnclaimFunc    func(context.Context, types.EUI64) error
 		ErrorAssertion func(error) bool
@@ -271,8 +271,8 @@ func TestGatewayClaimingServer(t *testing.T) { // nolint:paralleltest
 				TargetGatewayServerAddress: "things.example.com",
 			},
 			CallOpt: authorizedCallOpt,
-			ClaimFunc: func(_ context.Context, _ types.EUI64, _, _ string) error {
-				return errClaim.New()
+			ClaimFunc: func(_ context.Context, _ types.EUI64, _, _ string) (*dcstypes.GatewayMetadata, error) {
+				return nil, errClaim.New()
 			},
 			ErrorAssertion: errors.IsAborted,
 		},
@@ -290,8 +290,8 @@ func TestGatewayClaimingServer(t *testing.T) { // nolint:paralleltest
 				TargetGatewayServerAddress: "things.example.com",
 			},
 			CallOpt: authorizedCallOpt,
-			ClaimFunc: func(context.Context, types.EUI64, string, string) error {
-				return nil
+			ClaimFunc: func(context.Context, types.EUI64, string, string) (*dcstypes.GatewayMetadata, error) {
+				return &dcstypes.GatewayMetadata{}, nil
 			},
 			CreateFunc: func(context.Context, *ttnpb.CreateGatewayRequest) (*ttnpb.Gateway, error) {
 				return nil, errCreate.New()
@@ -318,8 +318,8 @@ func TestGatewayClaimingServer(t *testing.T) { // nolint:paralleltest
 				TargetGatewayServerAddress: "things.example.com",
 			},
 			CallOpt: authorizedCallOpt,
-			ClaimFunc: func(context.Context, types.EUI64, string, string) error {
-				return nil
+			ClaimFunc: func(context.Context, types.EUI64, string, string) (*dcstypes.GatewayMetadata, error) {
+				return &dcstypes.GatewayMetadata{}, nil
 			},
 			CreateFunc: func(context.Context, *ttnpb.CreateGatewayRequest) (*ttnpb.Gateway, error) {
 				return nil, errCreate.New()
@@ -342,8 +342,8 @@ func TestGatewayClaimingServer(t *testing.T) { // nolint:paralleltest
 				TargetGatewayId:            "test-gateway",
 				TargetGatewayServerAddress: "things.example.com",
 			},
-			ClaimFunc: func(context.Context, types.EUI64, string, string) error {
-				return nil
+			ClaimFunc: func(context.Context, types.EUI64, string, string) (*dcstypes.GatewayMetadata, error) {
+				return &dcstypes.GatewayMetadata{}, nil
 			},
 			CreateFunc: func(_ context.Context, in *ttnpb.CreateGatewayRequest) (*ttnpb.Gateway, error) {
 				return in.Gateway, nil
@@ -354,10 +354,10 @@ func TestGatewayClaimingServer(t *testing.T) { // nolint:paralleltest
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			if tc.ClaimFunc != nil {
-				mockGatewayclaimer.ClaimFunc = tc.ClaimFunc
+				mockGatewayClaimer.ClaimFunc = tc.ClaimFunc
 			}
 			if tc.UnclaimFunc != nil {
-				mockGatewayclaimer.UnclaimFunc = tc.UnclaimFunc
+				mockGatewayClaimer.UnclaimFunc = tc.UnclaimFunc
 			}
 			if tc.CreateFunc != nil {
 				mockGatewayRegistry.createFunc = tc.CreateFunc
@@ -480,7 +480,7 @@ func TestGatewayClaimingServer(t *testing.T) { // nolint:paralleltest
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			if tc.UnclaimFunc != nil {
-				mockGatewayclaimer.UnclaimFunc = tc.UnclaimFunc
+				mockGatewayClaimer.UnclaimFunc = tc.UnclaimFunc
 			}
 			if tc.GetFunc != nil {
 				mockGatewayRegistry.getFunc = tc.GetFunc

--- a/pkg/deviceclaimingserver/types/types.go
+++ b/pkg/deviceclaimingserver/types/types.go
@@ -15,7 +15,10 @@
 // Package types provides types for the Device Claiming Server.
 package types
 
-import "go.thethings.network/lorawan-stack/v3/pkg/types"
+import (
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
+)
 
 // EUI64Range is a range of EUI64s.
 type EUI64Range interface {
@@ -55,4 +58,9 @@ func RangeFromEUI64Range(start, end types.EUI64) EUI64Range {
 		start: start.MarshalNumber(),
 		end:   end.MarshalNumber(),
 	}
+}
+
+// GatewayMetadata contains metadata of a gateway, typically returned on claiming.
+type GatewayMetadata struct {
+	Antennas []*ttnpb.GatewayAntenna
 }

--- a/pkg/deviceclaimingserver/util_test.go
+++ b/pkg/deviceclaimingserver/util_test.go
@@ -17,6 +17,7 @@ package deviceclaimingserver_test
 import (
 	"context"
 
+	dcstypes "go.thethings.network/lorawan-stack/v3/pkg/deviceclaimingserver/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -80,7 +81,7 @@ func (m MockEndDeviceClaimer) BatchUnclaim(
 type MockGatewayClaimer struct {
 	EUIs []types.EUI64
 
-	ClaimFunc            func(context.Context, types.EUI64, string, string) error
+	ClaimFunc            func(context.Context, types.EUI64, string, string) (*dcstypes.GatewayMetadata, error)
 	UnclaimFunc          func(context.Context, types.EUI64) error
 	IsManagedGatewayFunc func(context.Context, types.EUI64) (bool, error)
 }
@@ -91,7 +92,7 @@ func (claimer MockGatewayClaimer) Claim(
 	eui types.EUI64,
 	ownerToken string,
 	clusterAddress string,
-) error {
+) (*dcstypes.GatewayMetadata, error) {
 	return claimer.ClaimFunc(ctx, eui, ownerToken, clusterAddress)
 }
 

--- a/pkg/gatewayserver/io/ttigw/ttigw.go
+++ b/pkg/gatewayserver/io/ttigw/ttigw.go
@@ -64,6 +64,8 @@ var _ io.Frontend = (*Frontend)(nil)
 
 // New returns a new The Things Industries V1 gateway frontend.
 func New(ctx context.Context, server io.Server, cfg Config) (*Frontend, error) {
+	ctx = log.NewContextWithField(ctx, "namespace", "gatewayserver/io/ttigw")
+
 	var proxyConfiguration webmiddleware.ProxyConfiguration
 	if err := proxyConfiguration.ParseAndAddTrusted(server.GetBaseConfig(ctx).HTTP.TrustedProxies...); err != nil {
 		return nil, err
@@ -130,7 +132,7 @@ func (f *Frontend) handleGet(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx, ids, err := f.authenticate(ctx, cert)
 	if err != nil {
-		logger.WithError(err).Debug("Client certificate verification failed")
+		logger.WithError(err).Warn("Client certificate verification failed")
 		writeError(w, err)
 		return
 	}
@@ -140,7 +142,7 @@ func (f *Frontend) handleGet(w http.ResponseWriter, r *http.Request) {
 		Ip: remoteIP(r),
 	})
 	if err != nil {
-		logger.WithError(err).Info("Failed to connect")
+		logger.WithError(err).Warn("Failed to connect")
 		writeError(w, err)
 		return
 	}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -218,7 +218,7 @@ require (
 	go.packetbroker.org/api/mapping/v2 v2.3.2 // indirect
 	go.packetbroker.org/api/routing v1.9.2 // indirect
 	go.packetbroker.org/api/v3 v3.17.1 // indirect
-	go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240729145607-ea516688afbd // indirect
+	go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240823134410-68cd7baab6c5 // indirect
 	go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df // indirect
 	go.thethings.network/lorawan-application-payload v0.0.0-20220125153912-1198ff1e403e // indirect
 	go.thethings.network/lorawan-stack-legacy/v2 v2.1.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -713,8 +713,8 @@ go.packetbroker.org/api/routing v1.9.2 h1:J4+4vYZxa60UWC70Y9yy7sktU7DXaAp9Q13Bfq
 go.packetbroker.org/api/routing v1.9.2/go.mod h1:kd2K7gieDI35YfPA8/zDmLX3qiKPuXia/MA77BEAeUA=
 go.packetbroker.org/api/v3 v3.17.1 h1:LcyFPUGqVubGWMvQ16tZlQIKd+noGx7urzEYhSLiEQA=
 go.packetbroker.org/api/v3 v3.17.1/go.mod h1:6bVbdWAYLnvZ5kgXxA7GBQvZTN7vxI0DoF1Di1NoAT4=
-go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240729145607-ea516688afbd h1:FvD516hdD/iWqoS20SFdcoiUgwRJP3egNXNiN+Ux2d0=
-go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240729145607-ea516688afbd/go.mod h1:2+WsMwIunNLh22oauBzGL56JazE3UY34W1fstqEbacw=
+go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240823134410-68cd7baab6c5 h1:w4NvcBAq7JCwlfthvGw1PRWuI6pCf5TlIjKgFHKml8M=
+go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240823134410-68cd7baab6c5/go.mod h1:2+WsMwIunNLh22oauBzGL56JazE3UY34W1fstqEbacw=
 go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df h1:IMSctPllwEtJLyM/1AWgBiN1NPwBKqEVkCiK0I/MNY4=
 go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df/go.mod h1:89OU623VYKW9i3W4CZgIGFmtgb/jsN8JV2PAuCsj+7w=
 go.thethings.network/lorawan-application-payload v0.0.0-20220125153912-1198ff1e403e h1:TWGQ3lh7gI2W5hnb6qPdpoAa0d7s/XPwvgf2VVCMJaY=


### PR DESCRIPTION

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/issues/4256

This sets the last known location on claim.

#### Changes

<!-- What are the changes made in this pull request? -->

- Add gateway metadata to Claim return value
- Get the last location from The Things Gateway Controller, could be observed via WiFi scan or cell tower or GPS if the gateway already powered on before it gets claimed
- Unrelated but small improvement: Fix log namespace and increase log level for failed connects

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Turn on supported gateway
2. Claim gateway

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

Should show location on the map immediately after claiming.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

None expected

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
