### PR TITLE
Support TX channel configuration in dynamic channel regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- RX2 and Class C with The Things Industries gateway protocol in dynamic channel plan regions (including `EU868`).
+
 ### Security
 
 ## [3.32.0] - unreleased

--- a/config/messages.json
+++ b/config/messages.json
@@ -5129,15 +5129,6 @@
       "file": "mapping.go"
     }
   },
-  "error:pkg/gatewayserver/io/ttigw:invalid_frequency": {
-    "translations": {
-      "en": "invalid frequency `{frequency}`"
-    },
-    "description": {
-      "package": "pkg/gatewayserver/io/ttigw",
-      "file": "mapping.go"
-    }
-  },
   "error:pkg/gatewayserver/io/ttigw:invalid_gateway_eui": {
     "translations": {
       "en": "invalid gateway EUI"

--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	go.packetbroker.org/api/mapping/v2 v2.3.2
 	go.packetbroker.org/api/routing v1.9.2
 	go.packetbroker.org/api/v3 v3.17.1
-	go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240729145607-ea516688afbd
+	go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240909122048-ff0bf82927c1
 	go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df
 	go.thethings.network/lorawan-application-payload v0.0.0-20220125153912-1198ff1e403e
 	go.thethings.network/lorawan-stack-legacy/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -663,8 +663,8 @@ go.packetbroker.org/api/routing v1.9.2 h1:J4+4vYZxa60UWC70Y9yy7sktU7DXaAp9Q13Bfq
 go.packetbroker.org/api/routing v1.9.2/go.mod h1:kd2K7gieDI35YfPA8/zDmLX3qiKPuXia/MA77BEAeUA=
 go.packetbroker.org/api/v3 v3.17.1 h1:LcyFPUGqVubGWMvQ16tZlQIKd+noGx7urzEYhSLiEQA=
 go.packetbroker.org/api/v3 v3.17.1/go.mod h1:6bVbdWAYLnvZ5kgXxA7GBQvZTN7vxI0DoF1Di1NoAT4=
-go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240729145607-ea516688afbd h1:FvD516hdD/iWqoS20SFdcoiUgwRJP3egNXNiN+Ux2d0=
-go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240729145607-ea516688afbd/go.mod h1:2+WsMwIunNLh22oauBzGL56JazE3UY34W1fstqEbacw=
+go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240909122048-ff0bf82927c1 h1:HbMxAtwFZlW9Wb2ozplPyrEvHGPFMyA47PCanAyQZCY=
+go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240909122048-ff0bf82927c1/go.mod h1:2+WsMwIunNLh22oauBzGL56JazE3UY34W1fstqEbacw=
 go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df h1:IMSctPllwEtJLyM/1AWgBiN1NPwBKqEVkCiK0I/MNY4=
 go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df/go.mod h1:89OU623VYKW9i3W4CZgIGFmtgb/jsN8JV2PAuCsj+7w=
 go.thethings.network/lorawan-application-payload v0.0.0-20220125153912-1198ff1e403e h1:TWGQ3lh7gI2W5hnb6qPdpoAa0d7s/XPwvgf2VVCMJaY=

--- a/pkg/gatewayserver/io/iotest/iotest.go
+++ b/pkg/gatewayserver/io/iotest/iotest.go
@@ -1508,7 +1508,7 @@ func Frontend(t *testing.T, frontend FrontendConfig) { //nolint:gocyclo
 								},
 								Priority: ttnpb.TxSchedulePriority_NORMAL,
 								Rx1Delay: ttnpb.RxDelay_RX_DELAY_1,
-								Rx1DataRate: &ttnpb.DataRate{
+								Rx2DataRate: &ttnpb.DataRate{
 									Modulation: &ttnpb.DataRate_Lora{
 										Lora: &ttnpb.LoRaDataRate{
 											SpreadingFactor: 7,
@@ -1517,7 +1517,7 @@ func Frontend(t *testing.T, frontend FrontendConfig) { //nolint:gocyclo
 										},
 									},
 								},
-								Rx1Frequency:    868100000,
+								Rx2Frequency:    869525000,
 								FrequencyPlanId: test.EUFrequencyPlanID,
 							},
 						},
@@ -1543,7 +1543,7 @@ func Frontend(t *testing.T, frontend FrontendConfig) { //nolint:gocyclo
 								},
 								Priority: ttnpb.TxSchedulePriority_NORMAL,
 								Rx1Delay: ttnpb.RxDelay_RX_DELAY_1,
-								Rx1DataRate: &ttnpb.DataRate{
+								Rx2DataRate: &ttnpb.DataRate{
 									Modulation: &ttnpb.DataRate_Lora{
 										Lora: &ttnpb.LoRaDataRate{
 											SpreadingFactor: 7,
@@ -1552,7 +1552,41 @@ func Frontend(t *testing.T, frontend FrontendConfig) { //nolint:gocyclo
 										},
 									},
 								},
-								Rx1Frequency: 868100000,
+								Rx2Frequency: 869525000,
+							},
+						},
+					},
+				},
+				{
+					Name: "ValidClassCWithCustomFrequency",
+					Message: &ttnpb.DownlinkMessage{
+						RawPayload: randomDownDataPayload(types.DevAddr{0x26, 0x02, 0xff, 0xff}, 42, 2),
+						Settings: &ttnpb.DownlinkMessage_Request{
+							Request: &ttnpb.TxRequest{
+								Class: ttnpb.Class_CLASS_C,
+								DownlinkPaths: []*ttnpb.DownlinkPath{
+									{
+										Path: &ttnpb.DownlinkPath_Fixed{
+											Fixed: &ttnpb.GatewayAntennaIdentifiers{
+												GatewayIds: &ttnpb.GatewayIdentifiers{
+													GatewayId: registeredGatewayID,
+												},
+											},
+										},
+									},
+								},
+								Priority: ttnpb.TxSchedulePriority_NORMAL,
+								Rx1Delay: ttnpb.RxDelay_RX_DELAY_1,
+								Rx2DataRate: &ttnpb.DataRate{
+									Modulation: &ttnpb.DataRate_Lora{
+										Lora: &ttnpb.LoRaDataRate{
+											SpreadingFactor: 7,
+											Bandwidth:       250000,
+											CodingRate:      band.Cr4_5,
+										},
+									},
+								},
+								Rx2Frequency: 868123000,
 							},
 						},
 					},

--- a/pkg/webui/locales/ja.json
+++ b/pkg/webui/locales/ja.json
@@ -2166,7 +2166,6 @@
   "error:pkg/gatewayserver/io/semtechws:no_auth_provided": "認証されていな `{uid}`",
   "error:pkg/gatewayserver/io/ttigw:downlink_channel_mixed_bandwidths": "",
   "error:pkg/gatewayserver/io/ttigw:invalid_board": "",
-  "error:pkg/gatewayserver/io/ttigw:invalid_frequency": "",
   "error:pkg/gatewayserver/io/ttigw:invalid_gateway_eui": "",
   "error:pkg/gatewayserver/io/ttigw:invalid_if_chain": "",
   "error:pkg/gatewayserver/io/ttigw:invalid_modulation": "",

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -223,7 +223,7 @@ require (
 	go.packetbroker.org/api/mapping/v2 v2.3.2 // indirect
 	go.packetbroker.org/api/routing v1.9.2 // indirect
 	go.packetbroker.org/api/v3 v3.17.1 // indirect
-	go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240729145607-ea516688afbd // indirect
+	go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240909122048-ff0bf82927c1 // indirect
 	go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df // indirect
 	go.thethings.network/lorawan-application-payload v0.0.0-20220125153912-1198ff1e403e // indirect
 	go.thethings.network/lorawan-stack-legacy/v2 v2.1.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -712,8 +712,8 @@ go.packetbroker.org/api/routing v1.9.2 h1:J4+4vYZxa60UWC70Y9yy7sktU7DXaAp9Q13Bfq
 go.packetbroker.org/api/routing v1.9.2/go.mod h1:kd2K7gieDI35YfPA8/zDmLX3qiKPuXia/MA77BEAeUA=
 go.packetbroker.org/api/v3 v3.17.1 h1:LcyFPUGqVubGWMvQ16tZlQIKd+noGx7urzEYhSLiEQA=
 go.packetbroker.org/api/v3 v3.17.1/go.mod h1:6bVbdWAYLnvZ5kgXxA7GBQvZTN7vxI0DoF1Di1NoAT4=
-go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240729145607-ea516688afbd h1:FvD516hdD/iWqoS20SFdcoiUgwRJP3egNXNiN+Ux2d0=
-go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240729145607-ea516688afbd/go.mod h1:2+WsMwIunNLh22oauBzGL56JazE3UY34W1fstqEbacw=
+go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240909122048-ff0bf82927c1 h1:HbMxAtwFZlW9Wb2ozplPyrEvHGPFMyA47PCanAyQZCY=
+go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240909122048-ff0bf82927c1/go.mod h1:2+WsMwIunNLh22oauBzGL56JazE3UY34W1fstqEbacw=
 go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df h1:IMSctPllwEtJLyM/1AWgBiN1NPwBKqEVkCiK0I/MNY4=
 go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df/go.mod h1:89OU623VYKW9i3W4CZgIGFmtgb/jsN8JV2PAuCsj+7w=
 go.thethings.network/lorawan-application-payload v0.0.0-20220125153912-1198ff1e403e h1:TWGQ3lh7gI2W5hnb6qPdpoAa0d7s/XPwvgf2VVCMJaY=


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

This fixes default and custom RX2 parameters as well as Class C in dynamic channel plan regions.

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

#### Changes

<!-- What are the changes made in this pull request? -->

- Update The Things Industries gateway protocol API with support for TX channel configuration. This allows for configuring TX frequency and bandwidth if it deviates from the frequency plan's downlink channels
- Configure default RX2 parameters as TX channel to save bandwidth
- Extend GS frontend test bench with a custom frequency and fix Class C parameters

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Register a gateway using The Things Industries gateway protocol
2. Register an EU868 end device with class C enabled
3. Configure the end device with data rate 6 (SF7, 250 KHz) for RX2 and enable class C
4. Let the end device join
5. Send downlink messages
6. Repeat step 3 with standard data rate for RX2 (any SF at 125 KHz)

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

Downlink messages should arrive.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
