### PR TITLE
Fix video feed on firefox

### DIFF
--- a/pkg/webui/components/qr/input/video/index.js
+++ b/pkg/webui/components/qr/input/video/index.js
@@ -76,14 +76,20 @@ const Camera = props => {
     }
   }, [cameras])
 
-  const setDeviceIdFromStream = useCallback(userStream => {
-    const videoTracks = userStream.getVideoTracks()
-
-    if (videoTracks.length > 0) {
-      const { deviceId } = videoTracks[0].getSettings()
-      setDeviceId(deviceId)
-    }
-  }, [])
+  const setDeviceIdFromStream = useCallback(
+    userStream => {
+      const videoTracks = userStream.getVideoTracks()
+      if (videoTracks.length > 0) {
+        const { deviceId } = videoTracks[0].getSettings()
+        if (deviceId) {
+          setDeviceId(deviceId)
+        } else if (cameras.length > 0) {
+          setDeviceId(cameras[0].deviceId)
+        }
+      }
+    },
+    [cameras],
+  )
 
   useEffect(() => {
     setHasFrontCamera(cameras.some(device => device.label.toLowerCase().includes('front')))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

On firefox the video feed would fail to load on QR component

#### Changes

<!-- What are the changes made in this pull request? -->

- When `videoTracks[0].getSettings()` fails on firefox get the first camera deviceId from `navigator.mediaDevices.enumerateDevices()`

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Open QR scanner on either add device or add gateway views using the latest firefox browser

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->


#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
