### PR TITLE
Fix device ID check for top devices in the app overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Potential leak of end devices of other (owned) applications in the top end devices panel in the application overview of the Console.
+
 ### Security
 
 ## [3.32.1] - unreleased

--- a/pkg/webui/console/containers/top-entities-dashboard-panel/top-devices/index.js
+++ b/pkg/webui/console/containers/top-entities-dashboard-panel/top-devices/index.js
@@ -31,7 +31,10 @@ import { selectEndDeviceTopEntities } from '@console/store/selectors/top-entitie
 import EntitiesList from '../list'
 
 const TopDevicesList = ({ appId }) => {
-  const topEntityFilter = useMemo(() => (appId ? e => e.id.startsWith(appId) : undefined), [appId])
+  const topEntityFilter = useMemo(
+    () => (appId ? e => e.id.split('/')[0] === appId : undefined),
+    [appId],
+  )
   const items = useSelector(state => selectEndDeviceTopEntities(state, topEntityFilter))
 
   const headers = [


### PR DESCRIPTION
#### Summary

This quickfix PR addresses an issue that would lead to top devices from other applications being shown in the application overview.

#### Changes

- Fix the app ID comparison

#### Notes for Reviewers

This has been reported by a community member and happens when two applications with a common prefix are visited. Due to the ID comparison running on `startsWith` this allows devices of applications that have a common start to be selected as well.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
