### PR TITLE
Add mage target for serve dev webui tool

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -360,10 +360,10 @@ The development server runs on `http://localhost:8080` and will proxy all API ca
 
 #### Interactive development stack launcher tool
 
-In order to easily launch development environments in different deployment contexts, this script configures and starts a development environment for The Things Stack, allowing users to choose between local and staging environments, enable branding, and configure cloud-hosted mock setups. You can launch it via:
+In order to easily launch development environments in different deployment contexts, this mage target configures and starts a development environment for The Things Stack, allowing users to choose between local and staging environments, enable branding, and configure cloud-hosted mock setups. You can launch it via:
 
 ```bash
-$ node tools/js/serve-dev-stack.js
+$ tools/bin/mage dev:serveDevWebui
 ```
 
 It will interactively guide you through the desired setup and launches the The Things Stack Enterprise as well as a frontend development server wia webpack.

--- a/tools/js/serve-dev-webui.js
+++ b/tools/js/serve-dev-webui.js
@@ -136,9 +136,6 @@ if (relevantSetEnvs.length > 0) {
       }
       envConfig += stagingConfig
     }
-  } else {
-    // Cypress setup
-    envConfig = baseConfig + localConfig
   }
 
   const envVars = envConfig

--- a/tools/mage/dev.go
+++ b/tools/mage/dev.go
@@ -349,6 +349,13 @@ func (Dev) StartDevStack() error {
 	return execGo(logFile, logFile, "run", "./cmd/ttn-lw-stack", "start", "--log.format=json")
 }
 
+func (Dev) ServeDevWebui() error {
+	if mg.Verbose() {
+		fmt.Println("Starting the webui with interactive configs")
+	}
+	return sh.RunV("node", "tools/js/serve-dev-webui.js")
+}
+
 func init() {
 	initDeps = append(initDeps, Dev.Certificates, Dev.InitDeviceRepo)
 }


### PR DESCRIPTION
#### Summary

This PR adds the serve dev webui tool as a mage target, so that it can also be run via `tools/bin/mage dev:serveDevWebui`.

#### Changes

- Rename the tool from `serve-dev-stack` (clashing with existing mage target) to `serve-dev-webui`
- Add a new mage target `dev:serveDevWebui` to the Dev module

#### Notes for Reviewers

Since this tool should become the unified go-to way of running the stack for frontend development, it should also have an appropriate mage target.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
