### PR TITLE
Support migration to uint32 RSSI for TTIGW protocol

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	go.packetbroker.org/api/mapping/v2 v2.3.2
 	go.packetbroker.org/api/routing v1.9.2
 	go.packetbroker.org/api/v3 v3.17.1
-	go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240909122048-ff0bf82927c1
+	go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20241023114011-31c9c9f86834
 	go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df
 	go.thethings.network/lorawan-application-payload v0.0.0-20220125153912-1198ff1e403e
 	go.thethings.network/lorawan-stack-legacy/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -663,8 +663,8 @@ go.packetbroker.org/api/routing v1.9.2 h1:J4+4vYZxa60UWC70Y9yy7sktU7DXaAp9Q13Bfq
 go.packetbroker.org/api/routing v1.9.2/go.mod h1:kd2K7gieDI35YfPA8/zDmLX3qiKPuXia/MA77BEAeUA=
 go.packetbroker.org/api/v3 v3.17.1 h1:LcyFPUGqVubGWMvQ16tZlQIKd+noGx7urzEYhSLiEQA=
 go.packetbroker.org/api/v3 v3.17.1/go.mod h1:6bVbdWAYLnvZ5kgXxA7GBQvZTN7vxI0DoF1Di1NoAT4=
-go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240909122048-ff0bf82927c1 h1:HbMxAtwFZlW9Wb2ozplPyrEvHGPFMyA47PCanAyQZCY=
-go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240909122048-ff0bf82927c1/go.mod h1:2+WsMwIunNLh22oauBzGL56JazE3UY34W1fstqEbacw=
+go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20241023114011-31c9c9f86834 h1:ANhGlIwofZn/HfA6bNkAD5Oh6n3wCcEjXjhT1LmpMv0=
+go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20241023114011-31c9c9f86834/go.mod h1:2+WsMwIunNLh22oauBzGL56JazE3UY34W1fstqEbacw=
 go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df h1:IMSctPllwEtJLyM/1AWgBiN1NPwBKqEVkCiK0I/MNY4=
 go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df/go.mod h1:89OU623VYKW9i3W4CZgIGFmtgb/jsN8JV2PAuCsj+7w=
 go.thethings.network/lorawan-application-payload v0.0.0-20220125153912-1198ff1e403e h1:TWGQ3lh7gI2W5hnb6qPdpoAa0d7s/XPwvgf2VVCMJaY=

--- a/pkg/gatewayserver/io/ttigw/ttigw.go
+++ b/pkg/gatewayserver/io/ttigw/ttigw.go
@@ -424,7 +424,7 @@ func processGatewayMessage(
 	switch msg := envelope.Message.(type) {
 	case *lorav1.GatewayMessage_ErrorNotification:
 		txAckResult, isTxAckResult := toTxAcknowledgmentResult[msg.ErrorNotification.Code]
-		down, _, isTxResponse := dlTokens.Get(uint16(envelope.TransactionId), receivedAt)
+		down, _, isTxResponse := dlTokens.Get(uint16(envelope.TransactionId), receivedAt) //nolint:gosec
 		if isTxAckResult || isTxResponse {
 			if !isTxAckResult {
 				txAckResult = ttnpb.TxAcknowledgment_UNKNOWN_ERROR
@@ -476,7 +476,7 @@ func processGatewayMessage(
 		txAck := &ttnpb.TxAcknowledgment{
 			Result: ttnpb.TxAcknowledgment_SUCCESS,
 		}
-		if down, _, ok := dlTokens.Get(uint16(envelope.TransactionId), receivedAt); ok {
+		if down, _, ok := dlTokens.Get(uint16(envelope.TransactionId), receivedAt); ok { //nolint:gosec
 			txAck.DownlinkMessage = down
 			txAck.CorrelationIds = down.CorrelationIds
 		}

--- a/pkg/gatewayserver/io/ttigw/ttigw_test.go
+++ b/pkg/gatewayserver/io/ttigw/ttigw_test.go
@@ -166,7 +166,7 @@ func TestFrontend(t *testing.T) { //nolint:gocyclo
 				txBandwidths    []uint32
 			)
 			for _, b := range gwConfig.Boards {
-				rfChainFreqs := []int64{int64(b.RfChain0.GetFrequency()), int64(b.RfChain1.GetFrequency())}
+				rfChainFreqs := []int64{int64(b.RfChain0.GetFrequency()), int64(b.RfChain1.GetFrequency())} //nolint:gosec
 				for i, multiSF := range []*lorav1.Board_IntermediateFrequencies_MultipleSF{
 					b.Ifs.GetMultipleSf0(),
 					b.Ifs.GetMultipleSf1(),
@@ -180,8 +180,8 @@ func TestFrontend(t *testing.T) { //nolint:gocyclo
 					if multiSF == nil {
 						continue
 					}
-					freq := uint64(rfChainFreqs[multiSF.RfChain] + int64(multiSF.Frequency))
-					multiSFIFChains[freq] = uint32(i)
+					freq := uint64(rfChainFreqs[multiSF.RfChain] + int64(multiSF.Frequency)) //nolint:gosec
+					multiSFIFChains[freq] = uint32(i)                                        //nolint:gosec
 				}
 			}
 			for _, ch := range gwConfig.Tx {
@@ -206,16 +206,20 @@ func TestFrontend(t *testing.T) { //nolint:gocyclo
 							messages := make([]*lorav1.UplinkMessage, 0, len(msg.UplinkMessages))
 							for _, up := range msg.UplinkMessages {
 								uplink := &lorav1.UplinkMessage{
-									Board:              0,
-									Timestamp:          up.RxMetadata[0].Timestamp,
-									RssiChannelNegated: -up.RxMetadata[0].ChannelRssi,
-									Payload:            up.RawPayload,
+									Board:     0,
+									Timestamp: up.RxMetadata[0].Timestamp,
+									RssiChannel: &lorav1.UplinkMessage_RssiChannelNegatedDeprecated{
+										RssiChannelNegatedDeprecated: -up.RxMetadata[0].ChannelRssi,
+									},
+									Payload: up.RawPayload,
 								}
 								switch mod := up.Settings.DataRate.Modulation.(type) {
 								case *ttnpb.DataRate_Lora:
 									dr := &lorav1.UplinkMessage_Lora{
-										RssiSignalNegated: -up.RxMetadata[0].SignalRssi.GetValue(),
-										SpreadingFactor:   mod.Lora.SpreadingFactor,
+										RssiSignal: &lorav1.UplinkMessage_Lora_RssiSignalNegatedDeprecated{
+											RssiSignalNegatedDeprecated: -up.RxMetadata[0].SignalRssi.GetValue(),
+										},
+										SpreadingFactor: mod.Lora.SpreadingFactor,
 										CodeRate: map[string]lorav1.CodeRate{
 											"4/5": lorav1.CodeRate_CODE_RATE_4_5,
 											"4/6": lorav1.CodeRate_CODE_RATE_4_6,

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -223,7 +223,7 @@ require (
 	go.packetbroker.org/api/mapping/v2 v2.3.2 // indirect
 	go.packetbroker.org/api/routing v1.9.2 // indirect
 	go.packetbroker.org/api/v3 v3.17.1 // indirect
-	go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240909122048-ff0bf82927c1 // indirect
+	go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20241023114011-31c9c9f86834 // indirect
 	go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df // indirect
 	go.thethings.network/lorawan-application-payload v0.0.0-20220125153912-1198ff1e403e // indirect
 	go.thethings.network/lorawan-stack-legacy/v2 v2.1.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -712,8 +712,8 @@ go.packetbroker.org/api/routing v1.9.2 h1:J4+4vYZxa60UWC70Y9yy7sktU7DXaAp9Q13Bfq
 go.packetbroker.org/api/routing v1.9.2/go.mod h1:kd2K7gieDI35YfPA8/zDmLX3qiKPuXia/MA77BEAeUA=
 go.packetbroker.org/api/v3 v3.17.1 h1:LcyFPUGqVubGWMvQ16tZlQIKd+noGx7urzEYhSLiEQA=
 go.packetbroker.org/api/v3 v3.17.1/go.mod h1:6bVbdWAYLnvZ5kgXxA7GBQvZTN7vxI0DoF1Di1NoAT4=
-go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240909122048-ff0bf82927c1 h1:HbMxAtwFZlW9Wb2ozplPyrEvHGPFMyA47PCanAyQZCY=
-go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20240909122048-ff0bf82927c1/go.mod h1:2+WsMwIunNLh22oauBzGL56JazE3UY34W1fstqEbacw=
+go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20241023114011-31c9c9f86834 h1:ANhGlIwofZn/HfA6bNkAD5Oh6n3wCcEjXjhT1LmpMv0=
+go.thethings.industries/pkg/api/gen/tti/gateway v0.0.0-20241023114011-31c9c9f86834/go.mod h1:2+WsMwIunNLh22oauBzGL56JazE3UY34W1fstqEbacw=
 go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df h1:IMSctPllwEtJLyM/1AWgBiN1NPwBKqEVkCiK0I/MNY4=
 go.thethings.industries/pkg/ca v0.0.0-20240809123127-21a24c0e47df/go.mod h1:89OU623VYKW9i3W4CZgIGFmtgb/jsN8JV2PAuCsj+7w=
 go.thethings.network/lorawan-application-payload v0.0.0-20220125153912-1198ff1e403e h1:TWGQ3lh7gI2W5hnb6qPdpoAa0d7s/XPwvgf2VVCMJaY=


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

Internal reference https://github.com/TheThingsIndustries/gateway/issues/32

This supports migrating from `float` RSSI values to `uint32` in protobuf, which are more bandwidth efficient.

#### Changes

<!-- What are the changes made in this pull request? -->

- Support reading both the (now deprecated) `float` as well as the new `uint32` fields

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Connect The Things Indoor Gateway Pro
2. Observe that LoRa channel and signal RSSI in uplink messages
3. Perform a WiFi access point scan

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

The RSSI values (including the WiFi AP signal strength) should make sense (i.e. not 0).

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

None

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
