### PR TITLE
Fix managed gateway stack error

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -4949,6 +4949,15 @@
       "file": "grpc.go"
     }
   },
+  "error:pkg/gatewayconfigurationserver/managed:managed_gateway_configuration_server_not_enabled": {
+    "translations": {
+      "en": "managed gateway configuration server is not enabled"
+    },
+    "description": {
+      "package": "pkg/gatewayconfigurationserver/managed",
+      "file": "grpc_disabled.go"
+    }
+  },
   "error:pkg/gatewayconfigurationserver/managed:no_profile_name": {
     "translations": {
       "en": "no profile name set"

--- a/pkg/gatewayconfigurationserver/grpc_test.go
+++ b/pkg/gatewayconfigurationserver/grpc_test.go
@@ -1,0 +1,88 @@
+// Copyright © 2024 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatewayconfigurationserver_test
+
+import (
+	"testing"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	componenttest "go.thethings.network/lorawan-stack/v3/pkg/component/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/config"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/gatewayconfigurationserver"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttgc"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+func TestNoopManagedGCSServer(t *testing.T) {
+	t.Parallel()
+
+	a, ctx := test.New(t)
+
+	c := componenttest.NewComponent(t, &component.Config{
+		ServiceBase: config.ServiceBase{
+			GRPC: config.GRPC{
+				Listen:                      ":0",
+				AllowInsecureForCredentials: true,
+			},
+			TTGC: ttgc.Config{Enabled: false},
+		},
+	})
+
+	_, err := gatewayconfigurationserver.New(c, &gatewayconfigurationserver.Config{})
+	if !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
+
+	componenttest.StartComponent(t, c)
+	defer c.Close()
+
+	mustHavePeer(ctx, c, ttnpb.ClusterRole_GATEWAY_CONFIGURATION_SERVER)
+
+	client := ttnpb.NewManagedGatewayConfigurationServiceClient(c.LoopbackConn())
+	a.So(client, should.NotBeNil)
+
+	managedGateway, err := client.Get(ctx, &ttnpb.GetGatewayRequest{
+		GatewayIds: &ttnpb.GatewayIdentifiers{GatewayId: "gtw-id"},
+	})
+	a.So(managedGateway, should.BeNil)
+	a.So(errors.IsNotFound(err), should.BeTrue)
+
+	managedGateway, err = client.Update(ctx, &ttnpb.UpdateManagedGatewayRequest{
+		Gateway: &ttnpb.ManagedGateway{
+			Ids: &ttnpb.GatewayIdentifiers{
+				GatewayId: "gtw-id",
+			},
+		},
+	})
+	a.So(managedGateway, should.BeNil)
+	a.So(errors.IsNotFound(err), should.BeTrue)
+
+	managedGatewayWiFiAccessPoints, err := client.ScanWiFiAccessPoints(ctx, &ttnpb.GatewayIdentifiers{
+		GatewayId: "gtw-id",
+	})
+	a.So(managedGatewayWiFiAccessPoints, should.BeNil)
+	a.So(errors.IsNotFound(err), should.BeTrue)
+
+	streamEventsClient, err := client.StreamEvents(ctx, &ttnpb.GatewayIdentifiers{GatewayId: "gtw-id"})
+	if !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
+
+	err = streamEventsClient.RecvMsg(nil)
+	a.So(errors.IsNotFound(err), should.BeTrue)
+}

--- a/pkg/gatewayconfigurationserver/managed/grpc_disabled.go
+++ b/pkg/gatewayconfigurationserver/managed/grpc_disabled.go
@@ -1,0 +1,158 @@
+// Copyright © 2024 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managed
+
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+var errManagedGatewayConfigurationServerNotEnabled = errors.DefineNotFound(
+	"managed_gateway_configuration_server_not_enabled", "managed gateway configuration server is not enabled",
+)
+
+type noopManagedGCSServer struct {
+	Component
+	ttnpb.UnsafeManagedGatewayConfigurationServiceServer
+}
+
+var _ ttnpb.ManagedGatewayConfigurationServiceServer = (*noopManagedGCSServer)(nil)
+
+// Get implements ttnpb.ManagedGatewayConfigurationServiceServer.
+func (*noopManagedGCSServer) Get(
+	_ context.Context,
+	_ *ttnpb.GetGatewayRequest,
+) (*ttnpb.ManagedGateway, error) {
+	return nil, errManagedGatewayConfigurationServerNotEnabled.New()
+}
+
+// ScanWiFiAccessPoints implements ttnpb.ManagedGatewayConfigurationServiceServer.
+func (*noopManagedGCSServer) ScanWiFiAccessPoints(
+	_ context.Context,
+	_ *ttnpb.GatewayIdentifiers,
+) (*ttnpb.ManagedGatewayWiFiAccessPoints, error) {
+	return nil, errManagedGatewayConfigurationServerNotEnabled.New()
+}
+
+// StreamEvents implements ttnpb.ManagedGatewayConfigurationServiceServer.
+func (*noopManagedGCSServer) StreamEvents(
+	_ *ttnpb.GatewayIdentifiers,
+	_ ttnpb.ManagedGatewayConfigurationService_StreamEventsServer,
+) error {
+	return errManagedGatewayConfigurationServerNotEnabled.New()
+}
+
+// Update implements ttnpb.ManagedGatewayConfigurationServiceServer.
+func (*noopManagedGCSServer) Update(
+	_ context.Context,
+	_ *ttnpb.UpdateManagedGatewayRequest,
+) (*ttnpb.ManagedGateway, error) {
+	return nil, errManagedGatewayConfigurationServerNotEnabled.New()
+}
+
+type noopManagedGatewayWiFiProfileServer struct {
+	ttnpb.UnsafeManagedGatewayWiFiProfileConfigurationServiceServer
+}
+
+var _ ttnpb.ManagedGatewayWiFiProfileConfigurationServiceServer = (*noopManagedGatewayWiFiProfileServer)(nil)
+
+// Create implements ttnpb.ManagedGatewayWiFiProfileConfigurationServiceServer.
+func (*noopManagedGatewayWiFiProfileServer) Create(
+	_ context.Context,
+	_ *ttnpb.CreateManagedGatewayWiFiProfileRequest,
+) (*ttnpb.ManagedGatewayWiFiProfile, error) {
+	return nil, errManagedGatewayConfigurationServerNotEnabled.New()
+}
+
+// Delete implements ttnpb.ManagedGatewayWiFiProfileConfigurationServiceServer.
+func (*noopManagedGatewayWiFiProfileServer) Delete(
+	_ context.Context,
+	_ *ttnpb.DeleteManagedGatewayWiFiProfileRequest,
+) (*emptypb.Empty, error) {
+	return nil, errManagedGatewayConfigurationServerNotEnabled.New()
+}
+
+// Get implements ttnpb.ManagedGatewayWiFiProfileConfigurationServiceServer.
+func (*noopManagedGatewayWiFiProfileServer) Get(
+	_ context.Context,
+	_ *ttnpb.GetManagedGatewayWiFiProfileRequest,
+) (*ttnpb.ManagedGatewayWiFiProfile, error) {
+	return nil, errManagedGatewayConfigurationServerNotEnabled.New()
+}
+
+// List implements ttnpb.ManagedGatewayWiFiProfileConfigurationServiceServer.
+func (*noopManagedGatewayWiFiProfileServer) List(
+	_ context.Context,
+	_ *ttnpb.ListManagedGatewayWiFiProfilesRequest,
+) (*ttnpb.ManagedGatewayWiFiProfiles, error) {
+	return nil, errManagedGatewayConfigurationServerNotEnabled.New()
+}
+
+// Update implements ttnpb.ManagedGatewayWiFiProfileConfigurationServiceServer.
+func (*noopManagedGatewayWiFiProfileServer) Update(
+	_ context.Context,
+	_ *ttnpb.UpdateManagedGatewayWiFiProfileRequest,
+) (*ttnpb.ManagedGatewayWiFiProfile, error) {
+	return nil, errManagedGatewayConfigurationServerNotEnabled.New()
+}
+
+type noopManagedGatewayEthernetProfileServer struct {
+	ttnpb.UnsafeManagedGatewayEthernetProfileConfigurationServiceServer
+}
+
+var _ ttnpb.ManagedGatewayEthernetProfileConfigurationServiceServer = (*noopManagedGatewayEthernetProfileServer)(nil) //nolint:lll
+
+// Create implements ttnpb.ManagedGatewayEthernetProfileConfigurationServiceServer.
+func (*noopManagedGatewayEthernetProfileServer) Create(
+	_ context.Context,
+	_ *ttnpb.CreateManagedGatewayEthernetProfileRequest,
+) (*ttnpb.ManagedGatewayEthernetProfile, error) {
+	return nil, errManagedGatewayConfigurationServerNotEnabled.New()
+}
+
+// Delete implements ttnpb.ManagedGatewayEthernetProfileConfigurationServiceServer.
+func (*noopManagedGatewayEthernetProfileServer) Delete(
+	_ context.Context,
+	_ *ttnpb.DeleteManagedGatewayEthernetProfileRequest,
+) (*emptypb.Empty, error) {
+	return nil, errManagedGatewayConfigurationServerNotEnabled.New()
+}
+
+// Get implements ttnpb.ManagedGatewayEthernetProfileConfigurationServiceServer.
+func (*noopManagedGatewayEthernetProfileServer) Get(
+	_ context.Context,
+	_ *ttnpb.GetManagedGatewayEthernetProfileRequest,
+) (*ttnpb.ManagedGatewayEthernetProfile, error) {
+	return nil, errManagedGatewayConfigurationServerNotEnabled.New()
+}
+
+// List implements ttnpb.ManagedGatewayEthernetProfileConfigurationServiceServer.
+func (*noopManagedGatewayEthernetProfileServer) List(
+	_ context.Context,
+	_ *ttnpb.ListManagedGatewayEthernetProfilesRequest,
+) (*ttnpb.ManagedGatewayEthernetProfiles, error) {
+	return nil, errManagedGatewayConfigurationServerNotEnabled.New()
+}
+
+// Update implements ttnpb.ManagedGatewayEthernetProfileConfigurationServiceServer.
+func (*noopManagedGatewayEthernetProfileServer) Update(
+	_ context.Context,
+	_ *ttnpb.UpdateManagedGatewayEthernetProfileRequest,
+) (*ttnpb.ManagedGatewayEthernetProfile, error) {
+	return nil, errManagedGatewayConfigurationServerNotEnabled.New()
+}

--- a/pkg/gatewayconfigurationserver/server.go
+++ b/pkg/gatewayconfigurationserver/server.go
@@ -74,13 +74,12 @@ func New(c *component.Component, conf *Config) (*Server, error) {
 	c.GRPC.RegisterUnaryHook("/ttn.lorawan.v3.GatewayConfigurationService", rpclog.NamespaceHook, rpclog.UnaryNamespaceHook("gatewayconfigurationserver")) //nolint:lll
 	c.GRPC.RegisterUnaryHook("/ttn.lorawan.v3.GatewayConfigurationService", cluster.HookName, c.ClusterAuthUnaryHook())
 
-	if ttgcConf := c.GetBaseConfig(c.Context()).TTGC; ttgcConf.Enabled {
-		var err error
-		gcs.managedServer, err = managed.New(c.Context(), c, ttgcConf)
-		if err != nil {
-			return nil, err
-		}
+	ttgcConf := c.GetBaseConfig(c.Context()).TTGC
+	managedServer, err := managed.New(c.Context(), c, ttgcConf)
+	if err != nil {
+		return nil, err
 	}
+	gcs.managedServer = managedServer
 
 	c.RegisterGRPC(gcs)
 	c.RegisterWeb(gcs)

--- a/pkg/webui/locales/ja.json
+++ b/pkg/webui/locales/ja.json
@@ -2344,6 +2344,7 @@
   "error:pkg/frequencyplans:read_base": "周波数プラン `{id}` のベース `{base_id}` を読み込めません",
   "error:pkg/frequencyplans:read_list": "周波数プランリストを読み込めません",
   "error:pkg/gatewayconfigurationserver/managed:gateway_not_managed": "",
+  "error:pkg/gatewayconfigurationserver/managed:managed_gateway_configuration_server_not_enabled": "",
   "error:pkg/gatewayconfigurationserver/managed:no_profile_name": "",
   "error:pkg/gatewayconfigurationserver/managed:no_ssid": "",
   "error:pkg/gatewayconfigurationserver/ttkg:unauthenticated": "",


### PR DESCRIPTION
#### Summary

References issue [#4423](https://github.com/TheThingsIndustries/lorawan-stack/issues/4423#issuecomment-2444759520).

#### Changes

- Add disabled managed gateway config server
- Use disabled managed gateway config server when ttgc is not enabled

#### Testing

##### Steps

- Run the stack locally with ttgc disabled
- Add a dummy gateway or make sure one is available
- Send the following request (change ttig with the id of the dummy gateway)
```
curl -s --location  -H "Authorization: $TTN_AUTH_TOKEN" "http://localhost:1885/api/v3/gcs/gateways/managed/ttig\?field_mask\=wifi_profile_id,ethernet_profile_id,version_ids,wifi_mac_address,ethernet_mac_address"
```

##### Results

The request should return an error that says the managed gateway config server is disabled.

##### Regressions

None.

#### Notes for Reviewers

None.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
