### PR TITLE
Pass custom CA to grpc dial option

### DIFF
--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -233,6 +233,9 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 			}
 			rootCAs.AppendCertsFromPEM(pemBytes)
 			http.DefaultTransport.(*http.Transport).TLSClientConfig.RootCAs = rootCAs
+			if err = api.AddCA(pemBytes); err != nil {
+				return err
+			}
 		}
 
 		// OAuth

--- a/cmd/ttn-lw-cli/internal/api/grpc.go
+++ b/cmd/ttn-lw-cli/internal/api/grpc.go
@@ -17,6 +17,7 @@ package api
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"sync"
 	"time"
 
@@ -133,6 +134,22 @@ var (
 	connMu sync.RWMutex
 	conns  = make(map[string]*grpc.ClientConn)
 )
+
+// AddCA adds the CA certificate file.
+func AddCA(pemBytes []byte) (err error) {
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	}
+	rootCAs := tlsConfig.RootCAs
+	if rootCAs == nil {
+		if rootCAs, err = x509.SystemCertPool(); err != nil {
+			rootCAs = x509.NewCertPool()
+		}
+	}
+	rootCAs.AppendCertsFromPEM(pemBytes)
+	tlsConfig.RootCAs = rootCAs
+	return nil
+}
 
 // Dial dials a gRPC connection to the target.
 func Dial(ctx context.Context, target string) (*grpc.ClientConn, error) {

--- a/cmd/ttn-lw-cli/internal/api/grpc.go
+++ b/cmd/ttn-lw-cli/internal/api/grpc.go
@@ -138,7 +138,9 @@ var (
 // AddCA adds the CA certificate file.
 func AddCA(pemBytes []byte) (err error) {
 	if tlsConfig == nil {
-		tlsConfig = &tls.Config{}
+		tlsConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
 	}
 	rootCAs := tlsConfig.RootCAs
 	if rootCAs == nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

Pass custom CA to grpc dial option, reverting: https://github.com/TheThingsNetwork/lorawan-stack/pull/7324/commits/b2b5d2c4f437488c0e446b29248cb50e042402a6

#### Changes

<!-- What are the changes made in this pull request? -->

- Pass custom CA to grpc dial option

#### Testing

Locally

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Set a custom CA to the CLI
```
export TTN_LW_CA=./ca.pem
```
2. Test fetching a gateway.

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

Before:
```bash
go run ./cmd/ttn-lw-cli gtw list
INFO	Telemetry is enabled. Check the documentation for more information on what is collected and how to disable it	{"documentation_url": "https://www.thethingsindustries.com/docs/reference/telemetry/cli"}
WARN	[core][Channel #1 SubChannel #2]grpc: addrConn.createTransport failed to connect to {Addr: "[::1]:8884", ServerName: "localhost:8884", }. Err: connection error: desc = "transport: authentication handshake failed: tls: failed to verify certificate: x509: “localhost” certificate is not trusted"
WARN	[core][Channel #1 SubChannel #2]grpc: addrConn.createTransport failed to connect to {Addr: "127.0.0.1:8884", ServerName: "localhost:8884", }. Err: connection error: desc = "transport: authentication handshake failed: tls: failed to verify certificate: x509: “localhost” certificate is not trusted"
WARN	Finished unary call	{"duration": 0.0924, "error": "error:unknown:unknown (connection error: desc = \"transport: authentication handshake failed: tls: failed to verify certificate: x509: “localhost” certificate is not trusted\")", "error_correlation_id": "f9413aaa5fbb43159868c2b607b0da4a", "grpc.method": "List", "grpc.service": "ttn.lorawan.v3.GatewayRegistry", "grpc_code": "Unavailable", "namespace": "grpc"}
error:unknown:unknown (connection error: desc = "transport: authentication handshake failed: tls: failed to verify certificate: x509: “localhost” certificate is not trusted")
    correlation_id=f9413aaa5fbb43159868c2b607b0da4a
```

After
```
go run ./cmd/ttn-lw-cli gtw list
INFO	Telemetry is enabled. Check the documentation for more information on what is collected and how to disable it	{"documentation_url": "https://www.thethingsindustries.com/docs/reference/telemetry/cli"}
[]
INFO	New patch version available	{"current": "3.32.1-dev", "docs_url": "https://www.thethingsindustries.com/docs/getting-started/upgrading/", "latest": "3.32.2"}
```

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

This fixes a regression.

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
