### PR TITLE
Add default pagination limit to Redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Enforce default page limit on AS and NS List RPCs if a value is not provided in the request.
+
 ### Security
 
 ## [3.33.0] - unreleased

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -79,6 +79,16 @@ func NewNetworkServerDownlinkTaskRedis(conf *Config) *redis.Client {
 	return redis.New(conf.Redis.WithNamespace("ns", "tasks"))
 }
 
+// NewNetworkServerMACSettingsProfileRegistryRedis instantiates a new redis client
+// with the Network Server MAC Settings Profile Registry namespace.
+func NewNetworkServerMACSettingsProfileRegistryRedis(conf *Config) *redis.Client {
+	redis.SetPaginationDefaults(redis.PaginationDefaults{
+		DefaultLimit: conf.NS.Pagination.DefaultLimit,
+	})
+
+	return redis.New(conf.Redis.WithNamespace("ns", "mac-settings-profiles"))
+}
+
 // NewIdentityServerTelemetryTaskRedis instantiates a new redis client
 // with the Identity Server Telemetry Task namespace.
 func NewIdentityServerTelemetryTaskRedis(conf *Config) *redis.Client {
@@ -89,6 +99,36 @@ func NewIdentityServerTelemetryTaskRedis(conf *Config) *redis.Client {
 // with the Application Server Device Registry namespace.
 func NewApplicationServerDeviceRegistryRedis(conf *Config) *redis.Client {
 	return NewComponentDeviceRegistryRedis(conf, "as")
+}
+
+// NewApplicationServerPubSubRegistryRedis instantiates a new redis client
+// with the Application Server PubSub Registry namespace.
+func NewApplicationServerPubSubRegistryRedis(conf *Config) *redis.Client {
+	redis.SetPaginationDefaults(redis.PaginationDefaults{
+		DefaultLimit: conf.AS.Pagination.DefaultLimit,
+	})
+
+	return redis.New(config.Redis.WithNamespace("as", "io", "pubsub"))
+}
+
+// NewApplicationServerPackagesRegistryRedis instantiates a new redis client
+// with the Application Server Packages Registry namespace.
+func NewApplicationServerPackagesRegistryRedis(conf *Config) *redis.Client {
+	redis.SetPaginationDefaults(redis.PaginationDefaults{
+		DefaultLimit: conf.AS.Pagination.DefaultLimit,
+	})
+
+	return redis.New(config.Redis.WithNamespace("as", "io", "applicationpackages"))
+}
+
+// NewApplicationServerWebhookRegistryRedis instantiates a new redis client
+// with the Application Server Webhook Registry namespace.
+func NewApplicationServerWebhookRegistryRedis(conf *Config) *redis.Client {
+	redis.SetPaginationDefaults(redis.PaginationDefaults{
+		DefaultLimit: conf.AS.Pagination.DefaultLimit,
+	})
+
+	return redis.New(config.Redis.WithNamespace("as", "io", "webhooks"))
 }
 
 // NewJoinServerDeviceRegistryRedis instantiates a new redis client
@@ -343,7 +383,7 @@ var startCommand = &cobra.Command{
 				Redis: redis.New(config.Cache.Redis.WithNamespace("ns", "scheduled-downlinks")),
 			}
 			macSettingsProfiles := &nsredis.MACSettingsProfileRegistry{
-				Redis:   redis.New(config.Redis.WithNamespace("ns", "mac-settings-profiles")),
+				Redis:   NewNetworkServerMACSettingsProfileRegistryRedis(config),
 				LockTTL: defaultLockTTL,
 			}
 			if err := macSettingsProfiles.Init(ctx); err != nil {
@@ -379,7 +419,7 @@ var startCommand = &cobra.Command{
 				Redis: redis.New(config.Cache.Redis.WithNamespace("as", "traffic")),
 			}
 			pubsubRegistry := &asiopsredis.PubSubRegistry{
-				Redis:   redis.New(config.Redis.WithNamespace("as", "io", "pubsub")),
+				Redis:   NewApplicationServerPubSubRegistryRedis(config),
 				LockTTL: defaultLockTTL,
 			}
 			if err := pubsubRegistry.Init(ctx); err != nil {
@@ -388,7 +428,7 @@ var startCommand = &cobra.Command{
 			config.AS.PubSub.Registry = pubsubRegistry
 			applicationPackagesRegistry, err := asioapredis.NewApplicationPackagesRegistry(
 				ctx,
-				redis.New(config.Redis.WithNamespace("as", "io", "applicationpackages")),
+				NewApplicationServerPackagesRegistryRedis(config),
 				defaultLockTTL,
 			)
 			if err != nil {
@@ -397,7 +437,7 @@ var startCommand = &cobra.Command{
 			config.AS.Packages.Registry = applicationPackagesRegistry
 			if config.AS.Webhooks.Target != "" {
 				webhookRegistry := &asiowebredis.WebhookRegistry{
-					Redis:   redis.New(config.Redis.WithNamespace("as", "io", "webhooks")),
+					Redis:   NewApplicationServerWebhookRegistryRedis(config),
 					LockTTL: defaultLockTTL,
 				}
 				if err := webhookRegistry.Init(ctx); err != nil {

--- a/pkg/applicationserver/config.go
+++ b/pkg/applicationserver/config.go
@@ -105,6 +105,11 @@ type DownlinksConfig struct {
 	ConfirmationConfig ConfirmationConfig `name:"confirmation" description:"Configuration for confirmed downlink"`
 }
 
+// PaginationConfig represents the configuration for pagination.
+type PaginationConfig struct {
+	DefaultLimit int64 `name:"default-limit" description:"Default limit for pagination"`
+}
+
 // Config represents the ApplicationServer configuration.
 type Config struct {
 	LinkMode                 string                         `name:"link-mode" description:"Deprecated - mode to link applications to their Network Server (all, explicit)"`
@@ -123,6 +128,7 @@ type Config struct {
 	DeviceKEKLabel           string                         `name:"device-kek-label" description:"Label of KEK used to encrypt device keys at rest"`
 	DeviceLastSeen           LastSeenConfig                 `name:"device-last-seen" description:"End Device last seen batch update configuration"`
 	Downlinks                DownlinksConfig                `name:"downlinks" description:"Downlink configuration"`
+	Pagination               PaginationConfig               `name:"pagination" description:"Pagination configuration"`
 }
 
 func (c Config) toProto() *ttnpb.AsConfiguration {

--- a/pkg/applicationserver/io/packages/grpc_test.go
+++ b/pkg/applicationserver/io/packages/grpc_test.go
@@ -30,6 +30,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	mockis "go.thethings.network/lorawan-stack/v3/pkg/identityserver/mock"
+	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
@@ -371,6 +372,8 @@ func TestAssociations(t *testing.T) {
 	t.Run("Pagination", func(t *testing.T) {
 		a := assertions.New(t)
 
+		ttnredis.SetPaginationDefaults(ttnredis.PaginationDefaults{DefaultLimit: 10})
+
 		for i := 1; i < 21; i++ {
 			association := &ttnpb.ApplicationPackageAssociation{
 				Ids: &ttnpb.ApplicationPackageAssociationIdentifiers{
@@ -424,8 +427,8 @@ func TestAssociations(t *testing.T) {
 				limit:    0,
 				page:     0,
 				portLow:  1,
-				portHigh: 20,
-				length:   20,
+				portHigh: 10,
+				length:   10,
 			},
 		} {
 			t.Run(fmt.Sprintf("limit:%v_page:%v", tc.limit, tc.page),

--- a/pkg/applicationserver/io/pubsub/redis/registry_test.go
+++ b/pkg/applicationserver/io/pubsub/redis/registry_test.go
@@ -1,0 +1,281 @@
+// Copyright © 2024 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package redis implements a Redis-backed PubSub registry.
+package redis
+
+import (
+	"fmt"
+	"testing"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+var Timeout = 10 * test.Delay
+
+func TestPubSubRegistry(t *testing.T) {
+	t.Parallel()
+	a, ctx := test.New(t)
+	cl, flush := test.NewRedis(ctx, "redis_test")
+	t.Cleanup(func() {
+		flush()
+		cl.Close()
+	})
+
+	ids := &ttnpb.ApplicationPubSubIdentifiers{
+		ApplicationIds: &ttnpb.ApplicationIdentifiers{
+			ApplicationId: "myapp-00",
+		},
+		PubSubId: "pubsub-00",
+	}
+	ids1 := &ttnpb.ApplicationPubSubIdentifiers{
+		ApplicationIds: &ttnpb.ApplicationIdentifiers{
+			ApplicationId: "myapp-01",
+		},
+		PubSubId: "pubsub-01",
+	}
+	ids2 := &ttnpb.ApplicationPubSubIdentifiers{
+		ApplicationIds: &ttnpb.ApplicationIdentifiers{
+			ApplicationId: "myapp-02",
+		},
+		PubSubId: "pubsub-02",
+	}
+	provider := &ttnpb.ApplicationPubSub_Nats{
+		Nats: &ttnpb.ApplicationPubSub_NATSProvider{
+			ServerUrl: "nats://localhost",
+		},
+	}
+
+	registry := &PubSubRegistry{
+		Redis:   cl,
+		LockTTL: test.Delay << 10,
+	}
+	if err := registry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
+
+	paths := []string{"ids", "provider", "format", "base_topic"}
+	format := "json"
+	format2 := "xml"
+	baseTopic := "app1.ps1"
+	baseTopic2 := "app1.ps2"
+
+	createPubSubFunc := func(ps *ttnpb.ApplicationPubSub,
+	) (*ttnpb.ApplicationPubSub, []string, error) { // nolint: unparam
+		a.So(ps, should.BeNil)
+		return &ttnpb.ApplicationPubSub{
+			Ids:      ids1,
+			Provider: provider,
+			Format:   format,
+		}, paths, nil
+	}
+	updatePubSubFunc := func(ps *ttnpb.ApplicationPubSub,
+	) (*ttnpb.ApplicationPubSub, []string, error) { // nolint: unparam
+		a.So(ps, should.NotBeNil)
+		return &ttnpb.ApplicationPubSub{
+			Ids:       ids1,
+			Provider:  provider,
+			Format:    format,
+			BaseTopic: baseTopic,
+		}, paths, nil
+	}
+	updateFieldMaskPubSubFunc := func(ps *ttnpb.ApplicationPubSub,
+	) (*ttnpb.ApplicationPubSub, []string, error) { // nolint: unparam
+		a.So(ps, should.NotBeNil)
+		return &ttnpb.ApplicationPubSub{
+			Ids:       ids1,
+			Provider:  provider,
+			Format:    format2,
+			BaseTopic: baseTopic2,
+		}, []string{"ids", "base_topic"}, nil
+	}
+	deletePubSubFunc := func(ps *ttnpb.ApplicationPubSub,
+	) (*ttnpb.ApplicationPubSub, []string, error) { // nolint: unparam
+		a.So(ps, should.NotBeNil)
+		return nil, nil, nil
+	}
+	listPubSubFunc := func(ps *ttnpb.ApplicationPubSub,
+	) (*ttnpb.ApplicationPubSub, []string, error) { // nolint: unparam
+		a.So(ps, should.BeNil)
+		return &ttnpb.ApplicationPubSub{
+			Ids:      ids2,
+			Provider: provider,
+			Format:   format,
+		}, paths, nil
+	}
+
+	t.Run("GetNonExisting", func(t *testing.T) {
+		t.Parallel()
+		a, ctx := test.New(t)
+		pubsub, err := registry.Get(ctx, ids, []string{"ids"})
+		a.So(pubsub, should.BeNil)
+		a.So(errors.IsNotFound(err), should.BeTrue)
+	})
+
+	t.Run("CreateReadUpdateDelete", func(t *testing.T) {
+		t.Parallel()
+		a, ctx := test.New(t)
+		pubsub, err := registry.Set(ctx, ids1, paths, createPubSubFunc)
+		a.So(err, should.BeNil)
+		a.So(pubsub, should.NotBeNil)
+		a.So(pubsub.Ids, should.Resemble, ids1)
+		a.So(pubsub.Format, should.NotBeNil)
+		a.So(pubsub.Format, should.Equal, format)
+
+		retrieved, err := registry.Get(ctx, ids1, paths)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.NotBeNil)
+		a.So(retrieved.Ids, should.Resemble, ids1)
+		a.So(retrieved.Format, should.NotBeNil)
+		a.So(retrieved.Format, should.Equal, format)
+
+		updated, err := registry.Set(ctx, ids1, paths, updatePubSubFunc)
+		a.So(err, should.BeNil)
+		a.So(updated, should.NotBeNil)
+		a.So(updated.Ids, should.Resemble, ids1)
+		a.So(updated.Format, should.NotBeNil)
+		a.So(updated.Format, should.Equal, format)
+		a.So(updated.BaseTopic, should.NotBeNil)
+		a.So(updated.BaseTopic, should.Equal, baseTopic)
+
+		updated2, err := registry.Set(ctx, ids1, paths, updateFieldMaskPubSubFunc)
+		a.So(err, should.BeNil)
+		a.So(updated2, should.NotBeNil)
+		a.So(updated2.Ids, should.Resemble, ids1)
+		a.So(updated2.Format, should.NotBeNil)
+		a.So(updated2.Format, should.Equal, format)
+		a.So(updated2.BaseTopic, should.NotBeNil)
+		a.So(updated2.BaseTopic, should.Equal, baseTopic2)
+
+		deleted, err := registry.Set(ctx, ids1, []string{"ids"}, deletePubSubFunc)
+		a.So(err, should.BeNil)
+		a.So(deleted, should.BeNil)
+	})
+
+	t.Run("List", func(t *testing.T) {
+		t.Parallel()
+		a, ctx := test.New(t)
+		pubsub, err := registry.Set(ctx, ids2, paths, listPubSubFunc)
+		a.So(err, should.BeNil)
+		a.So(pubsub, should.NotBeNil)
+		a.So(pubsub.Ids, should.Resemble, ids2)
+		a.So(pubsub.Format, should.NotBeNil)
+		a.So(pubsub.Format, should.Equal, format)
+
+		pubsubs, err := registry.List(ctx, ids2.ApplicationIds, paths)
+		a.So(err, should.BeNil)
+		a.So(pubsubs, should.HaveLength, 1)
+		a.So(pubsubs[0], should.NotBeNil)
+		a.So(pubsubs[0].Ids, should.Resemble, ids2)
+		a.So(pubsubs[0].Format, should.NotBeNil)
+		a.So(pubsubs[0].Format, should.Equal, format)
+	})
+
+	t.Run("Pagination", func(t *testing.T) {
+		t.Parallel()
+		a, ctx := test.New(t)
+
+		ttnredis.SetPaginationDefaults(ttnredis.PaginationDefaults{DefaultLimit: 10})
+
+		for i := 1; i < 21; i++ {
+			ids3 := &ttnpb.ApplicationPubSubIdentifiers{
+				ApplicationIds: &ttnpb.ApplicationIdentifiers{
+					ApplicationId: "myapp-pagination",
+				},
+				PubSubId: fmt.Sprintf("pubsub-%02d", i),
+			}
+
+			pubsub, err := registry.Set(
+				ctx,
+				ids3,
+				paths,
+				func(ps *ttnpb.ApplicationPubSub) (*ttnpb.ApplicationPubSub, []string, error) {
+					a.So(ps, should.BeNil)
+					return &ttnpb.ApplicationPubSub{
+						Ids:      ids3,
+						Provider: provider,
+						Format:   format,
+					}, paths, nil
+				},
+			)
+			a.So(err, should.BeNil)
+			a.So(pubsub, should.NotBeNil)
+		}
+
+		for _, tc := range []struct {
+			limit  uint32
+			page   uint32
+			idLow  string
+			idHigh string
+			length int
+		}{
+			{
+				limit:  10,
+				page:   0,
+				idLow:  "pubsub-01",
+				idHigh: "pubsub-10",
+				length: 10,
+			},
+			{
+				limit:  10,
+				page:   1,
+				idLow:  "pubsub-01",
+				idHigh: "pubsub-10",
+				length: 10,
+			},
+			{
+				limit:  10,
+				page:   2,
+				idLow:  "pubsub-11",
+				idHigh: "pubsub-20",
+				length: 10,
+			},
+			{
+				limit:  10,
+				page:   3,
+				length: 0,
+			},
+			{
+				limit:  0,
+				page:   0,
+				idLow:  "pubsub-01",
+				idHigh: "pubsub-10",
+				length: 10,
+			},
+		} {
+			t.Run(fmt.Sprintf("limit:%v_page:%v", tc.limit, tc.page),
+				func(t *testing.T) {
+					t.Parallel()
+					var total int64
+					paginationCtx := registry.WithPagination(ctx, tc.limit, tc.page, &total)
+
+					pubsubs, err := registry.List(paginationCtx, &ttnpb.ApplicationIdentifiers{
+						ApplicationId: "myapp-pagination",
+					},
+						paths,
+					)
+					a.So(err, should.BeNil)
+					a.So(pubsubs, should.HaveLength, tc.length)
+					a.So(total, should.Equal, 20)
+					for _, pubsub := range pubsubs {
+						a.So(pubsub.Ids.PubSubId, should.BeBetweenOrEqual, tc.idLow, tc.idHigh)
+					}
+				})
+		}
+	})
+}

--- a/pkg/applicationserver/io/pubsub/registry.go
+++ b/pkg/applicationserver/io/pubsub/registry.go
@@ -30,4 +30,6 @@ type Registry interface {
 	List(ctx context.Context, ids *ttnpb.ApplicationIdentifiers, paths []string) ([]*ttnpb.ApplicationPubSub, error)
 	// Set creates, updates or deletes the pub/sub integration by its identifiers.
 	Set(ctx context.Context, ids *ttnpb.ApplicationPubSubIdentifiers, paths []string, f func(*ttnpb.ApplicationPubSub) (*ttnpb.ApplicationPubSub, []string, error)) (*ttnpb.ApplicationPubSub, error)
+	// WithPagination returns a new context with pagination parameters.
+	WithPagination(ctx context.Context, limit uint32, page uint32, total *int64) context.Context
 }

--- a/pkg/applicationserver/io/web/redis/registry_test.go
+++ b/pkg/applicationserver/io/web/redis/registry_test.go
@@ -1,0 +1,274 @@
+// Copyright © 2024 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package redis implements a Redis-backed Webhook registry.
+package redis
+
+import (
+	"fmt"
+	"testing"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+var Timeout = 10 * test.Delay
+
+func TestWebhookRegistry(t *testing.T) {
+	t.Parallel()
+	a, ctx := test.New(t)
+	cl, flush := test.NewRedis(ctx, "redis_test")
+	t.Cleanup(func() {
+		flush()
+		cl.Close()
+	})
+
+	ids := &ttnpb.ApplicationWebhookIdentifiers{
+		ApplicationIds: &ttnpb.ApplicationIdentifiers{
+			ApplicationId: "myapp-00",
+		},
+		WebhookId: "webhook-00",
+	}
+	ids1 := &ttnpb.ApplicationWebhookIdentifiers{
+		ApplicationIds: &ttnpb.ApplicationIdentifiers{
+			ApplicationId: "myapp-01",
+		},
+		WebhookId: "webhook-01",
+	}
+	ids2 := &ttnpb.ApplicationWebhookIdentifiers{
+		ApplicationIds: &ttnpb.ApplicationIdentifiers{
+			ApplicationId: "myapp-02",
+		},
+		WebhookId: "webhook-02",
+	}
+
+	registry := &WebhookRegistry{
+		Redis:   cl,
+		LockTTL: test.Delay << 10,
+	}
+	if err := registry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
+
+	paths := []string{"ids", "base_url", "format"}
+	format := "json"
+	format2 := "xml"
+	baseURL := "http://localhost/test1"
+	baseURL2 := "http://localhost/test2"
+
+	createWebhookFunc := func(ps *ttnpb.ApplicationWebhook,
+	) (*ttnpb.ApplicationWebhook, []string, error) { // nolint: unparam
+		a.So(ps, should.BeNil)
+		return &ttnpb.ApplicationWebhook{
+			Ids:     ids1,
+			Format:  format,
+			BaseUrl: baseURL,
+		}, paths, nil
+	}
+	updateWebhookFunc := func(ps *ttnpb.ApplicationWebhook,
+	) (*ttnpb.ApplicationWebhook, []string, error) { // nolint: unparam
+		a.So(ps, should.NotBeNil)
+		return &ttnpb.ApplicationWebhook{
+			Ids:     ids1,
+			Format:  format,
+			BaseUrl: baseURL,
+		}, paths, nil
+	}
+	updateFieldMaskWebhookFunc := func(ps *ttnpb.ApplicationWebhook,
+	) (*ttnpb.ApplicationWebhook, []string, error) { // nolint: unparam
+		a.So(ps, should.NotBeNil)
+		return &ttnpb.ApplicationWebhook{
+			Ids:     ids1,
+			Format:  format2,
+			BaseUrl: baseURL2,
+		}, []string{"ids", "base_url"}, nil
+	}
+	deleteWebhookFunc := func(ps *ttnpb.ApplicationWebhook,
+	) (*ttnpb.ApplicationWebhook, []string, error) { // nolint: unparam
+		a.So(ps, should.NotBeNil)
+		return nil, nil, nil
+	}
+	listWebhookFunc := func(ps *ttnpb.ApplicationWebhook,
+	) (*ttnpb.ApplicationWebhook, []string, error) { // nolint: unparam
+		a.So(ps, should.BeNil)
+		return &ttnpb.ApplicationWebhook{
+			Ids:     ids2,
+			Format:  format,
+			BaseUrl: baseURL,
+		}, paths, nil
+	}
+
+	t.Run("GetNonExisting", func(t *testing.T) {
+		t.Parallel()
+		a, ctx := test.New(t)
+		webhook, err := registry.Get(ctx, ids, []string{"ids"})
+		a.So(webhook, should.BeNil)
+		a.So(errors.IsNotFound(err), should.BeTrue)
+	})
+
+	t.Run("CreateReadUpdateDelete", func(t *testing.T) {
+		t.Parallel()
+		a, ctx := test.New(t)
+		webhook, err := registry.Set(ctx, ids1, paths, createWebhookFunc)
+		a.So(err, should.BeNil)
+		a.So(webhook, should.NotBeNil)
+		a.So(webhook.Ids, should.Resemble, ids1)
+		a.So(webhook.Format, should.NotBeNil)
+		a.So(webhook.Format, should.Equal, format)
+
+		retrieved, err := registry.Get(ctx, ids1, paths)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.NotBeNil)
+		a.So(retrieved.Ids, should.Resemble, ids1)
+		a.So(retrieved.Format, should.NotBeNil)
+		a.So(retrieved.Format, should.Equal, format)
+
+		updated, err := registry.Set(ctx, ids1, paths, updateWebhookFunc)
+		a.So(err, should.BeNil)
+		a.So(updated, should.NotBeNil)
+		a.So(updated.Ids, should.Resemble, ids1)
+		a.So(updated.Format, should.NotBeNil)
+		a.So(updated.Format, should.Equal, format)
+		a.So(updated.BaseUrl, should.NotBeNil)
+		a.So(updated.BaseUrl, should.Equal, baseURL)
+
+		updated2, err := registry.Set(ctx, ids1, paths, updateFieldMaskWebhookFunc)
+		a.So(err, should.BeNil)
+		a.So(updated2, should.NotBeNil)
+		a.So(updated2.Ids, should.Resemble, ids1)
+		a.So(updated2.Format, should.NotBeNil)
+		a.So(updated2.Format, should.Equal, format)
+		a.So(updated2.BaseUrl, should.NotBeNil)
+		a.So(updated2.BaseUrl, should.Equal, baseURL2)
+
+		deleted, err := registry.Set(ctx, ids1, []string{"ids"}, deleteWebhookFunc)
+		a.So(err, should.BeNil)
+		a.So(deleted, should.BeNil)
+	})
+
+	t.Run("List", func(t *testing.T) {
+		t.Parallel()
+		a, ctx := test.New(t)
+		webhook, err := registry.Set(ctx, ids2, paths, listWebhookFunc)
+		a.So(err, should.BeNil)
+		a.So(webhook, should.NotBeNil)
+		a.So(webhook.Ids, should.Resemble, ids2)
+		a.So(webhook.Format, should.NotBeNil)
+		a.So(webhook.Format, should.Equal, format)
+
+		webhooks, err := registry.List(ctx, ids2.ApplicationIds, paths)
+		a.So(err, should.BeNil)
+		a.So(webhooks, should.HaveLength, 1)
+		a.So(webhooks[0], should.NotBeNil)
+		a.So(webhooks[0].Ids, should.Resemble, ids2)
+		a.So(webhooks[0].Format, should.NotBeNil)
+		a.So(webhooks[0].Format, should.Equal, format)
+	})
+
+	t.Run("Pagination", func(t *testing.T) {
+		t.Parallel()
+		a, ctx := test.New(t)
+
+		ttnredis.SetPaginationDefaults(ttnredis.PaginationDefaults{DefaultLimit: 10})
+
+		for i := 1; i < 21; i++ {
+			ids3 := &ttnpb.ApplicationWebhookIdentifiers{
+				ApplicationIds: &ttnpb.ApplicationIdentifiers{
+					ApplicationId: "myapp-pagination",
+				},
+				WebhookId: fmt.Sprintf("webhook-%02d", i),
+			}
+
+			webhook, err := registry.Set(
+				ctx,
+				ids3,
+				paths,
+				func(ps *ttnpb.ApplicationWebhook) (*ttnpb.ApplicationWebhook, []string, error) {
+					a.So(ps, should.BeNil)
+					return &ttnpb.ApplicationWebhook{
+						Ids:     ids3,
+						Format:  format,
+						BaseUrl: baseURL,
+					}, paths, nil
+				},
+			)
+			a.So(err, should.BeNil)
+			a.So(webhook, should.NotBeNil)
+		}
+
+		for _, tc := range []struct {
+			limit  uint32
+			page   uint32
+			idLow  string
+			idHigh string
+			length int
+		}{
+			{
+				limit:  10,
+				page:   0,
+				idLow:  "webhook-01",
+				idHigh: "webhook-10",
+				length: 10,
+			},
+			{
+				limit:  10,
+				page:   1,
+				idLow:  "webhook-01",
+				idHigh: "webhook-10",
+				length: 10,
+			},
+			{
+				limit:  10,
+				page:   2,
+				idLow:  "webhook-11",
+				idHigh: "webhook-20",
+				length: 10,
+			},
+			{
+				limit:  10,
+				page:   3,
+				length: 0,
+			},
+			{
+				limit:  0,
+				page:   0,
+				idLow:  "webhook-01",
+				idHigh: "webhook-10",
+				length: 10,
+			},
+		} {
+			t.Run(fmt.Sprintf("limit:%v_page:%v", tc.limit, tc.page),
+				func(t *testing.T) {
+					t.Parallel()
+					var total int64
+					paginationCtx := registry.WithPagination(ctx, tc.limit, tc.page, &total)
+
+					webhooks, err := registry.List(paginationCtx, &ttnpb.ApplicationIdentifiers{
+						ApplicationId: "myapp-pagination",
+					},
+						paths,
+					)
+					a.So(err, should.BeNil)
+					a.So(webhooks, should.HaveLength, tc.length)
+					a.So(total, should.Equal, 20)
+					for _, webhook := range webhooks {
+						a.So(webhook.Ids.WebhookId, should.BeBetweenOrEqual, tc.idLow, tc.idHigh)
+					}
+				})
+		}
+	})
+}

--- a/pkg/applicationserver/io/web/registry.go
+++ b/pkg/applicationserver/io/web/registry.go
@@ -30,4 +30,6 @@ type WebhookRegistry interface {
 	Set(ctx context.Context, ids *ttnpb.ApplicationWebhookIdentifiers, paths []string, f func(*ttnpb.ApplicationWebhook) (*ttnpb.ApplicationWebhook, []string, error)) (*ttnpb.ApplicationWebhook, error)
 	// Range ranges over the webhooks and calls the callback function, until false is returned.
 	Range(ctx context.Context, paths []string, f func(context.Context, *ttnpb.ApplicationIdentifiers, *ttnpb.ApplicationWebhook) bool) error
+	// WithPagination returns a new context with pagination parameters.
+	WithPagination(ctx context.Context, limit uint32, page uint32, total *int64) context.Context
 }

--- a/pkg/networkserver/config.go
+++ b/pkg/networkserver/config.go
@@ -131,6 +131,11 @@ type InteropConfig struct {
 	ID                   *types.EUI64 `name:"id" description:"NSID of this Network Server (EUI)"`
 }
 
+// PaginationConfig represents the configuration for pagination.
+type PaginationConfig struct {
+	DefaultLimit int64 `name:"default-limit" description:"Default limit for pagination"`
+}
+
 // Config represents the NetworkServer configuration.
 type Config struct {
 	ApplicationUplinkQueue     ApplicationUplinkQueueConfig `name:"application-uplink-queue"`
@@ -149,6 +154,7 @@ type Config struct {
 	DeviceKEKLabel             string                       `name:"device-kek-label" description:"Label of KEK used to encrypt device keys at rest"`                                                     // nolint: lll
 	DownlinkQueueCapacity      int                          `name:"downlink-queue-capacity" description:"Maximum downlink queue size per-session"`                                                       // nolint: lll
 	MACSettingsProfileRegistry MACSettingsProfileRegistry   `name:"-"`
+	Pagination                 PaginationConfig             `name:"pagination" description:"Pagination configuration"`
 }
 
 // DefaultConfig is the default Network Server configuration.

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -2614,6 +2614,12 @@ type MockMACSettingsProfileRegistry struct {
 		ids *ttnpb.ApplicationIdentifiers,
 		paths []string,
 	) ([]*ttnpb.MACSettingsProfile, error)
+	WithPaginationFunc func(
+		ctx context.Context,
+		limit uint32,
+		page uint32,
+		total *int64,
+	) context.Context
 }
 
 func (m MockMACSettingsProfileRegistry) Get(
@@ -2648,4 +2654,16 @@ func (m MockMACSettingsProfileRegistry) List(
 		panic("ListFunc not set")
 	}
 	return m.ListFunc(ctx, ids, paths)
+}
+
+func (m MockMACSettingsProfileRegistry) WithPagination(
+	ctx context.Context,
+	limit uint32,
+	page uint32,
+	total *int64,
+) context.Context {
+	if m.WithPaginationFunc == nil {
+		panic("WithPaginationFunc not set")
+	}
+	return m.WithPaginationFunc(ctx, limit, page, total)
 }

--- a/pkg/networkserver/redis/mac_settings_profile_test.go
+++ b/pkg/networkserver/redis/mac_settings_profile_test.go
@@ -17,9 +17,11 @@ package redis
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
@@ -38,7 +40,13 @@ func TestMACSettingsProfileRegistry(t *testing.T) {
 
 	ids := &ttnpb.MACSettingsProfileIdentifiers{
 		ApplicationIds: &ttnpb.ApplicationIdentifiers{
-			ApplicationId: "myapp",
+			ApplicationId: "myapp-00",
+		},
+		ProfileId: "prof-00",
+	}
+	ids1 := &ttnpb.MACSettingsProfileIdentifiers{
+		ApplicationIds: &ttnpb.ApplicationIdentifiers{
+			ApplicationId: "myapp-01",
 		},
 		ProfileId: "prof-01",
 	}
@@ -64,7 +72,7 @@ func TestMACSettingsProfileRegistry(t *testing.T) {
 	) (*ttnpb.MACSettingsProfile, []string, error) { // nolint: unparam
 		a.So(pb, should.BeNil)
 		return &ttnpb.MACSettingsProfile{
-			Ids: ids,
+			Ids: ids1,
 			MacSettings: &ttnpb.MACSettings{
 				ResetsFCnt: &ttnpb.BoolValue{Value: true},
 			},
@@ -75,7 +83,7 @@ func TestMACSettingsProfileRegistry(t *testing.T) {
 	) (*ttnpb.MACSettingsProfile, []string, error) { // nolint: unparam
 		a.So(pb, should.NotBeNil)
 		return &ttnpb.MACSettingsProfile{
-			Ids: ids,
+			Ids: ids1,
 			MacSettings: &ttnpb.MACSettings{
 				ResetsFCnt:               &ttnpb.BoolValue{Value: false},
 				FactoryPresetFrequencies: frequencies,
@@ -87,7 +95,7 @@ func TestMACSettingsProfileRegistry(t *testing.T) {
 	) (*ttnpb.MACSettingsProfile, []string, error) { // nolint: unparam
 		a.So(pb, should.NotBeNil)
 		return &ttnpb.MACSettingsProfile{
-			Ids: ids,
+			Ids: ids1,
 			MacSettings: &ttnpb.MACSettings{
 				ResetsFCnt:               &ttnpb.BoolValue{Value: true},
 				FactoryPresetFrequencies: frequencies2,
@@ -123,41 +131,41 @@ func TestMACSettingsProfileRegistry(t *testing.T) {
 	t.Run("CreateReadUpdateDelete", func(t *testing.T) {
 		t.Parallel()
 		a, ctx := test.New(t)
-		profile, err := registry.Set(ctx, ids, []string{"ids", "mac_settings"}, createProfileFunc)
+		profile, err := registry.Set(ctx, ids1, []string{"ids", "mac_settings"}, createProfileFunc)
 		a.So(err, should.BeNil)
 		a.So(profile, should.NotBeNil)
-		a.So(profile.Ids, should.Resemble, ids)
+		a.So(profile.Ids, should.Resemble, ids1)
 		a.So(profile.MacSettings, should.NotBeNil)
 		a.So(profile.MacSettings.ResetsFCnt, should.NotBeNil)
 		a.So(profile.MacSettings.ResetsFCnt.Value, should.BeTrue)
 
-		retrieved, err := registry.Get(ctx, ids, []string{"ids", "mac_settings"})
+		retrieved, err := registry.Get(ctx, ids1, []string{"ids", "mac_settings"})
 		a.So(err, should.BeNil)
 		a.So(retrieved, should.NotBeNil)
-		a.So(retrieved.Ids, should.Resemble, ids)
+		a.So(retrieved.Ids, should.Resemble, ids1)
 		a.So(retrieved.MacSettings, should.NotBeNil)
 		a.So(retrieved.MacSettings.ResetsFCnt, should.NotBeNil)
 		a.So(retrieved.MacSettings.ResetsFCnt.Value, should.BeTrue)
 
-		updated, err := registry.Set(ctx, ids, []string{"ids", "mac_settings"}, updateProfileFunc)
+		updated, err := registry.Set(ctx, ids1, []string{"ids", "mac_settings"}, updateProfileFunc)
 		a.So(err, should.BeNil)
 		a.So(updated, should.NotBeNil)
-		a.So(updated.Ids, should.Resemble, ids)
+		a.So(updated.Ids, should.Resemble, ids1)
 		a.So(updated.MacSettings, should.NotBeNil)
 		a.So(updated.MacSettings.ResetsFCnt, should.NotBeNil)
 		a.So(updated.MacSettings.ResetsFCnt.Value, should.BeFalse)
 		a.So(updated.MacSettings.FactoryPresetFrequencies, should.Resemble, frequencies)
 
-		updated2, err := registry.Set(ctx, ids, []string{"ids", "mac_settings"}, updateFieldMaskProfileFunc)
+		updated2, err := registry.Set(ctx, ids1, []string{"ids", "mac_settings"}, updateFieldMaskProfileFunc)
 		a.So(err, should.BeNil)
 		a.So(updated2, should.NotBeNil)
-		a.So(updated2.Ids, should.Resemble, ids)
+		a.So(updated2.Ids, should.Resemble, ids1)
 		a.So(updated2.MacSettings, should.NotBeNil)
 		a.So(updated2.MacSettings.ResetsFCnt, should.NotBeNil)
 		a.So(updated2.MacSettings.ResetsFCnt.Value, should.BeFalse)
 		a.So(updated2.MacSettings.FactoryPresetFrequencies, should.Resemble, frequencies2)
 
-		deleted, err := registry.Set(ctx, ids, []string{"ids", "mac_settings"}, deleteProfileFunc)
+		deleted, err := registry.Set(ctx, ids1, []string{"ids", "mac_settings"}, deleteProfileFunc)
 		a.So(err, should.BeNil)
 		a.So(deleted, should.BeNil)
 	})
@@ -181,5 +189,100 @@ func TestMACSettingsProfileRegistry(t *testing.T) {
 		a.So(profiles[0].MacSettings, should.NotBeNil)
 		a.So(profiles[0].MacSettings.ResetsFCnt, should.NotBeNil)
 		a.So(profiles[0].MacSettings.ResetsFCnt.Value, should.BeTrue)
+	})
+
+	t.Run("Pagination", func(t *testing.T) {
+		t.Parallel()
+		a, ctx := test.New(t)
+
+		ttnredis.SetPaginationDefaults(ttnredis.PaginationDefaults{DefaultLimit: 10})
+
+		for i := 1; i < 21; i++ {
+			ids3 := &ttnpb.MACSettingsProfileIdentifiers{
+				ApplicationIds: &ttnpb.ApplicationIdentifiers{
+					ApplicationId: "myapp-pagination",
+				},
+				ProfileId: fmt.Sprintf("listprof-%02d", i),
+			}
+
+			profile, err := registry.Set(
+				ctx,
+				ids3,
+				[]string{"ids", "mac_settings"},
+				func(_ context.Context, pb *ttnpb.MACSettingsProfile,
+				) (*ttnpb.MACSettingsProfile, []string, error) { // nolint: unparam
+					a.So(pb, should.BeNil)
+					return &ttnpb.MACSettingsProfile{
+						Ids: ids3,
+						MacSettings: &ttnpb.MACSettings{
+							ResetsFCnt: &ttnpb.BoolValue{Value: true},
+						},
+					}, []string{"ids", "mac_settings"}, nil
+				},
+			)
+			a.So(err, should.BeNil)
+			a.So(profile, should.NotBeNil)
+		}
+
+		for _, tc := range []struct {
+			limit  uint32
+			page   uint32
+			idLow  string
+			idHigh string
+			length int
+		}{
+			{
+				limit:  10,
+				page:   0,
+				idLow:  "listprof-01",
+				idHigh: "listprof-10",
+				length: 10,
+			},
+			{
+				limit:  10,
+				page:   1,
+				idLow:  "listprof-01",
+				idHigh: "listprof-10",
+				length: 10,
+			},
+			{
+				limit:  10,
+				page:   2,
+				idLow:  "listprof-11",
+				idHigh: "listprof-20",
+				length: 10,
+			},
+			{
+				limit:  10,
+				page:   3,
+				length: 0,
+			},
+			{
+				limit:  0,
+				page:   0,
+				idLow:  "listprof-01",
+				idHigh: "listprof-10",
+				length: 10,
+			},
+		} {
+			t.Run(fmt.Sprintf("limit:%v_page:%v", tc.limit, tc.page),
+				func(t *testing.T) {
+					t.Parallel()
+					var total int64
+					paginationCtx := registry.WithPagination(ctx, tc.limit, tc.page, &total)
+
+					profiles, err := registry.List(paginationCtx, &ttnpb.ApplicationIdentifiers{
+						ApplicationId: "myapp-pagination",
+					},
+						[]string{"ids", "mac_settings"},
+					)
+					a.So(err, should.BeNil)
+					a.So(profiles, should.HaveLength, tc.length)
+					a.So(total, should.Equal, 20)
+					for _, profile := range profiles {
+						a.So(profile.Ids.ProfileId, should.BeBetweenOrEqual, tc.idLow, tc.idHigh)
+					}
+				})
+		}
 	})
 }

--- a/pkg/networkserver/registry.go
+++ b/pkg/networkserver/registry.go
@@ -305,4 +305,5 @@ type MACSettingsProfileRegistry interface {
 	Get(ctx context.Context, ids *ttnpb.MACSettingsProfileIdentifiers, paths []string) (*ttnpb.MACSettingsProfile, error)                                                                                                  // nolint: lll
 	Set(ctx context.Context, ids *ttnpb.MACSettingsProfileIdentifiers, paths []string, f func(context.Context, *ttnpb.MACSettingsProfile) (*ttnpb.MACSettingsProfile, []string, error)) (*ttnpb.MACSettingsProfile, error) // nolint: lll
 	List(ctx context.Context, ids *ttnpb.ApplicationIdentifiers, paths []string) ([]*ttnpb.MACSettingsProfile, error)                                                                                                      // nolint: lll
+	WithPagination(ctx context.Context, limit uint32, page uint32, total *int64) context.Context
 }

--- a/pkg/redis/pagination.go
+++ b/pkg/redis/pagination.go
@@ -18,6 +18,18 @@ import (
 	"context"
 )
 
+// PaginationDefaults sets default values for paginations options within the Redis store.
+type PaginationDefaults struct {
+	DefaultLimit int64
+}
+
+var paginationDefaults = PaginationDefaults{}
+
+// SetPaginationDefaults should only be called at the initialization of the server.
+func SetPaginationDefaults(d PaginationDefaults) {
+	paginationDefaults = d
+}
+
 type paginationOptionsKeyType struct{}
 
 var paginationOptionsKey paginationOptionsKeyType
@@ -32,6 +44,9 @@ type paginationOptions struct {
 func NewContextWithPagination(ctx context.Context, limit, page int64, total *int64) context.Context {
 	if page == 0 {
 		page = 1
+	}
+	if limit == 0 {
+		limit = paginationDefaults.DefaultLimit
 	}
 	return context.WithValue(ctx, paginationOptionsKey, paginationOptions{
 		limit:  limit,

--- a/pkg/redis/pagination_test.go
+++ b/pkg/redis/pagination_test.go
@@ -84,4 +84,16 @@ func TestPagination(t *testing.T) {
 		redis.SetPaginationTotal(ctx, total)
 		a.So(totalCount, should.Equal, total)
 	})
+
+	t.Run("SetPaginationDefaults", func(t *testing.T) {
+		t.Parallel()
+		redis.SetPaginationDefaults(redis.PaginationDefaults{DefaultLimit: 20})
+
+		ctx := test.Context()
+		ctx = redis.NewContextWithPagination(ctx, 0, 0, nil)
+
+		limit, _ := redis.PaginationLimitAndOffsetFromContext(ctx)
+
+		a.So(limit, should.Equal, uint64(20))
+	})
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

References: https://github.com/TheThingsIndustries/lorawan-stack/issues/4441

Add default pagination limit to `List` queries in AS, JS, NS.

#### Changes

<!-- What are the changes made in this pull request? -->

- Add default pagination limit to 
  - ApplicationPackageRegistry/List
  - ApplicationPackageRegistry/ListAssociations
  - ApplicationPackageRegistry/ListDefaultAssociations
  - ApplicationPubSubRegistry/List
  - ApplicationWebhookRegistry/List
  - MACSettingsProfileRegistry/List
- Add default pagination limit config to AS and NS
- Add missing unit tests for PubSub and Webhook registries

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Prerequisite:
 - Set the default limit config for AS and NS in the `./config/stack/ttn-lw-stack.yml`
 ```
as:
  pagination:
    default-limit: 5
ns:
  pagination:
    default-limit: 5
```
 - Create an app called `myapp`
 - Create 20 MAC setting profiles from id `prof-01` to `prof-20`
```
POST http://localhost:1885/api/v3/ns/applications/myapp/mac_settings_profiles
{
  "mac_settings_profile": {
    "ids": {
      "application_ids": {
        "application_id": "myapp"
      },
      "profile_id": "prof-20"
    },
    "mac_settings": {
      "resets_f_cnt": false,
      "factory_preset_frequencies": [
        1,
        2,
        3
      ]
    }
  }
}
```

Tests:
 - Run the `List` query without `limit` set
 - Run the `List` query without `limit` set but ask the second page
 - Run the `List` query but overwrite the `limit` with 10
 - Run the `List` query but overwrite the `limit` with 0

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

 - Run the `List` query without `limit` set -> It gives you the first 5 profile
```
http://localhost:1885/api/v3/ns/applications/myapp/mac_settings_profiles?field_mask=ids
```

 - Run the `List` query without `limit` set but ask the second page -> It gives you the profile from 06 to 10
```
http://localhost:1885/api/v3/ns/applications/myapp/mac_settings_profiles?field_mask=ids&page=2
```

 - Run the `List` query but overwrite the `limit` with 10 -> It gives you the profiles from 01 to 10
```
http://localhost:1885/api/v3/ns/applications/myapp/mac_settings_profiles?field_mask=ids&page=1&limit=10
```

 - Run the `List` query but overwrite the `limit` with 0 -> It gives you the first 5 profile, the default limit
```
http://localhost:1885/api/v3/ns/applications/myapp/mac_settings_profiles?field_mask=ids&page=1&limit=0
```

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

...

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
