### PR TITLE
Filter email receivers by user state

### DIFF
--- a/pkg/identityserver/email.go
+++ b/pkg/identityserver/email.go
@@ -109,6 +109,11 @@ func (is *IdentityServer) SendNotificationEmailToUsers(ctx context.Context, noti
 			continue
 		}
 
+		// Skips over non approved users.
+		if receiver.State != ttnpb.State_STATE_APPROVED {
+			continue
+		}
+
 		wg.Go(func() error {
 			templateData, err := emailNotification.DataBuilder(
 				ctx,
@@ -147,7 +152,7 @@ func (is *IdentityServer) SendTemplateEmailToUserIDs(
 	return is.SendTemplateEmailToUsers(ctx, templateName, dataBuilder, receivers...)
 }
 
-var notificationEmailUserFields = store.FieldMask{"ids", "name", "primary_email_address", "admin"}
+var notificationEmailUserFields = store.FieldMask{"ids", "name", "primary_email_address", "admin", "state"}
 
 // SendNotificationEmailToUserIDs looks up the users and sends them a notification email.
 func (is *IdentityServer) SendNotificationEmailToUserIDs(ctx context.Context, notification *ttnpb.Notification, receiverIDs ...*ttnpb.UserIdentifiers) error {

--- a/pkg/identityserver/notification_registry.go
+++ b/pkg/identityserver/notification_registry.go
@@ -350,6 +350,11 @@ func (is *IdentityServer) notifyAdminsInternal(ctx context.Context, req *ttnpb.C
 		if receiver.Ids.IDString() == ttnpb.SupportUserID {
 			continue
 		}
+
+		// Skips over non approved administrators.
+		if receiver.State != ttnpb.State_STATE_APPROVED {
+			continue
+		}
 		receiverUserIDs[i] = receiver.Ids
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

Backport of https://github.com/TheThingsIndustries/lorawan-stack/pull/4468

#### Changes

<!-- What are the changes made in this pull request? -->

- Filter email receivers which don't have their user.State approved.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

...

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@happyRip this need to be cherry picked.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
