### PR TITLE
Fix delete device modal

### DIFF
--- a/pkg/webui/console/containers/device-overview-header/index.js
+++ b/pkg/webui/console/containers/device-overview-header/index.js
@@ -294,30 +294,36 @@ const DeviceOverviewHeader = ({ device }) => {
     })
   }, [device_id])
 
-  const onDeviceDelete = React.useCallback(async () => {
-    // Check if device is claimable and if so, try to unclaim.
-    if (supportsClaiming) {
-      try {
-        await handleUnclaim()
-      } catch {
-        return handleUnclaimFailure()
+  const onDeviceDelete = React.useCallback(
+    async confirmed => {
+      if (confirmed) {
+        // Check if device is claimable and if so, try to unclaim.
+        if (supportsClaiming) {
+          try {
+            await handleUnclaim()
+          } catch {
+            return handleUnclaimFailure()
+          }
+        }
+        // Delete device.
+        try {
+          await handleDelete()
+          handleDeleteSuccess()
+        } catch (error) {
+          handleDeleteFailure()
+        }
       }
-    }
-    // Delete device.
-    try {
-      await handleDelete()
-      handleDeleteSuccess()
-    } catch (error) {
-      handleDeleteFailure()
-    }
-  }, [
-    handleDelete,
-    handleDeleteFailure,
-    handleDeleteSuccess,
-    handleUnclaim,
-    handleUnclaimFailure,
-    supportsClaiming,
-  ])
+      setDeleteDeviceVisible(false)
+    },
+    [
+      handleDelete,
+      handleDeleteFailure,
+      handleDeleteSuccess,
+      handleUnclaim,
+      handleUnclaimFailure,
+      supportsClaiming,
+    ],
+  )
 
   const handleOpenDeleteDeviceModal = useCallback(() => {
     setDeleteDeviceVisible(true)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

This PR References [https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1192#issuecomment-2517420254](https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1192#issuecomment-2517420254)

#### Changes

<!-- What are the changes made in this pull request? -->

- Only delete device if confirmed

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Try to delete a device through the device overview header and then click on cancel. The deletion should be canceled

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
