### PR TITLE
Fix gateway server event data change during marshaling

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -4832,6 +4832,15 @@
       "file": "pattern.go"
     }
   },
+  "error:pkg/events:marshal_data": {
+    "translations": {
+      "en": "marshal data"
+    },
+    "description": {
+      "package": "pkg/events",
+      "file": "events.go"
+    }
+  },
   "error:pkg/events:no_matching_events": {
     "translations": {
       "en": "no matching events for regexp `{regexp}`"

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -1101,7 +1101,7 @@ func (gs *GatewayServer) updateConnStats(ctx context.Context, conn connectionEnt
 		Protocol:             conn.Connection.Frontend().Protocol(),
 		GatewayRemoteAddress: conn.Connection.GatewayRemoteAddress(),
 	}
-	registerGatewayConnectionStats(ctx, ids, stats)
+	registerGatewayConnectionStats(ctx, ids, ttnpb.Clone(stats))
 	if gs.statsRegistry != nil {
 		if err := gs.statsRegistry.Set(
 			decoupledCtx,
@@ -1121,7 +1121,7 @@ func (gs *GatewayServer) updateConnStats(ctx context.Context, conn connectionEnt
 			ConnectedAt:    nil,
 			DisconnectedAt: timestamppb.Now(),
 		}
-		registerGatewayConnectionStats(decoupledCtx, ids, stats)
+		registerGatewayConnectionStats(decoupledCtx, ids, ttnpb.Clone(stats))
 		if gs.statsRegistry == nil {
 			return
 		}

--- a/pkg/webui/locales/ja.json
+++ b/pkg/webui/locales/ja.json
@@ -2362,6 +2362,7 @@
   "error:pkg/events/redis:channel_closed": "チャネルが閉じています",
   "error:pkg/events/redis:unknown_encoding": "不明なエンコーディング",
   "error:pkg/events:invalid_regexp": "無効な正規表現",
+  "error:pkg/events:marshal_data": "",
   "error:pkg/events:no_matching_events": "正規表現`{regexp}`に一致するイベントがありません",
   "error:pkg/events:unknown_event_name": "不明なイベント`{name}`",
   "error:pkg/fetch:fetch_file": "ファイル `{filename}` を取得できません",


### PR DESCRIPTION
#### Summary

References support issue [#1163](https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1163).

#### Changes

- Clone event data when registering evtGatewayConnectionStats
- Add panic recover with logging in event data marshalling function

#### Testing

TODO

##### Steps

##### Results

##### Regressions

None.

#### Notes for Reviewers

I'm not really sure if this will give us more info than the debug stack that's already shown on panic recovery of the task.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
