### PR TITLE
Check ADR bit in `LinkADRAns`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Enforce default page limit on AS and NS List RPCs if a value is not provided in the request.
 - Swapped field order in `RelayNotifyNewEndDeviceReq` MAC command.
+- `LinkADRAns` MAC command verification when the end device does not support ADR.
 
 ### Security
 

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -568,7 +568,15 @@ macLoop:
 				break
 			}
 			cmds = cmds[dupCount:]
-			evs, err = mac.HandleLinkADRAns(ctx, dev, pld, uint(dupCount), cmacFMatchResult.FullFCnt, fps)
+			evs, err = mac.HandleLinkADRAns(
+				ctx,
+				dev,
+				pld,
+				uint(dupCount), // nolint: gosec
+				cmacFMatchResult.FullFCnt,
+				fps,
+				up.GetPayload().GetMacPayload().GetFHdr().GetFCtrl().GetAdr(),
+			)
 		case ttnpb.MACCommandIdentifier_CID_DUTY_CYCLE:
 			evs, err = mac.HandleDutyCycleAns(ctx, dev)
 		case ttnpb.MACCommandIdentifier_CID_RX_PARAM_SETUP:

--- a/pkg/networkserver/mac/link_adr.go
+++ b/pkg/networkserver/mac/link_adr.go
@@ -323,6 +323,12 @@ func HandleLinkADRAns(
 
 	ev := EvtReceiveLinkADRAccept
 
+	// LoRaWAN 1.0.4 spec L534-538:
+	// An end-device SHOULD accept the channel mask controls present in LinkADRReq, even
+	// when the ADR bit is not set. The end-device SHALL respond to all LinkADRReq commands
+	// with a LinkADRAns indicating which command elements were accepted and which were
+	// rejected. This behavior differs from when the uplink ADR bit is set, in which case the end-
+	// device accepts or rejects the entire command.
 	if (!adrEnabled && !pld.ChannelMaskAck) ||
 		(adrEnabled && !pld.DataRateIndexAck) ||
 		(adrEnabled && !pld.TxPowerIndexAck) {

--- a/pkg/networkserver/mac/link_adr.go
+++ b/pkg/networkserver/mac/link_adr.go
@@ -331,7 +331,7 @@ func HandleLinkADRAns(
 	// rejected. This behavior differs from when the uplink ADR bit is set, in which case the end-
 	// device accepts or rejects the entire command.
 	if macspec.UseADRBit(macState.LorawanVersion) {
-		rejected = (!adrEnabled && !pld.ChannelMaskAck) ||
+		rejected = !pld.ChannelMaskAck ||
 			(adrEnabled && !pld.DataRateIndexAck) ||
 			(adrEnabled && !pld.TxPowerIndexAck)
 	} else {

--- a/pkg/networkserver/mac/link_adr.go
+++ b/pkg/networkserver/mac/link_adr.go
@@ -322,6 +322,7 @@ func HandleLinkADRAns(
 	}
 
 	ev := EvtReceiveLinkADRAccept
+	rejected := false
 
 	// LoRaWAN 1.0.4 spec L534-538:
 	// An end-device SHOULD accept the channel mask controls present in LinkADRReq, even
@@ -329,9 +330,15 @@ func HandleLinkADRAns(
 	// with a LinkADRAns indicating which command elements were accepted and which were
 	// rejected. This behavior differs from when the uplink ADR bit is set, in which case the end-
 	// device accepts or rejects the entire command.
-	if (!adrEnabled && !pld.ChannelMaskAck) ||
-		(adrEnabled && !pld.DataRateIndexAck) ||
-		(adrEnabled && !pld.TxPowerIndexAck) {
+	if macspec.UseADRBit(macState.LorawanVersion) {
+		rejected = (!adrEnabled && !pld.ChannelMaskAck) ||
+			(adrEnabled && !pld.DataRateIndexAck) ||
+			(adrEnabled && !pld.TxPowerIndexAck)
+	} else {
+		rejected = !pld.ChannelMaskAck || !pld.DataRateIndexAck || !pld.TxPowerIndexAck
+	}
+
+	if rejected {
 		ev = EvtReceiveLinkADRReject
 
 		// See "Table 6: LinkADRAns status bits signification" of LoRaWAN 1.1 specification

--- a/pkg/networkserver/mac/link_adr.go
+++ b/pkg/networkserver/mac/link_adr.go
@@ -330,7 +330,7 @@ func HandleLinkADRAns(
 	// with a LinkADRAns indicating which command elements were accepted and which were
 	// rejected. This behavior differs from when the uplink ADR bit is set, in which case the end-
 	// device accepts or rejects the entire command.
-	if macspec.UseADRBit(macState.LorawanVersion) {
+	if macspec.LinkADRReqRejected(macState.LorawanVersion) {
 		rejected = !pld.ChannelMaskAck ||
 			(adrEnabled && !pld.DataRateIndexAck) ||
 			(adrEnabled && !pld.TxPowerIndexAck)

--- a/pkg/networkserver/mac/link_adr.go
+++ b/pkg/networkserver/mac/link_adr.go
@@ -310,6 +310,7 @@ func HandleLinkADRAns(
 	dupCount uint,
 	fCntUp uint32,
 	fps *frequencyplans.Store,
+	adrEnabled bool,
 ) (events.Builders, error) {
 	if pld == nil {
 		return nil, ErrNoPayload.New()
@@ -321,7 +322,10 @@ func HandleLinkADRAns(
 	}
 
 	ev := EvtReceiveLinkADRAccept
-	if !pld.ChannelMaskAck || !pld.DataRateIndexAck || !pld.TxPowerIndexAck {
+
+	if (!adrEnabled && !pld.ChannelMaskAck) ||
+		(adrEnabled && !pld.DataRateIndexAck) ||
+		(adrEnabled && !pld.TxPowerIndexAck) {
 		ev = EvtReceiveLinkADRReject
 
 		// See "Table 6: LinkADRAns status bits signification" of LoRaWAN 1.1 specification

--- a/pkg/networkserver/mac/link_adr_test.go
+++ b/pkg/networkserver/mac/link_adr_test.go
@@ -549,6 +549,37 @@ func TestHandleLinkADRAns(t *testing.T) {
 			AdrEnabled: false,
 		},
 		{
+			Name: "1.0.4/channel mask off/adr disabled/rejected",
+			Device: &ttnpb.EndDevice{
+				FrequencyPlanId:   test.EUFrequencyPlanID,
+				LorawanPhyVersion: ttnpb.PHYVersion_RP002_V1_0_4,
+				MacState: &ttnpb.MACState{
+					LorawanVersion: ttnpb.MACVersion_MAC_V1_0_4,
+				},
+			},
+			Expected: &ttnpb.EndDevice{
+				FrequencyPlanId:   test.EUFrequencyPlanID,
+				LorawanPhyVersion: ttnpb.PHYVersion_RP002_V1_0_4,
+				MacState: &ttnpb.MACState{
+					LorawanVersion: ttnpb.MACVersion_MAC_V1_0_4,
+				},
+			},
+			Payload: &ttnpb.MACCommand_LinkADRAns{
+				ChannelMaskAck:   false,
+				DataRateIndexAck: false,
+				TxPowerIndexAck:  false,
+			},
+			Events: events.Builders{
+				EvtReceiveLinkADRReject.With(events.WithData(&ttnpb.MACCommand_LinkADRAns{
+					ChannelMaskAck:   false,
+					DataRateIndexAck: false,
+					TxPowerIndexAck:  false,
+				})),
+			},
+			Error:      ErrRequestNotFound.WithAttributes("cid", ttnpb.MACCommandIdentifier_CID_LINK_ADR),
+			AdrEnabled: false,
+		},
+		{
 			Name: "1.0.4/channel mask on/adr enabled/rejected",
 			Device: &ttnpb.EndDevice{
 				FrequencyPlanId:   test.EUFrequencyPlanID,
@@ -572,6 +603,37 @@ func TestHandleLinkADRAns(t *testing.T) {
 			Events: events.Builders{
 				EvtReceiveLinkADRReject.With(events.WithData(&ttnpb.MACCommand_LinkADRAns{
 					ChannelMaskAck:   true,
+					DataRateIndexAck: false,
+					TxPowerIndexAck:  false,
+				})),
+			},
+			Error:      ErrRequestNotFound.WithAttributes("cid", ttnpb.MACCommandIdentifier_CID_LINK_ADR),
+			AdrEnabled: true,
+		},
+		{
+			Name: "1.0.4/channel mask off/adr enabled/rejected",
+			Device: &ttnpb.EndDevice{
+				FrequencyPlanId:   test.EUFrequencyPlanID,
+				LorawanPhyVersion: ttnpb.PHYVersion_RP002_V1_0_4,
+				MacState: &ttnpb.MACState{
+					LorawanVersion: ttnpb.MACVersion_MAC_V1_0_4,
+				},
+			},
+			Expected: &ttnpb.EndDevice{
+				FrequencyPlanId:   test.EUFrequencyPlanID,
+				LorawanPhyVersion: ttnpb.PHYVersion_RP002_V1_0_4,
+				MacState: &ttnpb.MACState{
+					LorawanVersion: ttnpb.MACVersion_MAC_V1_0_4,
+				},
+			},
+			Payload: &ttnpb.MACCommand_LinkADRAns{
+				ChannelMaskAck:   false,
+				DataRateIndexAck: false,
+				TxPowerIndexAck:  false,
+			},
+			Events: events.Builders{
+				EvtReceiveLinkADRReject.With(events.WithData(&ttnpb.MACCommand_LinkADRAns{
+					ChannelMaskAck:   false,
 					DataRateIndexAck: false,
 					TxPowerIndexAck:  false,
 				})),

--- a/pkg/networkserver/mac/link_adr_test.go
+++ b/pkg/networkserver/mac/link_adr_test.go
@@ -487,19 +487,19 @@ func TestHandleLinkADRAns(t *testing.T) {
 			AdrEnabled: true,
 		},
 		{
-			Name: "no request/channel mask ack/rejected",
+			Name: "1.0.2/channel mask on/adr enabled/rejected",
 			Device: &ttnpb.EndDevice{
 				FrequencyPlanId:   test.EUFrequencyPlanID,
-				LorawanPhyVersion: ttnpb.PHYVersion_RP001_V1_1_REV_B,
+				LorawanPhyVersion: ttnpb.PHYVersion_RP001_V1_0_2_REV_B,
 				MacState: &ttnpb.MACState{
-					LorawanVersion: ttnpb.MACVersion_MAC_V1_1,
+					LorawanVersion: ttnpb.MACVersion_MAC_V1_0_2,
 				},
 			},
 			Expected: &ttnpb.EndDevice{
 				FrequencyPlanId:   test.EUFrequencyPlanID,
-				LorawanPhyVersion: ttnpb.PHYVersion_RP001_V1_1_REV_B,
+				LorawanPhyVersion: ttnpb.PHYVersion_RP001_V1_0_2_REV_B,
 				MacState: &ttnpb.MACState{
-					LorawanVersion: ttnpb.MACVersion_MAC_V1_1,
+					LorawanVersion: ttnpb.MACVersion_MAC_V1_0_2,
 				},
 			},
 			Payload: &ttnpb.MACCommand_LinkADRAns{
@@ -518,19 +518,19 @@ func TestHandleLinkADRAns(t *testing.T) {
 			AdrEnabled: true,
 		},
 		{
-			Name: "no request/channel mask ack/accepted",
+			Name: "1.0.4/channel mask on/adr disabled/accepted",
 			Device: &ttnpb.EndDevice{
 				FrequencyPlanId:   test.EUFrequencyPlanID,
-				LorawanPhyVersion: ttnpb.PHYVersion_RP001_V1_1_REV_B,
+				LorawanPhyVersion: ttnpb.PHYVersion_RP002_V1_0_4,
 				MacState: &ttnpb.MACState{
-					LorawanVersion: ttnpb.MACVersion_MAC_V1_1,
+					LorawanVersion: ttnpb.MACVersion_MAC_V1_0_4,
 				},
 			},
 			Expected: &ttnpb.EndDevice{
 				FrequencyPlanId:   test.EUFrequencyPlanID,
-				LorawanPhyVersion: ttnpb.PHYVersion_RP001_V1_1_REV_B,
+				LorawanPhyVersion: ttnpb.PHYVersion_RP002_V1_0_4,
 				MacState: &ttnpb.MACState{
-					LorawanVersion: ttnpb.MACVersion_MAC_V1_1,
+					LorawanVersion: ttnpb.MACVersion_MAC_V1_0_4,
 				},
 			},
 			Payload: &ttnpb.MACCommand_LinkADRAns{
@@ -547,6 +547,37 @@ func TestHandleLinkADRAns(t *testing.T) {
 			},
 			Error:      ErrRequestNotFound.WithAttributes("cid", ttnpb.MACCommandIdentifier_CID_LINK_ADR),
 			AdrEnabled: false,
+		},
+		{
+			Name: "1.0.4/channel mask on/adr enabled/rejected",
+			Device: &ttnpb.EndDevice{
+				FrequencyPlanId:   test.EUFrequencyPlanID,
+				LorawanPhyVersion: ttnpb.PHYVersion_RP002_V1_0_4,
+				MacState: &ttnpb.MACState{
+					LorawanVersion: ttnpb.MACVersion_MAC_V1_0_4,
+				},
+			},
+			Expected: &ttnpb.EndDevice{
+				FrequencyPlanId:   test.EUFrequencyPlanID,
+				LorawanPhyVersion: ttnpb.PHYVersion_RP002_V1_0_4,
+				MacState: &ttnpb.MACState{
+					LorawanVersion: ttnpb.MACVersion_MAC_V1_0_4,
+				},
+			},
+			Payload: &ttnpb.MACCommand_LinkADRAns{
+				ChannelMaskAck:   true,
+				DataRateIndexAck: false,
+				TxPowerIndexAck:  false,
+			},
+			Events: events.Builders{
+				EvtReceiveLinkADRReject.With(events.WithData(&ttnpb.MACCommand_LinkADRAns{
+					ChannelMaskAck:   true,
+					DataRateIndexAck: false,
+					TxPowerIndexAck:  false,
+				})),
+			},
+			Error:      ErrRequestNotFound.WithAttributes("cid", ttnpb.MACCommandIdentifier_CID_LINK_ADR),
+			AdrEnabled: true,
 		},
 		{
 			Name: "1 request/all ack",

--- a/pkg/specification/macspec/specification.go
+++ b/pkg/specification/macspec/specification.go
@@ -238,8 +238,9 @@ func ValidateUplinkPayloadSize(v ttnpb.MACVersion) bool {
 	return compareMACVersion(v, ttnpb.MACVersion_MAC_V1_1) >= 0
 }
 
-// UseADRBit reports whether v uses the ADR bit in the FCtrl field.
-func UseADRBit(v ttnpb.MACVersion) bool {
+// LinkADRReqRejected reports whether v uses the ADR bit in the FCtrl field
+// to modify which ACK bits needs to check in the LinkADRAns.
+func LinkADRReqRejected(v ttnpb.MACVersion) bool {
 	return compareMACVersion(v, ttnpb.MACVersion_MAC_V1_0_3) >= 0 &&
 		compareMACVersion(v, ttnpb.MACVersion_MAC_V1_0_4) <= 0
 }

--- a/pkg/specification/macspec/specification.go
+++ b/pkg/specification/macspec/specification.go
@@ -237,3 +237,9 @@ func EncryptionOptions(v ttnpb.MACVersion, frameType FrameType, fPort uint32, cm
 func ValidateUplinkPayloadSize(v ttnpb.MACVersion) bool {
 	return compareMACVersion(v, ttnpb.MACVersion_MAC_V1_1) >= 0
 }
+
+// UseADRBit reports whether v uses the ADR bit in the FCtrl field.
+func UseADRBit(v ttnpb.MACVersion) bool {
+	return compareMACVersion(v, ttnpb.MACVersion_MAC_V1_0_3) >= 0 &&
+		compareMACVersion(v, ttnpb.MACVersion_MAC_V1_0_4) <= 0
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

References: https://github.com/TheThingsNetwork/lorawan-stack/issues/7376

According to the LoRaWAN spec 1.0.3 and 1.0.4 the Network Server should check the ADR bit in the `LinkADRAns` and based on that decide if the End device rejected the request or not.

#### Changes

<!-- What are the changes made in this pull request? -->

- Changed the logic in `HandleLinkADRAns` to use the ADR bit too (if the MAC version is 1.0.3 or 1.0.4) when it checks the `ChannelMaskAck`, `DataRateIndexAck` and `TxPowerIndexAck` bits 

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

 - Use an end device that doesn't support ADR
 - Send `LinkADRReq` command from network server
 - The device should reply with `LinkADRAns` and the `ChannelMaskAck` bit should be on and the `ADR` bit should be off in the uplink `FCtrl`
 - The network server should mark the answer as accepted and shouldn't send `LinkADRReq` again

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

...

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
