### PR TITLE
Add recvTime to uplink decoder input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Add recvTime field to the decodeUplink input in payload formatters
+
 ### Changed
 
 ### Deprecated

--- a/pkg/messageprocessors/javascript/javascript_test.go
+++ b/pkg/messageprocessors/javascript/javascript_test.go
@@ -814,6 +814,33 @@ func TestDecodeUplink(t *testing.T) {
 		err := host.DecodeUplink(ctx, ids, nil, message, script)
 		a.So(err, should.BeNil)
 	}
+
+	// Check recvTime.
+	{
+		script := `
+		function decodeUplink(input) {
+			if (input.recvTime === undefined) {
+				throw new Error('recvTime is undefined');
+			}
+
+			if (input.recvTime === null) {
+				throw new Error('recvTime is null');
+			}
+
+			if (!(input.recvTime instanceof Date)) {
+				throw new Error('recvTime is not a date object, got ' + typeof input.recvTime);
+			}
+
+			return {
+				data: {
+					recvTime: input.recvTime
+				}
+			}
+		}
+		`
+		err := host.DecodeUplink(ctx, ids, nil, message, script)
+		a.So(err, should.BeNil)
+	}
 }
 
 func TestDecodeDownlink(t *testing.T) {


### PR DESCRIPTION
#### Summary

References #7467.

#### Changes

<!-- What are the changes made in this pull request? -->

- Add a recvTime field to uplink decoder input
- Add a unit test to check the recvTime field

#### Testing

##### Steps

1. Launch a local instance of TTS
2. Create an application
3. Register an end device (e.g. The Things Uno)
4. Go to the overview of the device -> Payload Formatters tab
5. Choose Custom Javascript formatter
6. Update the decodeUplink function to access the recvTime passed in the input. E.g. for the default payload formatter of The Things Uno:
```js
function decodeUplink(input) {
  var data = {};
  data.ledState = LED_STATES[input.bytes[0]];
  data.recvTime = input.recvTime.toString();
  
  return {
    data: data,
  };
}
```
7. Click on the Test Decoder button

##### Results

Decoded test payload:  

```json
{
  "ledState": "off",
  "recvTime": "Thu Jan 01 1970 02:00:00 GMT+0200 (EET)"
}
```

Complete uplink data:  

```json
{
  "f_port": 1,
  "frm_payload": "AA==",
  "decoded_payload": {
    "ledState": "off",
    "recvTime": "Thu Jan 01 1970 02:00:00 GMT+0200 (EET)"
  },
  "rx_metadata": [
    {
      "gateway_ids": {
        "gateway_id": "test"
      },
      "rssi": 42,
      "channel_rssi": 42,
      "snr": 4.2
    }
  ],
  "settings": {
    "data_rate": {
      "lora": {
        "bandwidth": 125000,
        "spreading_factor": 7
      }
    },
    "frequency": "868000000"
  }
}
```

##### Regressions

None.

#### Notes for Reviewers

There is something really odd happening when trying to access the input directly. If I change this line from the decodeUplink function:
```js
data.recvTime = input.recvTime.toString();
```
to this:
```js
data.recvTime = input.recvTime;
```

I get a panic with the following message: reflect.Value.Interface: cannot return value obtained from unexported field or method, that's triggered by this piece of code:  

```golang
// pkg/messageprocessors/javascript.(*host).decodeUplink
// pkg/messageprocessors/javascript/javascript.go:313

decodedPayload, err := goproto.Struct(output.Decoded.Data)
if err != nil {
    return errOutput.WithCause(err)
}
```

I believe it's something related to conversion of the decoder output:

```
(javascript.uplinkDecoderOutput) {
 Decoded: (javascript.decodeUplinkOutput) {
  Data: (map[string]interface {}) (len=2) {
   (string) (len=8) "ledState": (string) (len=3) "off",
   (string) (len=8) "recvTime": (time.Time) 1970-01-01 02:00:00 +0200 EET
  },
  Warnings: ([]string) <nil>,
  Errors: ([]string) <nil>
 },
 Normalized: (*javascript.normalizeUplinkOutput)(<nil>)
}
```

I'll see how it can be avoided.

EDIT: it seems like this comes from the goproto.Struct not being able to handle time.Time. Reflection is applied on the private fields of time.Time, thus the panic. Should goproto.Struct be able to handle time.Time?

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
