### PR TITLE
Fix filter of end devices with `startsWith`

### DIFF
--- a/pkg/webui/console/containers/sidebar/navigation/app-side-navigation.js
+++ b/pkg/webui/console/containers/sidebar/navigation/app-side-navigation.js
@@ -73,7 +73,13 @@ const AppSideNavigation = () => {
   const rights = useSelector(selectApplicationRights)
   const natsDisabled = useSelector(selectNatsProviderDisabled)
   const mqttDisabled = useSelector(selectMqttProviderDisabled)
-  const topEntityFilter = useCallback(e => e.id.startsWith(appId), [appId])
+  const topEntityFilter = useCallback(
+    e => {
+      const separatedAppId = e.id.split('/')[0]
+      return separatedAppId === appId
+    },
+    [appId],
+  )
   const topEntities = useSelector(state => selectEndDeviceTopEntities(state, topEntityFilter))
 
   if (!app) {

--- a/pkg/webui/console/store/selectors/top-entities.js
+++ b/pkg/webui/console/store/selectors/top-entities.js
@@ -178,17 +178,20 @@ export const selectTopEntities = createSelector(
 )
 
 const createTopEntityByTypeSelector = entityType =>
-  createSelector([selectTopEntities, (_, filter) => filter], (topEntities, filter) => {
-    if (!topEntities[entityType]) {
-      return []
-    }
+  createSelector(
+    [selectTopEntities, (_, topEntityFilter) => topEntityFilter],
+    (topEntities, topEntityFilter) => {
+      if (!topEntities[entityType]) {
+        return []
+      }
 
-    const filteredEntities = filter
-      ? topEntities[entityType].filter(filter)
-      : topEntities[entityType]
+      const filteredEntities = topEntityFilter
+        ? topEntities[entityType].filter(topEntityFilter)
+        : topEntities[entityType]
 
-    return filteredEntities
-  })
+      return filteredEntities
+    },
+  )
 
 export const selectTopEntitiesAll = state => selectTopEntities(state)[ALL]
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

References #7468 

#### Changes

<!-- What are the changes made in this pull request? -->

- Remove `startWith` and improve end device filtering

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Create two applications with identical prefix for their application-ids
2. Register devices in both
3. Check the top end devices once they appear there

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
