### PR TITLE
Support wildcards in ACME hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Support wildcards in the supported hosts for TLS certifictes obtained via ACME (`tls.acme.hosts`).
+
 ### Deprecated
 
 ### Removed

--- a/config/messages.json
+++ b/config/messages.json
@@ -3626,6 +3626,15 @@
       "file": "listeners.go"
     }
   },
+  "error:pkg/config/tlsconfig:acme_host_not_whitelisted": {
+    "translations": {
+      "en": "host `{host}` for ACME not whitelisted"
+    },
+    "description": {
+      "package": "pkg/config/tlsconfig",
+      "file": "config.go"
+    }
+  },
   "error:pkg/config/tlsconfig:fetch_file": {
     "translations": {
       "en": "fetch file `{name}`"

--- a/pkg/config/tlsconfig/config_test.go
+++ b/pkg/config/tlsconfig/config_test.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/smarty/assertions"
-	. "go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
+	"go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
 )
@@ -84,8 +84,8 @@ func TestApplyTLSClientConfig(t *testing.T) {
 	t.Parallel()
 	a := assertions.New(t)
 	caCert, _ := genCert()
-	tlsConfig := &tls.Config{}
-	err := (&Client{
+	tlsConfig := &tls.Config{} //nolint:gosec
+	err := (&tlsconfig.Client{
 		FileReader: mockFileReader{
 			"ca.pem": caCert,
 		},
@@ -97,9 +97,10 @@ func TestApplyTLSClientConfig(t *testing.T) {
 	a.So(tlsConfig.InsecureSkipVerify, should.BeTrue)
 
 	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
 		a := assertions.New(t)
 		tlsConfig := &tls.Config{} //nolint:gosec
-		err := (&Client{}).ApplyTo(tlsConfig)
+		err := (&tlsconfig.Client{}).ApplyTo(tlsConfig)
 		a.So(err, should.BeNil)
 		a.So(tlsConfig.RootCAs, should.BeNil)
 		a.So(tlsConfig.InsecureSkipVerify, should.BeFalse)
@@ -111,7 +112,7 @@ func TestApplyTLSServerAuth(t *testing.T) {
 	a := assertions.New(t)
 	cert, key := genCert()
 	tlsConfig := &tls.Config{} //nolint:gosec
-	err := (&ServerAuth{
+	err := (&tlsconfig.ServerAuth{
 		Source: "file",
 		FileReader: mockFileReader{
 			"cert.pem": cert,
@@ -129,7 +130,7 @@ func TestApplyTLSClientAuth(t *testing.T) {
 	a := assertions.New(t)
 	cert, key := genCert()
 	tlsConfig := &tls.Config{} //nolint:gosec
-	err := (&ClientAuth{
+	err := (&tlsconfig.ClientAuth{
 		Source: "file",
 		FileReader: mockFileReader{
 			"cert.pem": cert,
@@ -145,7 +146,7 @@ func TestApplyTLSClientAuth(t *testing.T) {
 func TestACMEHosts(t *testing.T) {
 	t.Parallel()
 	a, ctx := test.New(t)
-	acmeConfig := &ACME{
+	acmeConfig := &tlsconfig.ACME{
 		Enable:      true,
 		Endpoint:    "https://acme.example.com/directory",
 		Dir:         "testdata",

--- a/pkg/webui/locales/ja.json
+++ b/pkg/webui/locales/ja.json
@@ -2228,6 +2228,7 @@
   "error:pkg/cluster:peer_unavailable": "クラスター {cluster_role} が利用できません",
   "error:pkg/component:listen_endpoint": "アドレス `{endpoint}` が見当たりません",
   "error:pkg/component:listener": "リスナー `{protocol}` を生成できません",
+  "error:pkg/config/tlsconfig:acme_host_not_whitelisted": "",
   "error:pkg/config/tlsconfig:fetch_file": "ファイル`{name}`を取得",
   "error:pkg/config/tlsconfig:missing_acme_default_host": "",
   "error:pkg/config/tlsconfig:missing_acme_dir": "ACEMの保存先が見つかりません",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

This adds support for wildcard domains in the ACME hosts configuration.

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1222.

#### Changes

<!-- What are the changes made in this pull request? -->

- Customize the ACME host policy by allowing wildcards

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Configure a wildcard domain, e.g. `*.example.com` if your actual domain is `thethings.example.com`.

Enable ACME certificates for TLS, see documentation.

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

The certificate should be issued via ACME.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

None

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This follows the default implementation in terms of IDNA.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
