### PR TITLE
Fix overflow device info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Downlink scheduling conflicts by gateways that require up to 32.5 ms margin between downlink transmissions (this includes the UDP Packet Forwarder and other packet forwarders that behave similarly).
 - Live data button covers content on the page.
+- Overflow device info in device overview -> General information panel.
 
 ### Security
 

--- a/pkg/webui/components/data-sheet/data-sheet.styl
+++ b/pkg/webui/components/data-sheet/data-sheet.styl
@@ -49,7 +49,7 @@
         font-size: $fs.s
 
     &-content
-      height: 2.5rem
+      min-height: 2.5rem
       display: flex
       align-items: center
       justify-content: space-between


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

References issue 4570 in ENT.

#### Changes

<!-- What are the changes made in this pull request? -->

- Change height with min-height in data-sheet styles.

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Register or open any device overview on https://tti.eu1.cloud.thethings.industries/ (Chrome)
1. Slowly resize the window while watching the General information box

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

![image](https://github.com/user-attachments/assets/b4cba1e4-4c9d-473d-80a9-d6480fd7d2a5)


#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
