### PR TITLE
Fix flaky e2e test

### DIFF
--- a/cypress/e2e/console/devices/device-on-othercluster.spec.js
+++ b/cypress/e2e/console/devices/device-on-othercluster.spec.js
@@ -27,8 +27,6 @@ describe('End device on other cluster', () => {
     ids: { application_id: applicationId },
   }
 
-  const deviceId = 'device-all-components'
-
   const ns = {
     end_device: {
       frequency_plan_id: 'EU_863_870_TTN',
@@ -36,11 +34,6 @@ describe('End device on other cluster', () => {
       multicast: false,
       supports_join: true,
       lorawan_version: 'MAC_V1_0_2',
-      ids: {
-        device_id: deviceId,
-        dev_eui: '70B3D57ED8000019',
-        join_eui: '0000000000000000',
-      },
       supports_class_c: false,
       supports_class_b: false,
       mac_settings: {
@@ -69,11 +62,6 @@ describe('End device on other cluster', () => {
 
   const is = {
     end_device: {
-      ids: {
-        dev_eui: '9000BEEF9000BEEF',
-        join_eui: '0000000000000000',
-        device_id: 'device-all-components',
-      },
       network_server_address: 'tti.staging1.cloud.thethings.industries',
       application_server_address: 'tti.staging1.cloud.thethings.industries',
       join_server_address: 'tti.staging1.cloud.thethings.industries',
@@ -83,11 +71,15 @@ describe('End device on other cluster', () => {
     },
   }
 
+  let deviceId
+
   before(() => {
     cy.dropAndSeedDatabase()
     cy.createUser(user)
     cy.createApplication(application, user.ids.user_id)
-    cy.createMockDeviceAllComponents(applicationId, undefined, { ns, is })
+    cy.createMockDeviceAllComponents(applicationId, undefined, { ns, is }).then(body => {
+      deviceId = body.end_device.ids.device_id
+    })
   })
 
   beforeEach(() => {

--- a/cypress/e2e/console/devices/device-overview.spec.js
+++ b/cypress/e2e/console/devices/device-overview.spec.js
@@ -29,10 +29,6 @@ describe('Device overview', () => {
       multicast: false,
       supports_join: false,
       lorawan_version: 'MAC_V1_0_2',
-      ids: {
-        device_id: 'device-all-components',
-        dev_eui: '70B3D57ED8000019',
-      },
       session: {
         keys: {
           f_nwk_s_int_key: {
@@ -52,13 +48,18 @@ describe('Device overview', () => {
       },
     },
   }
-  const endDeviceId = ns.end_device.ids.device_id
+
+  let endDeviceId
+  let endDeviceDevEui
 
   before(() => {
     cy.dropAndSeedDatabase()
     cy.createUser(user)
     cy.createApplication(application, userId)
-    cy.createMockDeviceAllComponents(appId, undefined, { ns })
+    cy.createMockDeviceAllComponents(appId, undefined, { ns }).then(body => {
+      endDeviceId = body.end_device.ids.device_id
+      endDeviceDevEui = body.end_device.ids.dev_eui
+    })
   })
 
   beforeEach(() => {
@@ -86,7 +87,7 @@ describe('Device overview', () => {
         application_ids: {
           application_id: appId,
         },
-        dev_eui: '70B3D57ED8000019',
+        dev_eui: endDeviceDevEui,
         dev_addr: '270000FC',
       },
       created_at: '2021-07-06T21:32:48.499001538Z',

--- a/cypress/e2e/console/devices/edit.spec.js
+++ b/cypress/e2e/console/devices/edit.spec.js
@@ -31,10 +31,6 @@ describe('Device general settings', () => {
       multicast: false,
       supports_join: false,
       lorawan_version: 'MAC_V1_0_2',
-      ids: {
-        device_id: 'device-all-components',
-        dev_eui: '70B3D57ED8000019',
-      },
       session: {
         keys: {
           f_nwk_s_int_key: {
@@ -54,13 +50,17 @@ describe('Device general settings', () => {
       },
     },
   }
-  const endDeviceId = ns.end_device.ids.device_id
+  let endDeviceId
+  let endDeviceDevEui
 
   before(() => {
     cy.dropAndSeedDatabase()
     cy.createUser(user)
     cy.createApplication(application, userId)
-    cy.createMockDeviceAllComponents(appId, undefined, { ns })
+    cy.createMockDeviceAllComponents(appId, undefined, { ns }).then(body => {
+      endDeviceId = body.end_device.ids.device_id
+      endDeviceDevEui = body.end_device.ids.dev_eui
+    })
   })
 
   beforeEach(() => {
@@ -82,7 +82,7 @@ describe('Device general settings', () => {
     cy.findByLabelText('DevEUI')
       .should('be.disabled')
       .and('have.attr', 'value')
-      .and('eq', ns.end_device.ids.dev_eui)
+      .and('eq', endDeviceDevEui)
 
     cy.fixture('console/devices/device.is.json').then(endDevice => {
       cy.findByLabelText('End device name')

--- a/cypress/e2e/console/devices/unclaim.spec.js
+++ b/cypress/e2e/console/devices/unclaim.spec.js
@@ -29,10 +29,6 @@ describe('Device un-claiming', () => {
       multicast: false,
       supports_join: false,
       lorawan_version: 'MAC_V1_0_2',
-      ids: {
-        device_id: 'device-all-components',
-        dev_eui: '70B3D57ED8000019',
-      },
       session: {
         keys: {
           f_nwk_s_int_key: {
@@ -52,13 +48,19 @@ describe('Device un-claiming', () => {
       },
     },
   }
-  const endDeviceId = ns.end_device.ids.device_id
+  let endDeviceId
+  let endDeviceDevEui
+  let endDeviceJoinEui
 
   before(() => {
     cy.dropAndSeedDatabase()
     cy.createUser(user)
     cy.createApplication(application, userId)
-    cy.createMockDeviceAllComponents(appId, undefined, { ns })
+    cy.createMockDeviceAllComponents(appId, undefined, { ns }).then(body => {
+      endDeviceId = body.end_device.ids.device_id
+      endDeviceDevEui = body.end_device.ids.dev_eui
+      endDeviceJoinEui = body.end_device.ids.join_eui
+    })
   })
 
   beforeEach(() => {
@@ -92,9 +94,8 @@ describe('Device un-claiming', () => {
         const params = new URLSearchParams(new URL(url).search)
         const hexToBase64 = hex =>
           btoa(String.fromCharCode(...hex.match(/.{1,2}/g).map(byte => parseInt(byte, 16))))
-
-        expect(params.get('dev_eui')).to.equal(hexToBase64(ns.end_device.ids.dev_eui))
-        expect(params.get('join_eui')).to.equal(hexToBase64('0000000000000000'))
+        expect(params.get('dev_eui')).to.equal(hexToBase64(endDeviceDevEui))
+        expect(params.get('join_eui')).to.equal(hexToBase64(endDeviceJoinEui))
       })
 
     cy.findByTestId('error-notification').should('not.exist')

--- a/cypress/e2e/console/shared/payload-formatters/edit.spec.js
+++ b/cypress/e2e/console/shared/payload-formatters/edit.spec.js
@@ -37,11 +37,6 @@ describe('Payload formatters', () => {
         fw_version: 'quickstart',
         band_id: 'EU_863_870',
       },
-      ids: {
-        device_id: 'device-all-components',
-        dev_eui: '70B3D57ED8000013',
-        join_eui: '0000000000000006',
-      },
       supports_class_c: false,
       supports_class_b: false,
       mac_settings: {
@@ -75,11 +70,6 @@ describe('Payload formatters', () => {
 
   const is = {
     end_device: {
-      ids: {
-        dev_eui: '70B3D57ED8000013',
-        join_eui: '0000000000000006',
-        device_id: 'device-all-components',
-      },
       network_server_address: window.location.hostname,
       application_server_address: window.location.hostname,
       join_server_address: window.location.hostname,

--- a/cypress/e2e/smoke/devices/index.js
+++ b/cypress/e2e/smoke/devices/index.js
@@ -28,7 +28,6 @@ const checkCollapsingFields = defineSmokeTest('check all end device sub pages', 
   const application = {
     ids: { application_id: applicationId },
   }
-  const deviceId = 'device-all-components'
   const ns = {
     end_device: {
       frequency_plan_id: 'EU_863_870_TTN',
@@ -36,10 +35,6 @@ const checkCollapsingFields = defineSmokeTest('check all end device sub pages', 
       multicast: false,
       supports_join: false,
       lorawan_version: 'MAC_V1_0_2',
-      ids: {
-        device_id: 'device-all-components',
-        dev_eui: '70B3D57ED8000019',
-      },
       session: {
         keys: {
           f_nwk_s_int_key: {
@@ -63,6 +58,8 @@ const checkCollapsingFields = defineSmokeTest('check all end device sub pages', 
   cy.createUser(user)
   cy.createApplication(application, user.ids.user_id)
   cy.createMockDeviceAllComponents(applicationId, undefined, { ns })
+    .its('end_device.ids.device_id')
+    .as('deviceId')
   cy.loginConsole({ user_id: user.ids.user_id, password: user.password })
   cy.visit(Cypress.config('consoleRootPath'))
 
@@ -71,7 +68,9 @@ const checkCollapsingFields = defineSmokeTest('check all end device sub pages', 
   cy.get('#sidebar').within(() => {
     cy.findByRole('link', { name: /End devices/ }).click()
   })
-  cy.findByRole('cell', { name: `Test Device Name ${deviceId}` }).click()
+  cy.get('@deviceId').then(deviceId => {
+    cy.findByRole('cell', { name: `Test Device Name ${deviceId}` }).click()
+  })
 
   cy.get('#stage').within(() => {
     cy.findByRole('button', { name: 'Live data' }).click()

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -18,6 +18,8 @@ import { noop, merge } from 'lodash'
 
 import stringToHash from '../../pkg/webui/lib/string-to-hash'
 
+import { generateHexValue } from './utils'
+
 before(() => {
   cy.readFile('.env/admin_api_key.txt').then(adminKey => {
     Cypress.config('adminApiKey', adminKey)
@@ -319,9 +321,17 @@ Cypress.Commands.add(
   (
     applicationId,
     fixture = 'console/devices/device.*.json',
-    overwrites = { ns: {}, as: {}, js: {}, is: {} },
+    overwrites = {},
     injectHost = true,
   ) => {
+    const randomSuffix = Cypress._.random(0, 1e6)
+    const deviceIds = {
+      device_id: `device-${Date.now()}-${randomSuffix}`,
+      dev_eui: generateHexValue(16).toUpperCase(),
+      join_eui: generateHexValue(16).toUpperCase(),
+    }
+    const mergedOverwrites = Cypress._.merge({ ns: {}, as: {}, js: {}, is: {} }, overwrites)
+    const { ns, as, js, is } = mergedOverwrites
     const baseUrl = Cypress.config('baseUrl')
     const adminApiKey = Cypress.config('adminApiKey')
     const interpolateFixture = (fixtureString, component) => fixtureString.replace('*', component)
@@ -329,6 +339,7 @@ Cypress.Commands.add(
       Authorization: `Bearer ${adminApiKey}`,
     }
     cy.fixture(interpolateFixture(fixture, 'is')).then(body => {
+      body.end_device.ids = deviceIds
       if (injectHost && body && 'end_device' in body) {
         if ('network_server_address' in body.end_device) {
           body.end_device.network_server_address = window.location.hostname
@@ -343,27 +354,30 @@ Cypress.Commands.add(
       cy.request({
         method: 'POST',
         url: `${baseUrl}/api/v3/applications/${applicationId}/devices`,
-        body: { ...body, ...overwrites.is },
+        body: Cypress._.merge({}, body, is),
         headers,
       })
     })
     cy.fixture(interpolateFixture(fixture, 'ns')).then(body => {
+      body.end_device.ids = deviceIds
       cy.request({
         method: 'PUT',
         url: `${baseUrl}/api/v3/ns/applications/${applicationId}/devices/${body.end_device.ids.device_id}`,
-        body: { ...body, ...overwrites.ns },
+        body: Cypress._.merge({}, body, ns),
         headers,
       })
     })
     cy.fixture(interpolateFixture(fixture, 'as')).then(body => {
+      body.end_device.ids = deviceIds
       cy.request({
         method: 'PUT',
         url: `${baseUrl}/api/v3/as/applications/${applicationId}/devices/${body.end_device.ids.device_id}`,
-        body: { ...body, ...overwrites.as },
+        body: Cypress._.merge({}, body, as),
         headers,
       })
     })
     cy.fixture(interpolateFixture(fixture, 'js')).then(body => {
+      body.end_device.ids = deviceIds
       if (injectHost && body && 'end_device' in body) {
         if ('network_server_address' in body.end_device) {
           body.end_device.network_server_address = window.location.hostname
@@ -375,11 +389,14 @@ Cypress.Commands.add(
       cy.request({
         method: 'PUT',
         url: `${baseUrl}/api/v3/js/applications/${applicationId}/devices/${body.end_device.ids.device_id}`,
-        body: { ...body, ...overwrites.js },
+        body: Cypress._.merge({}, body, js),
         headers,
       })
     })
-    return cy.fixture(interpolateFixture(fixture, 'is'))
+    return cy.fixture(interpolateFixture(fixture, 'is')).then(body => {
+      body.end_device.ids = deviceIds
+      return body
+    })
   },
 )
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

Fix flaky e2e test

#### Changes

<!-- What are the changes made in this pull request? -->

- If the device is present for some application for some reason, we were getting 409 error. With this workaround we are not failing the test if a request gets 409.

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Check CI if it turns green on every PR.

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

The CI should turn green


#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
