### PR TITLE
Fix invalid workflow in CLI telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Fixed searching users in User management in the Console.
+- CLI no longer causes a panic when running from a docker container in a Linux machine.
 
 ### Security
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ RUN rm -rf /srv/ttn-lorawan/lorawan-webhook-templates/.git
 
 FROM alpine:3.21
 
-RUN addgroup -g 886 thethings && adduser -u 886 -S -G thethings thethings
+RUN addgroup -g 886 thethings && \
+    adduser -u 886 -S -G thethings thethings && \
+    mkdir -p /home/thethings && \
+    chown thethings:thethings /home/thethings
 
 RUN apk --update --no-cache add ca-certificates curl
 
@@ -40,5 +43,8 @@ VOLUME ["/srv/ttn-lorawan/public/blob"]
 ENV TTN_LW_HEALTHCHECK_URL=http://localhost:1885/healthz
 
 HEALTHCHECK --interval=1m --timeout=5s CMD curl -f $TTN_LW_HEALTHCHECK_URL || exit 1
+
+RUN mkdir -p /home/thethings/.cache && chown -R thethings:thethings /home/thethings/.cache
+ENV XDG_CACHE_HOME=/home/thethings/.cache
 
 USER thethings:thethings

--- a/pkg/telemetry/exporter/cli/cli.go
+++ b/pkg/telemetry/exporter/cli/cli.go
@@ -79,50 +79,50 @@ func cliStatePath() (string, error) {
 }
 
 // getCLIState returns the telemetry state, if it doesn't exist it creates a file with default values for the state.
-func getCLIState() (*cliStateTelemetry, bool, error) {
+func getCLIState() (*cliStateTelemetry, error) {
 	folderPath, err := ttnPath()
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	if _, err := os.Stat(folderPath); err != nil {
 		if !os.IsNotExist(err) {
-			return nil, false, err
+			return nil, err
 		}
 		// Creates the folder since it does not exist.
 		if err := os.Mkdir(folderPath, 0o755); err != nil {
-			return nil, false, err
+			return nil, err
 		}
 	}
 
 	statePath, err := cliStatePath()
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	cliState := &cliStateTelemetry{}
 
 	if _, err := os.Stat(statePath); err != nil {
 		if !os.IsNotExist(err) {
-			return nil, false, err
+			return nil, err
 		}
 
 		cliState.UID = uuid.NewString()
 		cliState.LastSent = time.Now()
-		return cliState, true, nil
+		return cliState, nil
 	}
 
 	b, err := os.ReadFile(statePath)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	if err := yaml.Unmarshal(b, cliState); err != nil {
-		return nil, false, err
+		return nil, err
 	}
-	return cliState, false, nil
+	return cliState, nil
 }
 
-func shouldSendTelemetry(t time.Time) bool {
-	return time.Now().After(t.Add(defaultTimeout))
+func shouldSendTelemetry(st *cliStateTelemetry) bool {
+	return st != nil && time.Now().After(st.LastSent.Add(defaultTimeout))
 }
 
 type cliTask struct {
@@ -163,18 +163,23 @@ func NewCLITelemetry(opts ...Option) Task {
 // Run a small task that send telemetry data once a day.
 func (ct *cliTask) Run(ctx context.Context) {
 	logger := log.FromContext(ctx)
-	state, send, err := getCLIState()
+	state, err := getCLIState()
 	if err != nil {
 		logger.WithError(err).Debug("Failed to retrieve telemetry state")
+		return // Skip the telemetry procedure if an error is found creating or fetching the previous state.
 	}
 
-	if send || shouldSendTelemetry(state.LastSent) {
+	if shouldSendTelemetry(state) {
 		state.LastSent = time.Now()
-		if statePath, err := cliStatePath(); err != nil {
+
+		statePath, err := cliStatePath()
+		if err != nil {
 			logger.WithError(err).Debug("Failed to retrieve telemetry state file path")
-		} else {
-			// If no error fetching the state file path, update the last sent timestamp.
-			state.Write(statePath) //nolint:errcheck
+			return
+		}
+		if err := state.Write(statePath); err != nil {
+			logger.WithError(err).Debug("Failed to write new telemetry state")
+			return
 		}
 
 		b, err := json.Marshal(&models.TelemetryMessage{
@@ -186,6 +191,7 @@ func (ct *cliTask) Run(ctx context.Context) {
 			logger.WithError(err).Debug("Failed to marshal telemetry information")
 			return
 		}
+
 		resp, err := http.DefaultClient.Post(ct.target, "application/json", bytes.NewReader(b))
 		if err != nil {
 			logger.WithError(err).Debug("Failed to send telemetry information")
@@ -193,6 +199,7 @@ func (ct *cliTask) Run(ctx context.Context) {
 		}
 		defer resp.Body.Close()
 		io.Copy(io.Discard, resp.Body) // nolint:errcheck
+
 		logger.Info("Sent telemetry information")
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

Closes #7610

#### Changes

<!-- What are the changes made in this pull request? -->

- Remove the panic from CLI telemetry workflow
- Add cache folder creation in Dockerfile 

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Found out that running the Dockerfile in a linux machine causes the cli to panic due to telemetry being enabled. Added the cache folder and now the cli is running properly.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
