### PR TITLE
Fix race condition caused by location update and marshalling normalized uplink

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"runtime/trace"
 	"time"
@@ -1146,6 +1147,8 @@ func (as *ApplicationServer) setActivated(ctx context.Context, ids *ttnpb.EndDev
 }
 
 func (as *ApplicationServer) publishNormalizedUplink(ctx context.Context, info uplinkInfo) error {
+	loc := maps.Clone(info.uplink.Locations)
+
 	for _, measurement := range info.uplink.NormalizedPayload {
 		if err := as.Publish(ctx, &ttnpb.ApplicationUp{
 			EndDeviceIds:   info.ids,
@@ -1164,7 +1167,7 @@ func (as *ApplicationServer) publishNormalizedUplink(ctx context.Context, info u
 					ReceivedAt:                info.uplink.ReceivedAt,
 					Confirmed:                 info.uplink.Confirmed,
 					ConsumedAirtime:           info.uplink.ConsumedAirtime,
-					Locations:                 info.uplink.Locations,
+					Locations:                 loc,
 					VersionIds:                info.uplink.VersionIds,
 					NetworkIds:                info.uplink.NetworkIds,
 					Attributes:                info.uplink.Attributes,


### PR DESCRIPTION
#### Summary

References support issue [#1306](https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1306).

The support issue reports a `fatal error: concurrent map iteration and map write` panic). Upon checking the stack trace, I believe this is caused by an update to the location map in the `handleUplink` of the AS the published normalized uplink is marshalled. 

The only maps in uplink messages are attributes and locations, and the panic occurs during a async processing of messages which happens in case of normalized uplinks. Let me know if this makes sense.

1. This is where the location field is published. Afaik, the call to publish causes a fork.
```go

# applicationserver.go:1148
func (as *ApplicationServer) publishNormalizedUplink(ctx context.Context, info uplinkInfo) error {
	for _, measurement := range info.uplink.NormalizedPayload {
		if err := as.Publish(ctx, &ttnpb.ApplicationUp{
			EndDeviceIds:   info.ids,
			CorrelationIds: events.CorrelationIDsFromContext(ctx),
			ReceivedAt:     info.receivedAt,
			Up: &ttnpb.ApplicationUp_UplinkNormalized{
				UplinkNormalized: &ttnpb.ApplicationUplinkNormalized{
					/* ... */
					Locations:                 info.uplink.Locations, # this is the affected map
					VersionIds:                info.uplink.VersionIds,
					NetworkIds:                info.uplink.NetworkIds,
					Attributes:                info.uplink.Attributes,
				},
			},
			Simulated: info.simulated,
		}); err != nil {
			return err
		}
	}
	return nil
}
```
2. The call to publish a normalize uplink happens here:
```go
# applicationserver.go:1229
	if !as.skipPayloadCrypto(ctx, info.link, dev, dev.Session) {
		if err := as.decryptAndDecodeUplink(ctx, dev, info.uplink, info.link.DefaultFormatters); err != nil {
			return err
		}
		if err := as.publishNormalizedUplink(ctx, info); err != nil {
			return err
		}
	} else if appSKey := dev.GetSession().GetKeys().GetAppSKey(); appSKey != nil {
		info.uplink.AppSKey = appSKey
		info.uplink.LastAFCntDown = dev.Session.LastAFCntDown
	}
```

3. And after the publish, the location map in the uplink is updated here:

```go
# applicationserver.go:1247
// Set location in message and publish location solved if the payload contains location information.
	loc := as.locationFromPayload(info.uplink)
	if loc != nil {
		if info.uplink.Locations == nil {
			info.uplink.Locations = make(map[string]*ttnpb.Location, 1)
		}
		info.uplink.Locations["frm-payload"] = loc
/* ... */
```

I chose to simply clone the location map. But another solution would be to move the location update earlier, before publishing the normalized message if this is possible.

#### Changes

<!-- What are the changes made in this pull request? -->

- Clone the location map before publishing a normalized uplink to be processed.

#### Testing

N/A

##### Regressions

None.

#### Notes for Reviewers

None.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
