### PR TITLE
Allow importing more than 100 devices using the CLI tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For details about compatibility between different releases, see the **Commitment
   - This feature is experimental and subject to change.
 - Show normalized payload in the Console.
 - New modal in the gateway overview page for simplifying creation of API keys in the Console.
+- Introduced a backoff mechanism to the CLI device import process, allowing imports to exceed the default rate limit.
 
 ### Changed
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2025 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -584,14 +584,18 @@ var (
 				return err
 			}
 
-			application, err := ttnpb.NewApplicationRegistryClient(is).Get(ctx, &ttnpb.GetApplicationRequest{
-				ApplicationIds: devID.ApplicationIds,
-				FieldMask: ttnpb.FieldMask(
-					"network_server_address",
-					"application_server_address",
-					"join_server_address",
-				),
-			})
+			application, err := api.CallWithBackoff(
+				func() (*ttnpb.Application, error) {
+					return ttnpb.NewApplicationRegistryClient(is).Get(ctx, &ttnpb.GetApplicationRequest{
+						ApplicationIds: devID.ApplicationIds,
+						FieldMask: ttnpb.FieldMask(
+							"network_server_address",
+							"application_server_address",
+							"join_server_address",
+						),
+					})
+				},
+			)
 			if err != nil {
 				return err
 			}
@@ -604,7 +608,11 @@ var (
 					return errEndDeviceClaimGeneratedEUI.New()
 				}
 				logger.Debug("request-dev-eui flag set, requesting a DevEUI")
-				devEUIResponse, err := ttnpb.NewApplicationRegistryClient(is).IssueDevEUI(ctx, devID.ApplicationIds)
+				devEUIResponse, err := api.CallWithBackoff(
+					func() (*ttnpb.IssueDevEUIResponse, error) {
+						return ttnpb.NewApplicationRegistryClient(is).IssueDevEUI(ctx, devID.ApplicationIds)
+					},
+				)
 				if err != nil {
 					return err
 				}
@@ -634,26 +642,34 @@ var (
 				if err != nil {
 					return err
 				}
-				claimInfoResp, err := ttnpb.NewEndDeviceClaimingServerClient(dcs).GetInfoByJoinEUI(ctx, &ttnpb.GetInfoByJoinEUIRequest{
-					JoinEui: device.Ids.JoinEui,
-				})
+				claimInfoResp, err := api.CallWithBackoff(
+					func() (*ttnpb.GetInfoByJoinEUIResponse, error) {
+						return ttnpb.NewEndDeviceClaimingServerClient(dcs).GetInfoByJoinEUI(ctx, &ttnpb.GetInfoByJoinEUIRequest{
+							JoinEui: device.Ids.JoinEui,
+						})
+					},
+				)
 				if err != nil {
 					return errEndDeviceClaimInfo.WithCause(err)
 				}
 				if !claimInfoResp.SupportsClaiming {
 					return errClaimingNotSupported.WithAttributes("join_eui", types.MustEUI64(device.Ids.JoinEui).String())
 				}
-				_, err = ttnpb.NewEndDeviceClaimingServerClient(dcs).Claim(ctx, &ttnpb.ClaimEndDeviceRequest{
-					TargetApplicationIds: device.Ids.ApplicationIds,
-					TargetDeviceId:       device.Ids.DeviceId,
-					SourceDevice: &ttnpb.ClaimEndDeviceRequest_AuthenticatedIdentifiers_{
-						AuthenticatedIdentifiers: &ttnpb.ClaimEndDeviceRequest_AuthenticatedIdentifiers{
-							JoinEui:            device.Ids.JoinEui,
-							DevEui:             device.Ids.DevEui,
-							AuthenticationCode: device.ClaimAuthenticationCode.Value,
-						},
+				_, err = api.CallWithBackoff(
+					func() (*ttnpb.EndDeviceIdentifiers, error) {
+						return ttnpb.NewEndDeviceClaimingServerClient(dcs).Claim(ctx, &ttnpb.ClaimEndDeviceRequest{
+							TargetApplicationIds: device.Ids.ApplicationIds,
+							TargetDeviceId:       device.Ids.DeviceId,
+							SourceDevice: &ttnpb.ClaimEndDeviceRequest_AuthenticatedIdentifiers_{
+								AuthenticatedIdentifiers: &ttnpb.ClaimEndDeviceRequest_AuthenticatedIdentifiers{
+									JoinEui:            device.Ids.JoinEui,
+									DevEui:             device.Ids.DevEui,
+									AuthenticationCode: device.ClaimAuthenticationCode.Value,
+								},
+							},
+						})
 					},
-				})
+				)
 				if err != nil {
 					return errEndDeviceClaim.WithCause(err)
 				}
@@ -672,9 +688,13 @@ var (
 			if err := isDevice.SetFields(device, append(isPaths, "ids")...); err != nil {
 				return err
 			}
-			isRes, err := ttnpb.NewEndDeviceRegistryClient(is).Create(ctx, &ttnpb.CreateEndDeviceRequest{
-				EndDevice: isDevice,
-			})
+			isRes, err := api.CallWithBackoff(
+				func() (*ttnpb.EndDevice, error) {
+					return ttnpb.NewEndDeviceRegistryClient(is).Create(ctx, &ttnpb.CreateEndDeviceRequest{
+						EndDevice: isDevice,
+					})
+				},
+			)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -595,6 +595,7 @@ var (
 						),
 					})
 				},
+				api.WithLogger[*ttnpb.Application](log.FromContext(ctx)),
 			)
 			if err != nil {
 				return err
@@ -612,6 +613,7 @@ var (
 					func() (*ttnpb.IssueDevEUIResponse, error) {
 						return ttnpb.NewApplicationRegistryClient(is).IssueDevEUI(ctx, devID.ApplicationIds)
 					},
+					api.WithLogger[*ttnpb.IssueDevEUIResponse](log.FromContext(ctx)),
 				)
 				if err != nil {
 					return err
@@ -648,6 +650,7 @@ var (
 							JoinEui: device.Ids.JoinEui,
 						})
 					},
+					api.WithLogger[*ttnpb.GetInfoByJoinEUIResponse](log.FromContext(ctx)),
 				)
 				if err != nil {
 					return errEndDeviceClaimInfo.WithCause(err)
@@ -669,6 +672,7 @@ var (
 							},
 						})
 					},
+					api.WithLogger[*ttnpb.EndDeviceIdentifiers](log.FromContext(ctx)),
 				)
 				if err != nil {
 					return errEndDeviceClaim.WithCause(err)
@@ -694,6 +698,7 @@ var (
 						EndDevice: isDevice,
 					})
 				},
+				api.WithLogger[*ttnpb.EndDevice](log.FromContext(ctx)),
 			)
 			if err != nil {
 				return err

--- a/cmd/ttn-lw-cli/internal/api/grpc.go
+++ b/cmd/ttn-lw-cli/internal/api/grpc.go
@@ -195,6 +195,7 @@ func CloseAll() {
 // Retry defines retry logic for gRPC calls.
 type Retry[T proto.Message] struct {
 	backoff    time.Duration
+	logger     log.Interface
 	maxRetries int
 }
 
@@ -205,6 +206,13 @@ type RetryOption[T proto.Message] func(*Retry[T])
 func WithBackoff[T proto.Message](d time.Duration) RetryOption[T] {
 	return func(r *Retry[T]) {
 		r.backoff = d
+	}
+}
+
+// WithLogger sets a custom logger for retry operations.
+func WithLogger[T proto.Message](l log.Interface) RetryOption[T] {
+	return func(r *Retry[T]) {
+		r.logger = l
 	}
 }
 
@@ -225,6 +233,7 @@ func WithMaxRetries[T proto.Message](n int) RetryOption[T] {
 func CallWithBackoff[T proto.Message](call func() (T, error), opts ...RetryOption[T]) (T, error) {
 	r := Retry[T]{
 		backoff:    600 * time.Millisecond,
+		logger:     log.Noop,
 		maxRetries: 5,
 	}
 	for _, opt := range opts {
@@ -245,6 +254,13 @@ func (r Retry[T]) callWithBackoff(call func() (T, error)) (T, error) {
 		if !ok || st.Code() != codes.ResourceExhausted {
 			return zero, err
 		}
+		r.logger.Infof(
+			"Retrying gRPC call due to %q (attempt %d/%d, waiting %s)...",
+			st.Code(),
+			attempt+1,
+			r.maxRetries,
+			backoff,
+		)
 		time.Sleep(backoff)
 		backoff *= 2
 	}

--- a/cmd/ttn-lw-cli/internal/api/grpc.go
+++ b/cmd/ttn-lw-cli/internal/api/grpc.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2025 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,8 +28,11 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/rpclog"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/rpcretry"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -187,4 +190,63 @@ func CloseAll() {
 		}
 		conn.Close()
 	}
+}
+
+// Retry defines retry logic for gRPC calls.
+type Retry[T proto.Message] struct {
+	backoff    time.Duration
+	maxRetries int
+}
+
+// RetryOption defines a functional option for configuring retry behavior.
+type RetryOption[T proto.Message] func(*Retry[T])
+
+// WithBackoff sets the initial backoff duration between retries.
+func WithBackoff[T proto.Message](d time.Duration) RetryOption[T] {
+	return func(r *Retry[T]) {
+		r.backoff = d
+	}
+}
+
+// WithMaxRetries sets the maximum number of retry attempts.
+func WithMaxRetries[T proto.Message](n int) RetryOption[T] {
+	return func(r *Retry[T]) {
+		r.maxRetries = n
+	}
+}
+
+// CallWithBackoff executes a gRPC call with retry logic and exponential backoff.
+//
+// It takes a function `call` that performs the actual gRPC request and retries it
+// if the error returned is a gRPC `codes.ResourceExhausted` error. The retry behavior
+// (initial backoff duration and maximum number of retries) can be customized by
+// providing functional options (e.g., WithBackoff, WithMaxRetries). If no options are
+// provided, it defaults to a 600ms backoff and 5 maximum retries.
+func CallWithBackoff[T proto.Message](call func() (T, error), opts ...RetryOption[T]) (T, error) {
+	r := Retry[T]{
+		backoff:    600 * time.Millisecond,
+		maxRetries: 5,
+	}
+	for _, opt := range opts {
+		opt(&r)
+	}
+	return r.callWithBackoff(call)
+}
+
+func (r Retry[T]) callWithBackoff(call func() (T, error)) (T, error) {
+	var zero T
+	backoff := r.backoff
+	for attempt := 0; attempt < r.maxRetries; attempt++ {
+		v, err := call()
+		if err == nil {
+			return v, nil
+		}
+		st, ok := status.FromError(err)
+		if !ok || st.Code() != codes.ResourceExhausted {
+			return zero, err
+		}
+		time.Sleep(backoff)
+		backoff *= 2
+	}
+	return call()
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

Closes #7628

#### Changes

<!-- What are the changes made in this pull request? -->

- Add retry logic to API
- Use retry logic in end device create calls

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Create a `devices.json` file with 10 random devices:

<details><summary><code>devices.json</code></summary>

```json
{
  "ids": {
    "device_id": "eui-1ae653c29605251a",
    "dev_eui": "1AE653C29605251A",
    "join_eui": "30A71376812205CE"
  },
  "lorawan_version": "MAC_V1_0_3",
  "lorawan_phy_version": "PHY_V1_0_3_REV_A",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "3B81138441FE5686BF10F1D1F691564D"
    }
  }
}
{
  "ids": {
    "device_id": "eui-592bdfc2fbf5f802",
    "dev_eui": "592BDFC2FBF5F802",
    "join_eui": "635E9CCA96508148"
  },
  "lorawan_version": "MAC_V1_0_3",
  "lorawan_phy_version": "PHY_V1_0_3_REV_A",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "6F822AEDFEBE455379ED4BB81F00BD1E"
    }
  }
}
{
  "ids": {
    "device_id": "eui-99b43a504f448d94",
    "dev_eui": "99B43A504F448D94",
    "join_eui": "E20652CFA79C4F3F"
  },
  "lorawan_version": "MAC_V1_0_3",
  "lorawan_phy_version": "PHY_V1_0_3_REV_A",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "C9EAEC0159D66BB0A6CC6F3484261187"
    }
  }
}
{
  "ids": {
    "device_id": "eui-de485403a595a20f",
    "dev_eui": "DE485403A595A20F",
    "join_eui": "11C8E266BFE364EA"
  },
  "lorawan_version": "MAC_V1_0_3",
  "lorawan_phy_version": "PHY_V1_0_3_REV_A",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "9FC7885EEB8EA1B67B4B6CA8FE2ACCA9"
    }
  }
}
{
  "ids": {
    "device_id": "eui-42532973aa3196a2",
    "dev_eui": "42532973AA3196A2",
    "join_eui": "ACF70D1CBC0B57E0"
  },
  "lorawan_version": "MAC_V1_0_3",
  "lorawan_phy_version": "PHY_V1_0_3_REV_A",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "D53FF8E6EF383453542893A297B8CF86"
    }
  }
}
{
  "ids": {
    "device_id": "eui-42e36487ffdfa9f7",
    "dev_eui": "42E36487FFDFA9F7",
    "join_eui": "CF2AE950119BFAE9"
  },
  "lorawan_version": "MAC_V1_0_3",
  "lorawan_phy_version": "PHY_V1_0_3_REV_A",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "39FF5671FB5CF28D93A65D92A1AA2A5F"
    }
  }
}
{
  "ids": {
    "device_id": "eui-330f1234e4a7aa43",
    "dev_eui": "330F1234E4A7AA43",
    "join_eui": "47AF574DEA4228A0"
  },
  "lorawan_version": "MAC_V1_0_3",
  "lorawan_phy_version": "PHY_V1_0_3_REV_A",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "0458FF23C1C960BD5B04A9387437286E"
    }
  }
}
{
  "ids": {
    "device_id": "eui-1ef14380b0125895",
    "dev_eui": "1EF14380B0125895",
    "join_eui": "8D4B58A13D6C31F2"
  },
  "lorawan_version": "MAC_V1_0_3",
  "lorawan_phy_version": "PHY_V1_0_3_REV_A",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "BC9AC17496CF365E299EB3396654F56D"
    }
  }
}
{
  "ids": {
    "device_id": "eui-d026a8ac43ab97f1",
    "dev_eui": "D026A8AC43AB97F1",
    "join_eui": "E3A3A6010C31C47B"
  },
  "lorawan_version": "MAC_V1_0_3",
  "lorawan_phy_version": "PHY_V1_0_3_REV_A",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "924D1DB57D5099017220E0A79A0D84B2"
    }
  }
}
{
  "ids": {
    "device_id": "eui-53062e847344c6c2",
    "dev_eui": "53062E847344C6C2",
    "join_eui": "94EA6199333BA082"
  },
  "lorawan_version": "MAC_V1_0_3",
  "lorawan_phy_version": "PHY_V1_0_3_REV_A",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "CAC0E2890D4A7231824CDCC10D6692E9"
    }
  }
}
```

</details>

2. Add rate limiting to the config of the stack:

<details><summary><code>ttn-lw-stacl.yml</code></summary>

```yaml
rate-limiting:
  profiles:
    - name: gRPC API
      max-per-min: 5
      associations:
        - grpc:method
        - grpc:stream:accept
...
```

</details>

3. Run the stack with this modified config. The details can be found in `DEVELOPMENT.md`.

4. Login to the stack in the CLI:

Use `localhost`:

```bash
go run ./cmd/ttn-lw-cli/main.go use localhost --insecure --overwrite
```

> [!NOTE]
> Remember to export the variables from the `DEVELOPMENT.md`
> ``` bash
> export TTN_LW_CA=./ca.pem
> export TTN_LW_OAUTH_SERVER_ADDRESS=https://localhost:8885/oauth
> ```

Login:

```bash
go run ./cmd/ttn-lw-cli/main.go login
```

6. Create a `test-app`:

```bash
ORGANIZATION_ID='org1'
USER_ID='admin'
APP_ID='test-app'
```

```bash
go run ./cmd/ttn-lw-cli \
  organizations create $ORGANIZATION_ID \
  --user-id $USER_ID
```

```bash
go run ./cmd/ttn-lw-cli \
  app create $APP_ID \
  --organization-id $ORGANIZATION_ID
```

7. Try to create end devices:

```bash
go run ./cmd/ttn-lw-cli \
  end-devices create \
  --application-id $APP_ID < devices.json
```

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

The request should be rate limited, so you should be able to see the following error:

```bash
WARN    Finished unary call     {"duration": 0.0021, "error": "error:pkg/ratelimit:rate_limit_exceeded (rate limit of `5` accesses per minute exceeded for resource `grpc:method:/ttn.lorawan.v3.ApplicationRegistry/Get:application:test-app:token:PMNFB2Y6B4B4ABO3YWVEZMMIW7GFO6EBREEM4EI`)", "error_correlation_id": "3d6a64eebd7b46449ec12801e438641c", "error_name": "rate_limit_exceeded", "error_namespace": "pkg/ratelimit", "grpc.method": "Get", "grpc.service": "ttn.lorawan.v3.ApplicationRegistry", "grpc_code": "ResourceExhausted", "key": "grpc:method:/ttn.lorawan.v3.ApplicationRegistry/Get:application:test-app:token:PMNFB2Y6B4B4ABO3YWVEZMMIW7GFO6EBREEM4EI", "namespace": "grpc", "rate": 5, "request_id": "01JWXFVC89C6VK1NWTET4SNCGT"}
```

But the command shouldn't fail. It should try to create the device with a backoff. With a rate limit of 5 requests per minute the whole process should take a couple minutes for 10 devices.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

nil

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The default backoff is tuned for the **100 requests per minute** we have now on TTSC for gRPC (0.6s backoff).

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
