### PR TITLE
Fix race condition on downlink attempt event registration

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -4841,15 +4841,6 @@
       "file": "pattern.go"
     }
   },
-  "error:pkg/events:marshal_data": {
-    "translations": {
-      "en": "marshal data"
-    },
-    "description": {
-      "package": "pkg/events",
-      "file": "events.go"
-    }
-  },
   "error:pkg/events:no_matching_events": {
     "translations": {
       "en": "no matching events for regexp `{regexp}`"

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -25,9 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/getsentry/sentry-go"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
-	sentryerrors "go.thethings.network/lorawan-stack/v3/pkg/errors/sentry"
 	"go.thethings.network/lorawan-stack/v3/pkg/goproto"
 	"go.thethings.network/lorawan-stack/v3/pkg/jsonpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -222,45 +220,12 @@ func Proto(e Event) (*ttnpb.Event, error) {
 	pb.Context = ctx
 	if evt.data != nil {
 		var err error
-		// TODO: uncomment masrshalData and remove mustMarshalEventData after the issue mentioned
-		// below (7632) is fixed.
-		// pb.Data, err = marshalData(e.Data())
-		pb.Data, err = mustMarshalEventData(e)
+		pb.Data, err = marshalData(e.Data())
 		if err != nil {
 			return nil, err
 		}
 	}
 	return pb, nil
-}
-
-// TODO: remove after issue is resolved
-// https://github.com/TheThingsNetwork/lorawan-stack/issues/7623
-var errMarshalData = errors.Define("marshal_data", "marshal data")
-
-func mustMarshalEventData(e Event) (*anypb.Any, error) {
-	defer func() {
-		if p := recover(); p != nil {
-			var err error
-			if pErr, ok := p.(error); ok {
-				err = errMarshalData.WithCause(pErr).WithAttributes(
-					"event_name", e.Name(),
-					"event_correlation_ids", e.CorrelationIds(),
-					"event_identifiers", e.Identifiers(),
-				)
-			} else {
-				err = errMarshalData.WithAttributes(
-					"panic", p,
-					"event_name", e.Name(),
-					"event_correlation_ids", e.CorrelationIds(),
-					"event_identifiers", e.Identifiers(),
-				)
-			}
-			event := sentryerrors.NewEvent(err)
-			sentry.CaptureEvent(event)
-		}
-	}()
-
-	return marshalData(e.Data())
 }
 
 // FromProto returns the event from its protobuf representation.

--- a/pkg/gatewayserver/grpc_nsgs.go
+++ b/pkg/gatewayserver/grpc_nsgs.go
@@ -83,7 +83,7 @@ func (gs *GatewayServer) ScheduleDownlink(ctx context.Context, down *ttnpb.Downl
 		connDown.GetRequest().DownlinkPaths = nil // And do not leak the downlink paths to the gateway.
 		connDown.CorrelationIds = events.CorrelationIDsFromContext(ctx)
 
-		registerScheduleDownlinkAttempt(ctx, conn.Gateway(), connDown, conn.Frontend().Protocol())
+		registerScheduleDownlinkAttempt(ctx, conn.Gateway(), ttnpb.Clone(connDown), conn.Frontend().Protocol())
 
 		rx1, rx2, delay, err := conn.ScheduleDown(path, connDown)
 		if err != nil {

--- a/pkg/webui/locales/ja.json
+++ b/pkg/webui/locales/ja.json
@@ -2401,7 +2401,6 @@
   "error:pkg/events/redis:channel_closed": "チャネルが閉じています",
   "error:pkg/events/redis:unknown_encoding": "不明なエンコーディング",
   "error:pkg/events:invalid_regexp": "無効な正規表現",
-  "error:pkg/events:marshal_data": "",
   "error:pkg/events:no_matching_events": "正規表現`{regexp}`に一致するイベントがありません",
   "error:pkg/events:unknown_event_name": "不明なイベント`{name}`",
   "error:pkg/fetch:fetch_file": "ファイル `{filename}` を取得できません",


### PR DESCRIPTION
#### Summary

References:

- https://github.com/TheThingsNetwork/lorawan-stack/issues/7623
- https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1324
- https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1300

#### Changes

- Remove the panic recover for marshalling event data that sends events to sentry.

Logging would be useful to still have in place but I realised it's not really doing what is supposed to. Sometimes SIGBUS or even SIGSEGV is triggered which cannot be caught by the recover mechanism in Go.

To get more insight into the problem, only logging every event name from GS will help (only events that marshal data). That might increase the logs significantly because the events that marshal data are for uplinks and downlinks too.

- Clone the downlink message before registering an schedule downlink attempt event.

There is already a clone created:

```go
//pkg/gatewayserver/grpc_nsgs.go:82
connDown := ttnpb.Clone(down)             // Let the connection own the DownlinkMessage.
connDown.GetRequest().DownlinkPaths = nil // And do not leak the downlink paths to the gateway.
connDown.CorrelationIds = events.CorrelationIDsFromContext(ctx)
```

However, this clone is published as an event using `registerScheduleDownlinkAttempt` and marshalled later in the subscriber of the events and at the same time it is modified in the `conn.ScheduleDown` method:

```go
//pkg/gatewayserver/io/io.go:690
msg.Settings = &ttnpb.DownlinkMessage_Scheduled{
	Scheduled: settings,
}
```

#### Testing

I don't have a way to trigger this race condition.

##### Results

N/A.

##### Regressions

None.

#### Notes for Reviewers

This is caused by the race condition triggered by publishing events. The issue was initially discussed in here: 
- https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1163

There are more issues related to this one (some closed some still on going):
- https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1324
- https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1300
- https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1276
- https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1259
- https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1199 
- https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1163
 
I believe the root cause of the problem is that the event system does not marshal the data immediately when the event is created or published. Instead, the data is stored as a reference in the event struct (event.data) and is later marshalled by the events subscriber. The subscriber runs in a different goroutine and it is not synced in any way with the publisher who might modify the referenced event. 

I don't know if marshalling in the subscribers was a conscious decision or not. The only reason I can think of is pulling out the marshalling workload of the events from the hot path of processing messages.

The proper fix I believe would be to move the event marshalling into the publisher and send the already marshalled data to the subscriber. This change might take some work (I haven’t yet gone through the code to see what this implies) and will affect the whole codebase because the event system is shared by other components too.

The quick fix is to just clone all the events that marshal data, but might increase resource usage.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
