### PR TITLE
Keep the ADR data rate index value between min and max values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ For details about compatibility between different releases, see the **Commitment
 
 - Parsers for newly added normalized payload fields.
 
+### Fixed
+
+- ADR respects the MAC settings `adr.mode.dynamic.min-data-rate-index` and `adr.mode.dynamic.max-data-rate-index` values
+
 ## [3.34.2] - 2025-07-24
 
 ### Added

--- a/pkg/networkserver/mac/adr.go
+++ b/pkg/networkserver/mac/adr.go
@@ -584,12 +584,8 @@ func adrAdaptDataRate(
 	currentParameters, desiredParameters := macState.CurrentParameters, macState.DesiredParameters
 	currentDataRateIndex := currentParameters.AdrDataRateIndex
 	// Keep the data rate index between min and max
-	if currentDataRateIndex < minDataRateIndex {
-		currentDataRateIndex = minDataRateIndex
-	}
-	if currentDataRateIndex > maxDataRateIndex {
-		currentDataRateIndex = maxDataRateIndex
-	}
+	currentDataRateIndex = max(currentDataRateIndex, minDataRateIndex)
+	currentDataRateIndex = min(currentDataRateIndex, maxDataRateIndex)
 	// NOTE: Network Server may only increase the data rate index of the device.
 	if currentDataRateIndex > minDataRateIndex {
 		minDataRateIndex = currentDataRateIndex

--- a/pkg/networkserver/mac/adr.go
+++ b/pkg/networkserver/mac/adr.go
@@ -583,6 +583,13 @@ func adrAdaptDataRate(
 ) float32 {
 	currentParameters, desiredParameters := macState.CurrentParameters, macState.DesiredParameters
 	currentDataRateIndex := currentParameters.AdrDataRateIndex
+	// Keep the data rate index between min and max
+	if currentDataRateIndex < minDataRateIndex {
+		currentDataRateIndex = minDataRateIndex
+	}
+	if currentDataRateIndex > maxDataRateIndex {
+		currentDataRateIndex = maxDataRateIndex
+	}
 	// NOTE: Network Server may only increase the data rate index of the device.
 	if currentDataRateIndex > minDataRateIndex {
 		minDataRateIndex = currentDataRateIndex

--- a/pkg/networkserver/mac/adr_test.go
+++ b/pkg/networkserver/mac/adr_test.go
@@ -2185,8 +2185,69 @@ func TestADRAdaptDataRate(t *testing.T) {
 			},
 			OutputMargin: 5.0,
 		},
+		{
+			Name: "current index below min value",
+
+			MACState: &ttnpb.MACState{
+				CurrentParameters: &ttnpb.MACParameters{
+					AdrDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_0,
+					AdrTxPowerIndex:  1,
+				},
+				DesiredParameters: &ttnpb.MACParameters{
+					AdrDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_0,
+					AdrTxPowerIndex:  1,
+				},
+			},
+			Band:                   &band.EU_863_870_RP1_V1_0_3_Rev_A,
+			MinDataRateIndex:       ttnpb.DataRateIndex_DATA_RATE_2,
+			MaxDataRateIndex:       ttnpb.DataRateIndex_DATA_RATE_3,
+			AllowedDataRateIndices: newDataRateIndexRange(ttnpb.DataRateIndex_DATA_RATE_0, ttnpb.DataRateIndex_DATA_RATE_5),
+			InitialMargin:          0,
+
+			OutputMACState: &ttnpb.MACState{
+				CurrentParameters: &ttnpb.MACParameters{
+					AdrDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_0,
+					AdrTxPowerIndex:  1,
+				},
+				DesiredParameters: &ttnpb.MACParameters{
+					AdrDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_2,
+					AdrTxPowerIndex:  1,
+				},
+			},
+			OutputMargin: 0,
+		},
+		{
+			Name: "current index above max value",
+
+			MACState: &ttnpb.MACState{
+				CurrentParameters: &ttnpb.MACParameters{
+					AdrDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+					AdrTxPowerIndex:  1,
+				},
+				DesiredParameters: &ttnpb.MACParameters{
+					AdrDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+					AdrTxPowerIndex:  1,
+				},
+			},
+			Band:                   &band.EU_863_870_RP1_V1_0_3_Rev_A,
+			MinDataRateIndex:       ttnpb.DataRateIndex_DATA_RATE_2,
+			MaxDataRateIndex:       ttnpb.DataRateIndex_DATA_RATE_3,
+			AllowedDataRateIndices: newDataRateIndexRange(ttnpb.DataRateIndex_DATA_RATE_0, ttnpb.DataRateIndex_DATA_RATE_5),
+			InitialMargin:          0,
+
+			OutputMACState: &ttnpb.MACState{
+				CurrentParameters: &ttnpb.MACParameters{
+					AdrDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+					AdrTxPowerIndex:  1,
+				},
+				DesiredParameters: &ttnpb.MACParameters{
+					AdrDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_3,
+					AdrTxPowerIndex:  1,
+				},
+			},
+			OutputMargin: 0,
+		},
 	} {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

References: https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1336

The ADR desired data rate index didn't respect the MAC settings min and max value if the current data rate index was below the min or above the max value. It has been fixed. 

#### Changes

<!-- What are the changes made in this pull request? -->

- Keep the ADR data rate index value between min and max values

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Check the MAC state current and desired `adr_data_rate_index`
2. Set a value for `mac-settings.adr.mode.dynamic.min-data-rate-index` and `mac-settings.adr.mode.dynamic.max-data-rate-index` that the current data rate value will be outside of this range.
3. Wait for the next uplinks and check the MAC state desired `adr_data_rate_index` value is between the min and max value

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

1. Check the MAC state current and desired `adr_data_rate_index`
```
  "mac_state": {
    "current_parameters": {
      "max_eirp": 16,
      "adr_data_rate_index": 1,
      "adr_tx_power_index": 1,
      "adr_nb_trans": 1,
      "rx1_delay": 1,
      "rx2_data_rate_index": 5,
      "rx2_frequency": "869525000",
      "ping_slot_frequency": "869525000",
      "beacon_frequency": "869525000",
       },
    "desired_parameters": {
      "max_eirp": 16,
      "adr_data_rate_index": 1,
      "adr_tx_power_index": 1,
      "adr_nb_trans": 1,
      "rx1_delay": 1,
      "rx2_data_rate_index": 5,
      "rx2_frequency": "869525000",
      "ping_slot_frequency": "869525000",
      "beacon_frequency": "869525000",
      },
   }
```

2. Set a value for `mac-settings.adr.mode.dynamic.min-data-rate-index` and `mac-settings.adr.mode.dynamic.max-data-rate-index` that the current data rate value will be outside of this range.
```
go run ./cmd/ttn-lw-cli end-devices set --application-id myapp --device-id arduino-mkr --mac-settings.adr.mode.dynamic  --mac-settings.adr.mode.dynamic.max-data-rate-index 4 --mac-settings.adr.mode.dynamic.min-data-rate-index 2
```
MAC settings:
```
  "mac_settings": {
    "rx1_delay": 1,
    "rx2_data_rate_index": 0,
    "rx2_frequency": "869525000",
    "factory_preset_frequencies": [
      "868500000"
    ],
    "supports_32_bit_f_cnt": true,
    "status_time_periodicity": "86400s",
    "status_count_periodicity": 200,
    "desired_rx1_delay": 1,
    "desired_rx1_data_rate_offset": 0,
    "desired_rx2_data_rate_index": 5,
    "desired_rx2_frequency": "869525000",
    "desired_max_duty_cycle": "DUTY_CYCLE_1",
    "adr": {
      "dynamic": {
        "min_data_rate_index": 2,
        "max_data_rate_index": 4
      }
    }
```

3. Wait for the next uplinks and check the MAC state desired `adr_data_rate_index` value is between the min and max value
```
  "mac_state": {
    "current_parameters": {
      "max_eirp": 16,
      "adr_data_rate_index": 1,
      "adr_tx_power_index": 1,
      "adr_nb_trans": 1,
      "rx1_delay": 1,
      "rx2_data_rate_index": 5,
      "rx2_frequency": "869525000",
      "ping_slot_frequency": "869525000",
      "beacon_frequency": "869525000",
       },
    "desired_parameters": {
      "max_eirp": 16,
      "adr_data_rate_index": 2,
      "adr_tx_power_index": 1,
      "adr_nb_trans": 1,
      "rx1_delay": 1,
      "rx2_data_rate_index": 5,
      "rx2_frequency": "869525000",
      "ping_slot_frequency": "869525000",
      "beacon_frequency": "869525000",
      },
   }
```


#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
