### PR TITLE
Fix gateway status in the overview

### DIFF
--- a/pkg/webui/console/containers/gateway-connection/index.js
+++ b/pkg/webui/console/containers/gateway-connection/index.js
@@ -109,13 +109,6 @@ const GatewayConnection = props => {
     } else if (isFetching) {
       statusIndicator = 'mediocre'
       message = sharedMessages.connecting
-    } else if (isUnavailable) {
-      statusIndicator = 'unknown'
-      message = error.message
-      if (isOtherCluster) {
-        tooltipMessage = m.otherClusterTooltip
-        docPath = '/gateways/troubleshooting/#my-gateway-shows-a-other-cluster-status-why'
-      }
     } else if (hasStatistics) {
       message = sharedMessages.connected
       statusIndicator = 'good'
@@ -127,6 +120,13 @@ const GatewayConnection = props => {
         tooltipMessage = m.connectedTooltip
       }
       docTitle = sharedMessages.moreInformation
+    } else if (isUnavailable) {
+      statusIndicator = 'unknown'
+      message = error.message
+      if (isOtherCluster) {
+        tooltipMessage = m.otherClusterTooltip
+        docPath = '/gateways/troubleshooting/#my-gateway-shows-a-other-cluster-status-why'
+      }
     } else {
       message = sharedMessages.unknown
       statusIndicator = 'unknown'

--- a/pkg/webui/console/containers/gateway-status-panel/index.js
+++ b/pkg/webui/console/containers/gateway-status-panel/index.js
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { useEffect, useMemo } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import React, { useMemo } from 'react'
+import { useSelector } from 'react-redux'
 import { defineMessages } from 'react-intl'
-import { useParams } from 'react-router-dom'
 
 import Panel from '@ttn-lw/components/panel'
 import Icon, { IconGateway, IconInfoCircle, IconBolt, IconRouterOff } from '@ttn-lw/components/icon'
@@ -30,8 +29,6 @@ import Message from '@ttn-lw/lib/components/message'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import { getBackendErrorName, isBackend } from '@ttn-lw/lib/errors/utils'
-
-import { startGatewayStatistics, stopGatewayStatistics } from '@console/store/actions/gateways'
 
 import {
   selectGatewayStatistics,
@@ -107,13 +104,13 @@ EmptyState.propTypes = {
 }
 
 const GatewayStatusPanel = () => {
-  const dispatch = useDispatch()
-  const { gtwId } = useParams()
   const gatewayStats = useSelector(selectGatewayStatistics)
   const error = useSelector(selectGatewayStatisticsError)
   const fetching = useSelector(selectGatewayStatisticsIsFetching)
   const isDisconnected = Boolean(gatewayStats?.disconnected_at)
+  const isConnected = Boolean(gatewayStats?.connected_at) && !isDisconnected
   const isFetching = !Boolean(gatewayStats) && fetching
+  const hasStatistics = Boolean(gatewayStats)
   const noConnectionYet = useMemo(
     () => isBackend(error) && getBackendErrorName(error).includes('not_connected'),
     [error],
@@ -142,13 +139,6 @@ const GatewayStatusPanel = () => {
   const showRoundTripTimes = Boolean(gatewayStats?.round_trip_times)
   const showDutyCycleUtilization = Boolean(gatewayStats?.sub_bands)
 
-  useEffect(() => {
-    dispatch(startGatewayStatistics(gtwId))
-    return () => {
-      dispatch(stopGatewayStatistics())
-    }
-  }, [dispatch, gtwId])
-
   return (
     <Panel
       title={sharedMessages.gatewayStatus}
@@ -165,9 +155,11 @@ const GatewayStatusPanel = () => {
           status={
             isDisconnected
               ? 'bad'
-              : isFetching || hasError || noConnectionYet
+              : isFetching || noConnectionYet
                 ? 'mediocre'
-                : 'green'
+                : isConnected
+                  ? 'green'
+                  : 'unknown'
           }
           pulse
           big
@@ -206,7 +198,7 @@ const GatewayStatusPanel = () => {
           </div>
         </div>
       )}
-      {!isFetching && !noConnectionYet && !isUnavailable && (
+      {hasStatistics && !isFetching && !noConnectionYet && !isUnavailable && (
         <>
           <div className={style.gtwStatusPanelUpperContainer}>
             <div className="d-flex direction-column j-between w-full sm-md:j-start">
@@ -255,6 +247,9 @@ const GatewayStatusPanel = () => {
             </div>
           </div>
         </>
+      )}
+      {!hasStatistics && !isFetching && !noConnectionYet && !isUnavailable && (
+        <EmptyState title={m.isUnavailable} message={m.isUnavailableDesc} />
       )}
     </Panel>
   )

--- a/pkg/webui/console/store/middleware/logics/gateways.js
+++ b/pkg/webui/console/store/middleware/logics/gateways.js
@@ -254,6 +254,7 @@ const startGatewayStatisticsLogic = createLogic({
         }),
       )
       done()
+      return
     }
 
     let gtwGsAddress
@@ -273,6 +274,7 @@ const startGatewayStatisticsLogic = createLogic({
         }),
       )
       done()
+      return
     }
 
     if (gtwGsAddress !== consoleGsAddress) {
@@ -282,6 +284,7 @@ const startGatewayStatisticsLogic = createLogic({
         }),
       )
       done()
+      return
     }
 
     dispatch(gateways.startGatewayStatisticsSuccess())


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

When a disconnected gateway overview page is refreshed, the console changes to Unknown state with green dot and changes to disconnected state only when navigating to another tab and coming back to the overview page.


#### Changes

<!-- What are the changes made in this pull request? -->

- Removed one of the useEffect's so we avoid race condition.
- Strengthening up the status color conditions.

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

- Navigate to a disconnected gateway's overview page and observe the state as Disconnected with a brown dot.
- Refresh the page and observe state changes to Unknown with a green dot, and it stays like that.
- This unknown state changes back to Disconnected only when we navigate to another page and come back to the overview page.

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

It should go back to the desired state.

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I left the `startGatewayStatistics` function only in the overview header. (I couldn't put it in the initial fetch since the gateway needs to be loaded and then on unmount we are calling `stopGatewayStatistics`)

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
