### PR TITLE
Retry confirmed class C downlink on timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- The NS resends the class C confirmed downlink after the `mac_settings.class_c_timeout` time.
+
 ### Changed
 
 - Increased the default value from 5 to 15 for maximum number of confirmed uplink retransmission for LoRaWAN version prior 1.0.4.

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -53,7 +53,12 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/web"
 )
 
-const defaultLockTTL = 10 * time.Second
+const (
+	defaultLockTTL = 10 * time.Second
+
+	downlinkKey        = "downlink"
+	pendingDownlinkKey = "pending-downlink"
+)
 
 // NewComponentDeviceRegistryRedis instantiates a new redis client with the Component Device Registry namespace.
 func NewComponentDeviceRegistryRedis(conf *Config, name string) *redis.Client {
@@ -76,6 +81,12 @@ func NewNetworkServerApplicationUplinkQueueRedis(conf *Config) *redis.Client {
 // with the Network Server Downlink Task namespace.
 func NewNetworkServerDownlinkTaskRedis(conf *Config) *redis.Client {
 	return redis.New(conf.Redis.WithNamespace("ns", "tasks"))
+}
+
+// NewNetworkServerPendingDownlinkTaskRedis instantiates a new redis client
+// with the Network Server Pending Downlink Task namespace.
+func NewNetworkServerPendingDownlinkTaskRedis(conf *Config) *redis.Client {
+	return redis.New(conf.Redis.WithNamespace("ns", "pending-tasks"))
 }
 
 // NewNetworkServerMACSettingsProfileRegistryRedis instantiates a new redis client
@@ -372,12 +383,25 @@ var startCommand = &cobra.Command{
 				100000,
 				redisConsumerGroup,
 				redis.DefaultStreamBlockLimit,
+				downlinkKey,
 			)
 			if err := downlinkTasks.Init(ctx); err != nil {
 				return shared.ErrInitializeNetworkServer.WithCause(err)
 			}
 			defer downlinkTasks.Close(ctx)
 			config.NS.DownlinkTaskQueue.Queue = downlinkTasks
+			pendingDownlinkTasks := nsredis.NewDownlinkTaskQueue(
+				NewNetworkServerPendingDownlinkTaskRedis(config),
+				100000,
+				redisConsumerGroup,
+				redis.DefaultStreamBlockLimit,
+				pendingDownlinkKey,
+			)
+			if err := pendingDownlinkTasks.Init(ctx); err != nil {
+				return shared.ErrInitializeNetworkServer.WithCause(err)
+			}
+			defer pendingDownlinkTasks.Close(ctx)
+			config.NS.PendingDownlinkTaskQueue.Queue = pendingDownlinkTasks
 			config.NS.ScheduledDownlinkMatcher = &nsredis.ScheduledDownlinkMatcher{
 				Redis: redis.New(config.Cache.Redis.WithNamespace("ns", "scheduled-downlinks")),
 			}

--- a/pkg/email/templates/base.html.tmpl
+++ b/pkg/email/templates/base.html.tmpl
@@ -106,7 +106,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ block "preview" . }}{{ end }}</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="{{ block "title" . }}{{ end }}" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/api_key_changed.body.golden.html
+++ b/pkg/email/templates/testdata/api_key_changed.body.golden.html
@@ -93,7 +93,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">An API key of your application "foo-app" has been changed.</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="API Key Changed" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/api_key_created.body.with_sender_ids.golden.html
+++ b/pkg/email/templates/testdata/api_key_created.body.with_sender_ids.golden.html
@@ -93,7 +93,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">A new API key has just been created for your application "foo-app".</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="API Key Created" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/client_requested.body.golden.html
+++ b/pkg/email/templates/testdata/client_requested.body.golden.html
@@ -93,7 +93,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Your review is required for a newly registered OAuth client.</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="Client Requested" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/client_requested.body.with_api_key_id.golden.html
+++ b/pkg/email/templates/testdata/client_requested.body.with_api_key_id.golden.html
@@ -93,7 +93,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Your review is required for a newly registered OAuth client.</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="Client Requested" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/client_requested.body.with_api_key_name.golden.html
+++ b/pkg/email/templates/testdata/client_requested.body.with_api_key_name.golden.html
@@ -93,7 +93,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Your review is required for a newly registered OAuth client.</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="Client Requested" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/collaborator_changed.body.golden.html
+++ b/pkg/email/templates/testdata/collaborator_changed.body.golden.html
@@ -93,7 +93,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">A collaborator of your application "foo-app" has been added or updated.</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="Collaborator Changed" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/entity_state_changed.body.golden.html
+++ b/pkg/email/templates/testdata/entity_state_changed.body.golden.html
@@ -93,7 +93,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">The state of your client "foo-cli" has been changed.</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="Entity State Changed" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/invitation.body.golden.html
+++ b/pkg/email/templates/testdata/invitation.body.golden.html
@@ -93,7 +93,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">You have been invited to join The Things Network.</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="Invitation" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/login_token.body.golden.html
+++ b/pkg/email/templates/testdata/login_token.body.golden.html
@@ -93,7 +93,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">A login token was requested for your user "john-doe".</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="Login Token" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/password_changed.body.golden.html
+++ b/pkg/email/templates/testdata/password_changed.body.golden.html
@@ -93,7 +93,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">The password of your user "foo-usr" has just been changed.</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="Password Changed" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/temporary_password.body.golden.html
+++ b/pkg/email/templates/testdata/temporary_password.body.golden.html
@@ -93,7 +93,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">A temporary password was requested for your user "john-doe".</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="Temporary Password" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/user_requested.body.golden.html
+++ b/pkg/email/templates/testdata/user_requested.body.golden.html
@@ -93,7 +93,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Your review is required for a newly registered user.</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="User Requested" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/validate.body.golden.html
+++ b/pkg/email/templates/testdata/validate.body.golden.html
@@ -93,7 +93,7 @@
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Please confirm your email address for The Things Network.</div>
-  <div style="background-color:#E7E7E7;" lang="und" dir="auto">
+  <div aria-label="Validate" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/networkserver/config.go
+++ b/pkg/networkserver/config.go
@@ -34,7 +34,7 @@ type ApplicationUplinkQueueConfig struct {
 	FastNumConsumers uint64 `name:"fast-num-consumers"`
 }
 
-// ApplicationUplinkQueueConfig defines downlink task queue configuration.
+// DownlinkTaskQueueConfig defines downlink task queue configuration.
 type DownlinkTaskQueueConfig struct {
 	Queue        DownlinkTaskQueue `name:"-"`
 	NumConsumers uint64            `name:"num-consumers"`
@@ -141,6 +141,7 @@ type Config struct {
 	ApplicationUplinkQueue     ApplicationUplinkQueueConfig `name:"application-uplink-queue"`
 	Devices                    DeviceRegistry               `name:"-"`
 	DownlinkTaskQueue          DownlinkTaskQueueConfig      `name:"downlink-task-queue"`
+	PendingDownlinkTaskQueue   DownlinkTaskQueueConfig      `name:"pending-downlink-task-queue"`
 	UplinkDeduplicator         UplinkDeduplicator           `name:"-"`
 	ScheduledDownlinkMatcher   ScheduledDownlinkMatcher     `name:"-"`
 	NetID                      types.NetID                  `name:"net-id" description:"NetID of this Network Server"`                                                                                   // nolint: lll
@@ -168,6 +169,9 @@ var DefaultConfig = Config{
 		FastNumConsumers: 128,
 	},
 	DownlinkTaskQueue: DownlinkTaskQueueConfig{
+		NumConsumers: 1,
+	},
+	PendingDownlinkTaskQueue: DownlinkTaskQueueConfig{
 		NumConsumers: 1,
 	},
 	DeduplicationWindow: 200 * time.Millisecond,

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -2326,7 +2326,10 @@ func (ns *NetworkServer) processPendingDownlinkTask(ctx context.Context, consume
 	err := ns.pendingDownlinkTasks.Pop(
 		ctx,
 		consumerID,
-		func(ctx context.Context, devID *ttnpb.EndDeviceIdentifiers, t time.Time,
+		func(
+			ctx context.Context,
+			devID *ttnpb.EndDeviceIdentifiers,
+			t time.Time,
 		) (time.Time, error) {
 			ctx = log.NewContextWithFields(ctx, log.Fields(
 				"device_uid", unique.ID(ctx, devID),

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -2310,8 +2310,6 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context, consumerID str
 	return err
 }
 
-const maxConfirmedDownlinkRetries = 8
-
 func (ns *NetworkServer) createProcessPendingDownlinkTask(consumerID string) func(context.Context) error {
 	return func(ctx context.Context) error {
 		return ns.processPendingDownlinkTask(ctx, consumerID)
@@ -2356,28 +2354,21 @@ func (ns *NetworkServer) processPendingDownlinkTask(ctx context.Context, consume
 
 					pendingAppDown := dev.MacState.GetPendingApplicationDownlink()
 					if pendingAppDown != nil {
-						pendingAppDown.FCnt = dev.Session.LastNFCntDown + 1
-						pendingAppDown.ConfirmedRetry.Attempt++
-
-						if pendingAppDown.ConfirmedRetry.Attempt > maxConfirmedDownlinkRetries {
-							dev.MacState.PendingApplicationDownlink = nil
-							logger.Warn("Max confirmed downlink retries reached, drop pending application downlink")
-							return dev, []string{
-								"mac_state.pending_application_downlink",
-							}, nil
+						queuedApplicationUplinks := []*ttnpb.ApplicationUp{
+							{
+								EndDeviceIds: dev.Ids,
+								Up: &ttnpb.ApplicationUp_DownlinkNack{
+									DownlinkNack: pendingAppDown,
+								},
+								CorrelationIds: pendingAppDown.CorrelationIds,
+							},
 						}
 
-						// Enqueue the pending application downlink at the front of the queue.
-						// This preserves the order of other queued application downlinks.
-						// The pending application downlink will be processed first in the next downlink task.
-						// This is important for confirmed downlinks, as we need to ensure that the ACK is received
-						// before processing other downlinks.
-						dev.Session.QueuedApplicationDownlinks = append(
-							[]*ttnpb.ApplicationDownlink{pendingAppDown},
-							dev.Session.QueuedApplicationDownlinks...,
-						)
 						dev.MacState.PendingApplicationDownlink = nil
+						logger.Debug("Pending application downlink not confirmed in time, send NACK to application")
+						ns.submitApplicationUplinks(ctx, queuedApplicationUplinks...)
 					}
+
 					return dev, []string{
 						"mac_state",
 						"session",

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -2335,7 +2335,7 @@ func (ns *NetworkServer) processPendingDownlinkTask(ctx context.Context, consume
 			logger := log.FromContext(ctx)
 			logger.WithField("start_at", t).Debug("Process pending downlink task")
 
-			dev, ctx, err := ns.devices.SetByID(ctx, devID.ApplicationIds, devID.DeviceId,
+			_, ctx, err := ns.devices.SetByID(ctx, devID.ApplicationIds, devID.DeviceId,
 				[]string{
 					"frequency_plan_id",
 					"last_dev_status_received_at",
@@ -2363,8 +2363,9 @@ func (ns *NetworkServer) processPendingDownlinkTask(ctx context.Context, consume
 								CorrelationIds: pendingAppDown.CorrelationIds,
 							},
 						}
-
+						// Clear pending application downlink to avoid repeatedly sending NACKs in case of an error.
 						dev.MacState.PendingApplicationDownlink = nil
+
 						logger.Debug("Pending application downlink not confirmed in time, send NACK to application")
 						ns.submitApplicationUplinks(ctx, queuedApplicationUplinks...)
 					}
@@ -2379,11 +2380,6 @@ func (ns *NetworkServer) processPendingDownlinkTask(ctx context.Context, consume
 				setErr = true
 				logger.WithError(err).Error("Failed to update device in registry")
 				return time.Time{}, err
-			}
-
-			if err := ns.updateDataDownlinkTask(ctx, dev, time.Time{}); err != nil {
-				log.FromContext(ctx).WithError(err).Error(
-					"Failed to update downlink task queue after processing pending downlink")
 			}
 
 			return time.Time{}, nil

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -1473,7 +1473,15 @@ type downlinkAttemptResult struct {
 	DownlinkTaskUpdateStrategy downlinkTaskUpdateStrategy
 }
 
-func (ns *NetworkServer) attemptClassADataDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, fp *frequencyplans.FrequencyPlan, slot *classADownlinkSlot, maxUpLength uint16) downlinkAttemptResult {
+func (ns *NetworkServer) attemptClassADataDownlink( // nolint:gocyclo
+	ctx context.Context,
+	dev *ttnpb.EndDevice,
+	phy *band.Band,
+	fp *frequencyplans.FrequencyPlan,
+	slot *classADownlinkSlot,
+	maxUpLength uint16,
+	profile *ttnpb.MACSettings,
+) downlinkAttemptResult {
 	ctx = events.ContextWithCorrelationID(ctx, slot.Uplink.CorrelationIds...)
 	if !dev.MacState.RxWindowsAvailable {
 		log.FromContext(ctx).Error("RX windows not available, skip class A downlink slot")
@@ -1661,6 +1669,16 @@ func (ns *NetworkServer) attemptClassADataDownlink(ctx context.Context, dev *ttn
 		dev.Session.QueuedApplicationDownlinks = dev.Session.QueuedApplicationDownlinks[:0:0]
 	}
 	recordDataDownlink(dev, genState, genDown.NeedsMACAnswer, down, ns.defaultMACSettings)
+	if genState.ApplicationDownlink != nil &&
+		genState.ApplicationDownlink.Confirmed &&
+		dev.MacState.DeviceClass == ttnpb.Class_CLASS_C {
+		timeout := mac.DeviceClassCTimeout(dev, ns.defaultMACSettings, profile)
+		taskAt := time.Now().UTC().Add(timeout)
+		log.FromContext(ctx).WithField("start_at", taskAt).Debug("Add pending downlink task")
+		if err := ns.pendingDownlinkTasks.Add(ctx, dev.Ids, taskAt, true); err != nil {
+			log.FromContext(ctx).WithError(err).Warn("Failed to add pending downlink task")
+		}
+	}
 	dev.MacState.PendingRelayDownlink = nil
 	return downlinkAttemptResult{
 		SetPaths: ttnpb.AddFields(sets,
@@ -1679,7 +1697,15 @@ func (ns *NetworkServer) attemptClassADataDownlink(ctx context.Context, dev *ttn
 	}
 }
 
-func (ns *NetworkServer) attemptNetworkInitiatedDataDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, fp *frequencyplans.FrequencyPlan, slot *networkInitiatedDownlinkSlot, maxUpLength uint16) downlinkAttemptResult {
+func (ns *NetworkServer) attemptNetworkInitiatedDataDownlink( // nolint:gocyclo
+	ctx context.Context,
+	dev *ttnpb.EndDevice,
+	phy *band.Band,
+	fp *frequencyplans.FrequencyPlan,
+	slot *networkInitiatedDownlinkSlot,
+	maxUpLength uint16,
+	profile *ttnpb.MACSettings,
+) downlinkAttemptResult {
 	var drIdx ttnpb.DataRateIndex
 	var freq uint64
 	switch slot.Class {
@@ -1890,6 +1916,16 @@ func (ns *NetworkServer) attemptNetworkInitiatedDataDownlink(ctx context.Context
 	}
 
 	recordDataDownlink(dev, genState, genDown.NeedsMACAnswer, down, ns.defaultMACSettings)
+	if genState.ApplicationDownlink != nil &&
+		genState.ApplicationDownlink.Confirmed &&
+		dev.MacState.DeviceClass == ttnpb.Class_CLASS_C {
+		timeout := mac.DeviceClassCTimeout(dev, ns.defaultMACSettings, profile)
+		taskAt := time.Now().UTC().Add(timeout)
+		log.FromContext(ctx).WithField("start_at", taskAt).Debug("Add pending downlink task")
+		if err := ns.pendingDownlinkTasks.Add(ctx, dev.Ids, taskAt, true); err != nil {
+			log.FromContext(ctx).WithError(err).Warn("Failed to add pending downlink task")
+		}
+	}
 	if genState.ApplicationDownlink != nil || genState.EvictDownlinkQueueIfScheduled {
 		sets = ttnpb.AddFields(sets, "session.queued_application_downlinks")
 	}
@@ -2198,7 +2234,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context, consumerID str
 					}
 					switch slot := v.(type) {
 					case *classADownlinkSlot:
-						a := ns.attemptClassADataDownlink(ctx, dev, phy, fp, slot, maxUpLength)
+						a := ns.attemptClassADataDownlink(ctx, dev, phy, fp, slot, maxUpLength, profile.GetMacSettings())
 						queuedEvents = append(queuedEvents, a.QueuedEvents...)
 						queuedApplicationUplinks = append(queuedApplicationUplinks, a.QueuedApplicationUplinks...)
 						taskUpdateStrategy = a.DownlinkTaskUpdateStrategy
@@ -2229,7 +2265,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context, consumerID str
 							earliestAt = time.Now().Add(absoluteTimeSchedulingDelay / 2)
 							continue
 						}
-						a := ns.attemptNetworkInitiatedDataDownlink(ctx, dev, phy, fp, slot, maxUpLength)
+						a := ns.attemptNetworkInitiatedDataDownlink(ctx, dev, phy, fp, slot, maxUpLength, profile.GetMacSettings())
 						queuedEvents = append(queuedEvents, a.QueuedEvents...)
 						queuedApplicationUplinks = append(queuedApplicationUplinks, a.QueuedApplicationUplinks...)
 						taskUpdateStrategy = a.DownlinkTaskUpdateStrategy
@@ -2270,6 +2306,93 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context, consumerID str
 	})
 	if err != nil && !setErr && !computeNextErr {
 		log.FromContext(ctx).WithError(err).Error("Failed to pop entry from downlink task queue")
+	}
+	return err
+}
+
+const maxConfirmedDownlinkRetries = 8
+
+func (ns *NetworkServer) createProcessPendingDownlinkTask(consumerID string) func(context.Context) error {
+	return func(ctx context.Context) error {
+		return ns.processPendingDownlinkTask(ctx, consumerID)
+	}
+}
+
+// processPendingDownlinkTask processes the most recent pending downlink task ready for execution,
+// if such is available or wait until it is before processing it.
+// NOTE: ctx.Done() is not guaranteed to be respected by processPendingDownlinkTask.
+// The processPendingDownlinkTask receives the consumerID that will be used for popping
+// from the pending downlink task queue.
+func (ns *NetworkServer) processPendingDownlinkTask(ctx context.Context, consumerID string) error {
+	var setErr bool
+	err := ns.pendingDownlinkTasks.Pop(
+		ctx,
+		consumerID,
+		func(ctx context.Context, devID *ttnpb.EndDeviceIdentifiers, t time.Time,
+		) (time.Time, error) {
+			ctx = log.NewContextWithFields(ctx, log.Fields(
+				"device_uid", unique.ID(ctx, devID),
+				"started_at", time.Now().UTC(),
+			))
+			logger := log.FromContext(ctx)
+			logger.WithField("start_at", t).Debug("Process pending downlink task")
+
+			dev, ctx, err := ns.devices.SetByID(ctx, devID.ApplicationIds, devID.DeviceId,
+				[]string{
+					"mac_state",
+					"session",
+				},
+				func(_ context.Context, dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
+					if dev == nil {
+						logger.Warn("Device not found")
+						return nil, nil, nil
+					}
+
+					pendingAppDown := dev.MacState.GetPendingApplicationDownlink()
+					if pendingAppDown != nil {
+						pendingAppDown.FCnt = dev.Session.LastNFCntDown + 1
+						pendingAppDown.ConfirmedRetry.Attempt++
+
+						if pendingAppDown.ConfirmedRetry.Attempt > maxConfirmedDownlinkRetries {
+							dev.MacState.PendingApplicationDownlink = nil
+							logger.Warn("Max confirmed downlink retries reached, drop pending application downlink")
+							return dev, []string{
+								"mac_state.pending_application_downlink",
+							}, nil
+						}
+
+						// Enqueue the pending application downlink at the front of the queue.
+						// This preserves the order of other queued application downlinks.
+						// The pending application downlink will be processed first in the next downlink task.
+						// This is important for confirmed downlinks, as we need to ensure that the ACK is received
+						// before processing other downlinks.
+						dev.Session.QueuedApplicationDownlinks = append(
+							[]*ttnpb.ApplicationDownlink{pendingAppDown},
+							dev.Session.QueuedApplicationDownlinks...,
+						)
+						dev.MacState.PendingApplicationDownlink = nil
+					}
+					return dev, []string{
+						"mac_state",
+						"session",
+					}, nil
+				},
+			)
+			if err != nil {
+				setErr = true
+				logger.WithError(err).Error("Failed to update device in registry")
+				return time.Time{}, err
+			}
+
+			if err := ns.updateDataDownlinkTask(ctx, dev, time.Time{}); err != nil {
+				log.FromContext(ctx).WithError(err).Error(
+					"Failed to update downlink task queue after processing pending downlink")
+			}
+
+			return time.Time{}, nil
+		})
+	if err != nil && !setErr {
+		log.FromContext(ctx).WithError(err).Error("Failed to pop entry from pending downlink task queue")
 	}
 	return err
 }

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -2339,7 +2339,13 @@ func (ns *NetworkServer) processPendingDownlinkTask(ctx context.Context, consume
 
 			dev, ctx, err := ns.devices.SetByID(ctx, devID.ApplicationIds, devID.DeviceId,
 				[]string{
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
 					"mac_state",
+					"multicast",
+					"pending_mac_state",
 					"session",
 				},
 				func(_ context.Context, dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {

--- a/pkg/networkserver/internal/test/shared/redis.go
+++ b/pkg/networkserver/internal/test/shared/redis.go
@@ -70,7 +70,7 @@ func NewRedisDeviceRegistry(ctx context.Context) (DeviceRegistry, func()) {
 func NewRedisDownlinkTaskQueue(ctx context.Context) (DownlinkTaskQueue, func()) {
 	tb := test.MustTBFromContext(ctx)
 	cl, flush := test.NewRedis(ctx, append(redisNamespace[:], "downlink-tasks")...)
-	q := redis.NewDownlinkTaskQueue(cl, 10000, redisConsumerGroup, testStreamBlockLimit())
+	q := redis.NewDownlinkTaskQueue(cl, 10000, redisConsumerGroup, testStreamBlockLimit(), "downlink")
 	if err := q.Init(ctx); err != nil {
 		tb.Fatalf("Failed to initialize Redis downlink task queue: %s", test.FormatError(err))
 	}

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -172,8 +172,9 @@ type NetworkServer struct {
 
 	applicationUplinks ApplicationUplinkQueue
 
-	downlinkTasks      DownlinkTaskQueue
-	downlinkPriorities DownlinkPriorities
+	downlinkTasks        DownlinkTaskQueue
+	downlinkPriorities   DownlinkPriorities
+	pendingDownlinkTasks DownlinkTaskQueue
 
 	deduplicationWindow windowDurationFunc
 	collectionWindow    windowDurationFunc
@@ -211,6 +212,7 @@ const (
 	downlinkProcessTaskName           = "process_downlink"
 	applicationUplinkDispatchTaskName = "dispatch_application_uplink"
 	downlinkDispatchTaskName          = "dispatch_downlink"
+	pendingDownlinkProcessTaskName    = "process_pending_downlink"
 
 	maxInt = int(^uint(0) >> 1)
 )
@@ -230,10 +232,14 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 		panic(errInvalidConfiguration.WithCause(errors.New("Devices is not specified")))
 	case conf.DownlinkTaskQueue.NumConsumers == 0:
 		return nil, errInvalidConfiguration.WithCause(errors.New("DownlinkTaskQueue.NumConsumers must be greater than 0"))
+	case conf.PendingDownlinkTaskQueue.NumConsumers == 0:
+		return nil, errInvalidConfiguration.WithCause(errors.New("PendingDownlinkTaskQueue.NumConsumers must be greater than 0")) // nolint:lll
 	case conf.ApplicationUplinkQueue.NumConsumers == 0:
 		return nil, errInvalidConfiguration.WithCause(errors.New("ApplicationUplinkQueue.NumConsumers must be greater than 0"))
 	case conf.DownlinkTaskQueue.Queue == nil:
 		panic(errInvalidConfiguration.WithCause(errors.New("DownlinkTaskQueue is not specified")))
+	case conf.PendingDownlinkTaskQueue.Queue == nil:
+		panic(errInvalidConfiguration.WithCause(errors.New("PendingDownlinkTaskQueue is not specified")))
 	case conf.UplinkDeduplicator == nil:
 		panic(errInvalidConfiguration.WithCause(errors.New("UplinkDeduplicator is not specified")))
 	case conf.ScheduledDownlinkMatcher == nil:
@@ -297,6 +303,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 		macSettingsProfile:       &NsMACSettingsProfileRegistry{registry: conf.MACSettingsProfileRegistry},
 		macSettingsProfiles:      conf.MACSettingsProfileRegistry,
 		downlinkTasks:            conf.DownlinkTaskQueue.Queue,
+		pendingDownlinkTasks:     conf.PendingDownlinkTaskQueue.Queue,
 		downlinkPriorities:       downlinkPriorities,
 		defaultMACSettings:       defaultMACSettings,
 		interopClient:            interopCl,
@@ -358,7 +365,8 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 	for id, dispatcher := range map[string]interface {
 		Dispatch(context.Context, string) error
 	}{
-		downlinkDispatchTaskName: ns.downlinkTasks,
+		downlinkDispatchTaskName:       ns.downlinkTasks,
+		pendingDownlinkProcessTaskName: ns.pendingDownlinkTasks,
 	} {
 		dispatcher := dispatcher
 		ns.RegisterTask(&task.Config{
@@ -387,6 +395,16 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 			Context: ctx,
 			ID:      fmt.Sprintf("%s_%d", downlinkProcessTaskName, i),
 			Func:    ns.createProcessDownlinkTask(consumerID),
+			Restart: task.RestartAlways,
+			Backoff: processTaskBackoff,
+		})
+	}
+	for i := uint64(0); i < conf.PendingDownlinkTaskQueue.NumConsumers; i++ {
+		consumerID := fmt.Sprintf("%s:%d", consumerIDPrefix, i)
+		ns.RegisterTask(&task.Config{
+			Context: ctx,
+			ID:      fmt.Sprintf("%s_%d", pendingDownlinkProcessTaskName, i),
+			Func:    ns.createProcessPendingDownlinkTask(consumerID),
 			Restart: task.RestartAlways,
 			Backoff: processTaskBackoff,
 		})

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -2052,6 +2052,9 @@ func StartTest(ctx context.Context, conf TestConfig) (*NetworkServer, context.Co
 	if conf.NetworkServer.DownlinkTaskQueue.NumConsumers == 0 {
 		conf.NetworkServer.DownlinkTaskQueue.NumConsumers = 1
 	}
+	if conf.NetworkServer.PendingDownlinkTaskQueue.NumConsumers == 0 {
+		conf.NetworkServer.PendingDownlinkTaskQueue.NumConsumers = 1
+	}
 
 	cmpOpts := []component.Option{
 		component.WithClusterNew(func(context.Context, *cluster.Config, ...cluster.Option) (cluster.Cluster, error) {
@@ -2090,6 +2093,13 @@ func StartTest(ctx context.Context, conf TestConfig) (*NetworkServer, context.Co
 			closeFuncs = append(closeFuncs, closeFn)
 		}
 		conf.NetworkServer.DownlinkTaskQueue.Queue = v
+	}
+	if conf.NetworkServer.PendingDownlinkTaskQueue.Queue == nil {
+		v, closeFn := NewDownlinkTaskQueue(ctx)
+		if closeFn != nil {
+			closeFuncs = append(closeFuncs, closeFn)
+		}
+		conf.NetworkServer.PendingDownlinkTaskQueue.Queue = v
 	}
 	if conf.NetworkServer.UplinkDeduplicator == nil {
 		v, closeFn := NewUplinkDeduplicator(ctx)

--- a/pkg/networkserver/redis/downlink_task_queue.go
+++ b/pkg/networkserver/redis/downlink_task_queue.go
@@ -29,20 +29,16 @@ type DownlinkTaskQueue struct {
 	queue *ttnredis.TaskQueue
 }
 
-const (
-	downlinkKey = "downlink"
-)
-
 // NewDownlinkTaskQueue returns new downlink task queue.
 func NewDownlinkTaskQueue(
-	cl *ttnredis.Client, maxLen int64, group string, streamBlockLimit time.Duration,
+	cl *ttnredis.Client, maxLen int64, group string, streamBlockLimit time.Duration, key string,
 ) *DownlinkTaskQueue {
 	return &DownlinkTaskQueue{
 		queue: &ttnredis.TaskQueue{
 			Redis:            cl,
 			MaxLen:           maxLen,
 			Group:            group,
-			Key:              cl.Key(downlinkKey),
+			Key:              cl.Key(key),
 			StreamBlockLimit: streamBlockLimit,
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

The NS resends the class C confirmed downlink after the `mac_settings.class_c_timeout` time.

When the NS sends a confirmed downlink to a class C device then the device should send an uplink within the `mac_settings.class_c_timeout`. If no uplink has arrived within the timeout then the NS sends a `NACK` to the AS and the AS resends the downlink message again maximum 8 times and after that drops it.

#### Changes

<!-- What are the changes made in this pull request? -->

- Add a new task runner for the pending downlink messages.
- NS adds a task to the pending downlink queue if there is a pending downlink.
- The pending downlink task reschedules the pending downlink message after the timeout.

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Set a short value for the `mac_settings.class_c_timeout` (e.g. 30 sec), it should be less than the period how the end device sends the uplinks (e.g. 5 min).

Send a confirmed downlink message to a class C device.
- If the end device doesn't send an uplink within the timeout then the NS should resend the pending downlink again until either it reaches the maximum retry number, which is 8 or the end device sends an uplink with an `ACK`.
- If the end device sends an uplink within the timeout but without an `ACK` then the NS should resend the pending downlink.
- If the end device sends an uplink within the timeout with an `ACK` then the NS shouldn't resend the pending downlink.

Send more than one confirmed downlink to a class C device.
- The NS should put back the pending downlink to the downlink queue for resending.

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

I've tested it on my test env and it works as expected.

---

- If the end device doesn't send an uplink within the timeout then the NS should resend the pending downlink again until either it reaches the maximum retry number, which is 8 or the end device sends an uplink with an `ACK`.

<img width="1240" height="604" alt="image" src="https://github.com/user-attachments/assets/62ff9475-921d-437c-8b81-2805dc948a28" />

<img width="1008" height="680" alt="image" src="https://github.com/user-attachments/assets/c5b1a6eb-65d3-4c72-a1d4-8e61f814018a" />


- If the end device sends an uplink within the timeout but without an `ACK` then the NS should resend the pending downlink. (The `class_c_timeout` was set to 7 min)

<img width="1237" height="565" alt="image" src="https://github.com/user-attachments/assets/9ffce57d-a75a-49f8-aa2e-7d2e0344ef45" />

- If the end device sends an uplink within the timeout with an `ACK` then the NS shouldn't resend the pending downlink. (The `class_c_timeout` was set to 7 min)

<img width="1218" height="602" alt="image" src="https://github.com/user-attachments/assets/e3ce3694-4b96-46dd-863f-bd8c4ec3f928" />

---

Send more than one confirmed downlink to a class C device.
- The NS should put back the pending downlink to the downlink queue for resending.

<img width="1232" height="685" alt="image" src="https://github.com/user-attachments/assets/8b9ce9bc-a02e-43d3-bfb1-45b007dadfc3" />

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

...

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@PavelJankoski @ryaplots The `mjml` node package has been updated https://github.com/TheThingsNetwork/lorawan-stack/pull/7720 and now it generates a different file for the email templates `base.html.tmpl`. I had to regenerate the golden files otherwise the go tests are failing. Could you please review the new template file changes?

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
