### PR TITLE
Reduce TTIGW protocol disconnects based on missed pongs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - Increased the default value from 5 to 15 for maximum number of confirmed uplink retransmission for LoRaWAN version prior 1.0.4.
+- Ping response settings for the TTIGW protocol to mark less gateway connections as disconnected.
 
 ### Deprecated
 

--- a/pkg/gatewayserver/io/ttigw/config.go
+++ b/pkg/gatewayserver/io/ttigw/config.go
@@ -26,6 +26,6 @@ type Config struct {
 
 // DefaultConfig is the default configuration for The Things Industries gateway protocol frontend.
 var DefaultConfig = Config{
-	WSPingInterval:      30 * time.Second,
+	WSPingInterval:      60 * time.Second,
 	MissedPongThreshold: 2,
 }

--- a/pkg/gatewayserver/io/ttigw/ttigw.go
+++ b/pkg/gatewayserver/io/ttigw/ttigw.go
@@ -49,7 +49,7 @@ import (
 
 const (
 	pingIntervalJitter = 0.1
-	pingTimeout        = 10 * time.Second
+	pingTimeout        = 30 * time.Second
 	subprotocol        = "v1.lora.data.gateway.thethings.industries"
 )
 

--- a/pkg/gatewayserver/io/ttigw/ttigw.go
+++ b/pkg/gatewayserver/io/ttigw/ttigw.go
@@ -245,14 +245,14 @@ func (f *Frontend) handleConnection(wsConn *websocket.Conn, srvConn *io.Connecti
 	gtwConfig, err := buildLoRaGatewayConfig(srvConn.PrimaryFrequencyPlan())
 	if err != nil {
 		logger.WithError(err).Warn("Failed to build LoRa gateway configuration")
-		wsConn.Close(websocket.StatusInternalError, "failed to build LoRa gateway configuration")
+		_ = wsConn.Close(websocket.StatusInternalError, "failed to build LoRa gateway configuration")
 		return err
 	}
 
 	go func() {
 		if err := f.ping(ctx, wsConn, srvConn); err != nil && !errors.Is(err, context.Canceled) {
 			logger.WithError(err).Info("Ping failed")
-			wsConn.Close(websocket.StatusPolicyViolation, "ping failed")
+			_ = wsConn.Close(websocket.StatusPolicyViolation, "ping failed")
 		}
 	}()
 
@@ -379,14 +379,14 @@ func readGatewayMessages(
 
 		if typ != websocket.MessageBinary {
 			logger.Debug("Received message with non-binary message type")
-			wsConn.Close(websocket.StatusUnsupportedData, "unsupported message type")
+			_ = wsConn.Close(websocket.StatusUnsupportedData, "unsupported message type")
 			return errUnsupportedMessageType.New()
 		}
 
 		var envelope lorav1.GatewayMessage
 		if err := proto.Unmarshal(buf, &envelope); err != nil {
 			logger.WithError(err).Debug("Failed to unmarshal message")
-			wsConn.Close(websocket.StatusInvalidFramePayloadData, "invalid message")
+			_ = wsConn.Close(websocket.StatusInvalidFramePayloadData, "invalid message")
 			return err
 		}
 
@@ -394,7 +394,7 @@ func readGatewayMessages(
 			clientHello := envelope.GetClientHelloNotification()
 			if clientHello == nil {
 				logger.Debug("Received message without client hello")
-				wsConn.Close(websocket.StatusPolicyViolation, "client hello required")
+				_ = wsConn.Close(websocket.StatusPolicyViolation, "client hello required")
 				return errNoClientHello.New()
 			}
 			if err := srvConn.HandleStatus(gatewayStatusFromClientHello(clientHello)); err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

This reduces the number of TTIGW protocol disconnections because of not receiving pong answers to pings in time.

The ping timeout and interval are now aligned with the Gateway Controller. The Gateway Controller marks far less gateway connections as disconnected for the same gateway during the same time frame, suggesting that The Things Stack unnecessarily marks gateway connections gone.

#### Changes

<!-- What are the changes made in this pull request? -->

- Increase ping interval from 30 seconds to 1 minute
- Increase ping timeout from 10 seconds to 30 seconds

#### Testing

We'll observe this in operational metrics.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
