### PR TITLE
Fix Reset used DevNonces button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Reset used DevNonces button on the Console now works for LoRaWAN 1.0.4 and 1.1 devices.
+
 ### Security
 
 ## [3.34.3] - unreleased

--- a/pkg/webui/console/store/middleware/logics/devices.js
+++ b/pkg/webui/console/store/middleware/logics/devices.js
@@ -161,6 +161,7 @@ const resetUsedDevNoncesLogic = createRequestLogic({
     } = action
     const result = await tts.Applications.Devices.updateById(appId, deviceId, {
       used_dev_nonces: [],
+      last_dev_nonce: 0,
     })
 
     return { ...result }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

This fixes the Resets used DevNonces button on the Console. This button did not work for LoRaWAN versions with incrementing DevNonces (1.0.4, 1.1).

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/7722

#### Changes

<!-- What are the changes made in this pull request? -->

- Besides resetting `used_dev_nonces`, this also resets `last_dev_nonce` to 0

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Create end-device with LoRaWAN 1.0.4
2. Let it join a few times
3. Click Reset used DevNonces
4. Reset the end-device, making sure DevNonce starts from 0 again
5. Let it join

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

The end-device should join successfully without (repeated) `DevNonce is too small` errors.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

None expected.

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Tested locally.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
