### PR TITLE
Block requests on Fetch Table when fetching

### DIFF
--- a/pkg/webui/components/tabs/index.js
+++ b/pkg/webui/components/tabs/index.js
@@ -35,43 +35,53 @@ const Tabs = ({
   divider,
   narrow,
   toggleStyle,
-}) => (
-  <ul
-    className={classnames(className, style.tabs, {
-      [style.divider]: divider,
-      [style.tabsToggleStyle]: toggleStyle,
-    })}
-    data-test-id="tabs"
-  >
-    {tabs.map(
-      ({ name, disabled, narrow: nrw, link, exact, icon, title, hidden, description }, index) =>
-        !Boolean(hidden) && (
-          <Tab
-            key={index}
-            active={name === active}
-            name={name}
-            disabled={disabled}
-            onClick={onTabChange}
-            narrow={nrw || narrow}
-            link={link}
-            exact={exact}
-            tabClassName={individualTabClassName}
-            className={tabItemClassName}
-            toggleStyle={toggleStyle}
-            tooltip={description}
-          >
-            {icon && <Icon icon={icon} className={style.icon} />}
-            <Message content={title} />
-          </Tab>
-        ),
-    )}
-  </ul>
-)
+  disabled,
+}) => {
+  const handleClick = tabName => {
+    if (!disabled && onTabChange) {
+      onTabChange(tabName)
+    }
+  }
+
+  return (
+    <ul
+      className={classnames(className, style.tabs, {
+        [style.divider]: divider,
+        [style.tabsToggleStyle]: toggleStyle,
+      })}
+      data-test-id="tabs"
+    >
+      {tabs.map(
+        ({ name, disabled, narrow: nrw, link, exact, icon, title, hidden, description }, index) =>
+          !Boolean(hidden) && (
+            <Tab
+              key={index}
+              active={name === active}
+              name={name}
+              disabled={disabled}
+              onClick={handleClick}
+              narrow={nrw || narrow}
+              link={link}
+              exact={exact}
+              tabClassName={individualTabClassName}
+              className={tabItemClassName}
+              toggleStyle={toggleStyle}
+              tooltip={description}
+            >
+              {icon && <Icon icon={icon} className={style.icon} />}
+              <Message content={title} />
+            </Tab>
+          ),
+      )}
+    </ul>
+  )
+}
 
 Tabs.propTypes = {
   /** The name of the active tab. */
   active: PropTypes.string,
   className: PropTypes.string,
+  disabled: PropTypes.bool,
   /** Flag specifying whether the tab should render a bottom divider. */
   divider: PropTypes.bool,
   individualTabClassName: PropTypes.string,
@@ -104,6 +114,7 @@ Tabs.defaultProps = {
   divider: false,
   narrow: false,
   toggleStyle: false,
+  disabled: false,
 }
 
 export default Tabs

--- a/pkg/webui/console/containers/applications-table/index.js
+++ b/pkg/webui/console/containers/applications-table/index.js
@@ -265,8 +265,6 @@ const ApplicationsTable = props => {
     const { tab, query } = filters
     const isDeletedTab = tab === DELETED_TAB
 
-    setTab(tab)
-
     return getApplicationsList(
       { ...filters, deleted: isDeletedTab },
       [
@@ -297,6 +295,7 @@ const ApplicationsTable = props => {
       tabs={isAdmin ? tabs : []}
       searchPlaceholderMessage={sharedMessages.searchApplications}
       {...rest}
+      setTab={setTab}
     />
   )
 }

--- a/pkg/webui/console/containers/gateways-table/index.js
+++ b/pkg/webui/console/containers/gateways-table/index.js
@@ -233,8 +233,6 @@ const GatewaysTable = () => {
     const { tab, query } = filters
     const isDeletedTab = tab === DELETED_TAB
 
-    setTab(tab)
-
     return getGatewaysList(
       { ...filters, deleted: isDeletedTab },
       ['name', 'description', 'frequency_plan_ids', 'gateway_server_address'],
@@ -258,6 +256,7 @@ const GatewaysTable = () => {
       searchPlaceholderMessage={sharedMessages.searchGateways}
       clickable={!isDeletedTab}
       tabs={isAdmin ? tabs : undefined}
+      setTab={setTab}
     />
   )
 }

--- a/pkg/webui/console/containers/oauth-clients-table/index.js
+++ b/pkg/webui/console/containers/oauth-clients-table/index.js
@@ -191,7 +191,6 @@ const ClientsTable = () => {
     const { tab, query } = filters
     const isDeletedTab = tab === DELETED_TAB
 
-    setTab(tab)
     return getClientsList({ ...filters, deleted: isDeletedTab }, ['name', 'description', 'state'], {
       isSearch: tab === ALL_TAB || isDeletedTab || query.length > 0,
     })
@@ -209,6 +208,7 @@ const ClientsTable = () => {
       searchable
       clickable={!isDeletedTab}
       tabs={isAdmin ? tabs : EMPTY_ARRAY}
+      setTab={setTab}
     />
   )
 }

--- a/pkg/webui/console/containers/organizations-table/index.js
+++ b/pkg/webui/console/containers/organizations-table/index.js
@@ -202,8 +202,6 @@ const OrganizationsTable = () => {
     const { tab, query } = filters
     const isDeletedTab = tab === DELETED_TAB
 
-    setTab(tab)
-
     return getOrganizationsList({ ...filters, deleted: isDeletedTab }, ['name', 'description'], {
       isSearch: tab === ALL_TAB || isDeletedTab || query.length > 0,
       withCollaboratorCount: true,
@@ -222,6 +220,7 @@ const OrganizationsTable = () => {
       searchable
       clickable={!isDeletedTab}
       tabs={isAdmin ? tabs : []}
+      setTab={setTab}
     />
   )
 }

--- a/pkg/webui/console/containers/users-table/index.js
+++ b/pkg/webui/console/containers/users-table/index.js
@@ -306,7 +306,6 @@ const UsersTable = () => {
   const getItems = React.useCallback(params => {
     const { tab, query } = params
     const isDeletedTab = tab === DELETED_TAB
-    setTab(tab)
 
     if (tab === INVITATIONS_TAB) {
       return getUserInvitations(params, ['state'])
@@ -356,6 +355,7 @@ const UsersTable = () => {
       clickable={!isDeletedTab}
       tabs={mayInvite ? tabsWithInvitations : tabs}
       searchable={!isInvitationsTab}
+      setTab={setTab}
     />
   )
 }

--- a/pkg/webui/containers/fetch-table/index.js
+++ b/pkg/webui/containers/fetch-table/index.js
@@ -267,6 +267,7 @@ const FetchTable = props => {
                 tabs={tabs}
                 onTabChange={onTabChange}
                 toggleStyle
+                disabled={fetching}
               />
             ) : (
               tableTitle && (
@@ -286,6 +287,7 @@ const FetchTable = props => {
                 className={style.searchBar}
                 inputWidth="full"
                 maxLength={searchQueryMaxLength}
+                disabled={fetching}
               />
             )}
             {(Boolean(actionItems) || mayAdd) && (

--- a/pkg/webui/containers/fetch-table/index.js
+++ b/pkg/webui/containers/fetch-table/index.js
@@ -88,6 +88,7 @@ const FetchTable = props => {
     filtersClassName,
     smallCells,
     tableClassName,
+    setTab,
   } = props
 
   const globalPageSize = useSelector(selectPageSize)
@@ -96,7 +97,7 @@ const FetchTable = props => {
   const dispatch = useDispatch()
   const defaultTab = tabs.length > 0 ? tabs[0].name : undefined
   const [page, setPage] = useQueryState('page', 1, parseInt)
-  const [tab, setTab] = useQueryState('tab', defaultTab)
+  const [queryTab, setQueryTab] = useQueryState('tab', defaultTab)
   const [order, setOrder] = useQueryState('order', defaultOrder)
   const [query, setQuery] = useQueryState('query', '')
   const debouncedQuery = useDebounce(
@@ -113,7 +114,13 @@ const FetchTable = props => {
   const mayAdd = 'mayAdd' in base ? base.mayAdd : true
   const mayLink = 'mayLink' in base ? base.mayLink : true
 
-  const filters = { query: debouncedQuery, tab, order, page, limit: globalPageSize ?? pageSize }
+  const filters = {
+    query: debouncedQuery,
+    queryTab,
+    order,
+    page,
+    limit: globalPageSize ?? pageSize,
+  }
   const [fetching, setFetching] = useState(true)
   const [error, setError] = useState(undefined)
   let orderDirection, orderBy
@@ -141,10 +148,10 @@ const FetchTable = props => {
     const fetchItems = async () => {
       setFetching(true)
       const f = { query: debouncedQuery || '', page, limit: globalPageSize ?? pageSize }
-      if (tabs.find(t => t.name === tab)) {
-        f.tab = tab
+      if (tabs.find(t => t.name === queryTab)) {
+        f.tab = queryTab
       } else {
-        setTab(defaultTab)
+        setQueryTab(defaultTab)
         f.tab = undefined
       }
 
@@ -162,6 +169,7 @@ const FetchTable = props => {
           await dispatch(attachPromise(searchItemsAction(f)))
         } else {
           await dispatch(attachPromise(getItemsAction(f)))
+          setTab(f.tab)
         }
         if (isMounted.current) {
           setFetching(false)
@@ -187,9 +195,10 @@ const FetchTable = props => {
     pageSize,
     searchItemsAction,
     setOrder,
-    setTab,
-    tab,
     tabs,
+    queryTab,
+    setQueryTab,
+    setTab,
   ])
 
   const onPageChange = useCallback(
@@ -217,11 +226,11 @@ const FetchTable = props => {
 
   const onTabChange = useCallback(
     tab => {
-      setTab(tab)
+      setQueryTab(tab)
       setPage(1)
       setQuery('')
     },
-    [setPage, setQuery, setTab],
+    [setPage, setQuery, setQueryTab],
   )
 
   const rowHrefSelector = useCallback(
@@ -262,7 +271,7 @@ const FetchTable = props => {
           <div className={style.filtersLeft}>
             {tabs.length > 0 ? (
               <Tabs
-                active={tab}
+                active={queryTab}
                 className={style.tabs}
                 tabs={tabs}
                 onTabChange={onTabChange}
@@ -380,6 +389,7 @@ FetchTable.propTypes = {
   searchPlaceholderMessage: PropTypes.message,
   searchQueryMaxLength: PropTypes.number,
   searchable: PropTypes.bool,
+  setTab: PropTypes.func,
   smallCells: PropTypes.bool,
   tableClassName: PropTypes.string,
   tableTitle: PropTypes.message,
@@ -418,6 +428,7 @@ FetchTable.defaultProps = {
   filtersClassName: undefined,
   smallCells: false,
   tableClassName: undefined,
+  setTab: () => {},
 }
 
 export default FetchTable


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1363

#### Changes

<!-- What are the changes made in this pull request? -->

- Disable Tabs and Search while fetching
- Move setTab to after request to stop headers updating before data. For all Fetching Tables with Tabs

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

- Log in to The Things Stack Cloud deployment gateways section.
- Navigate to All (Admin) and then to Deleted (Admin) tab to and from a few times.
- You should notice it is now not possible to click until the network request completes, and the headers and actions of the table do not change until the data is updated.

I recommend using the chrome inspector and setting the throttling to 3G to see the underlying issue.

Here is the expected results 


https://github.com/user-attachments/assets/a4d51774-556a-40d4-a816-7e83a44ff569

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

There are two separate issues here.

The customers issue is that some was able to purge gateways that where not deleted. This can be seen in the video here.

https://github.com/user-attachments/assets/c0d3a6e2-36c5-43ec-b1c7-54477458d994

This is because the last request to complete is displayed to user regardless of the last tab that was pressed. 
This is a larger issue to do with how the fetching table handles cancelling requests which is too big of a project for this patch. This is why I have chosen a cosmetic fix to block the use input of the tabs and search while the table is fetching.

See [console: Add disabled state to Tabs component](https://github.com/TheThingsNetwork/lorawan-stack/commit/0eb42475f8d62c1c592b7d9d10eb8ed253456e5b) and [console: Disable FetchTable data requests when fetching](https://github.com/TheThingsNetwork/lorawan-stack/commit/9b544f499ceeb8fe1732b93a9bf7786c06676ad9)

The second issue I have addressed in the PR is something that was shown in the support ticket as the issue but was not what caused the gateways to be purged.  

See screen recording in https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1363 

Here we can see the headers of the table updating before the request is completing and temporarily showing the headers and the actions for deleted items on the non deleted items.

See [console: Move setTab to after request completes](https://github.com/TheThingsNetwork/lorawan-stack/commit/aedab1c4814c162d78a3201774d0153c734789f5) where I have moved the setTab to after the network request completes. This is not perfect as it still allows the incorrect data to be displayed in the table but at least the data has the correct headers so will not show the purge and restore actions.

Here is an example where I allowed spamming of the tabs, you can see that the incorrect data is shown but the headers are correct.


https://github.com/user-attachments/assets/b7fec14c-955c-41ae-99e7-14428715d95f



##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

This effects all Fetching tables with Tabs

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
