### PR TITLE
Fix CLI telemetry task when disabled

### DIFF
--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -102,7 +102,9 @@ var (
 			case <-telemetrySubmission:
 			}
 
-			telemetryTask.SaveData(ctx, cmd)
+			if telemetryTask != nil {
+				telemetryTask.SaveData(ctx, cmd)
+			}
 
 			err := util.SaveAuthCache(cache)
 			if err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

This fixes the telemetry collection of the CLI when it is disabled.