### PR TITLE
Rate limit device creation by application ID instead of device ID

### DIFF
--- a/pkg/ttnpb/application_interfaces.go
+++ b/pkg/ttnpb/application_interfaces.go
@@ -74,6 +74,11 @@ func (m *CreateApplicationRequest) IDString() string {
 	return m.GetApplication().IDString()
 }
 
+// RateLimitKey is the implementation of the RateLimitKeyer interface.
+func (*CreateApplicationRequest) RateLimitKey() string {
+	return ""
+}
+
 func (m *UpdateApplicationRequest) IDString() string {
 	return m.GetApplication().IDString()
 }

--- a/pkg/ttnpb/application_ratelimit_test.go
+++ b/pkg/ttnpb/application_ratelimit_test.go
@@ -1,0 +1,111 @@
+// Copyright © 2025 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnpb_test
+
+import (
+	"testing"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+func TestCreateApplicationRequest_RateLimitKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		req      *ttnpb.CreateApplicationRequest
+		expected string
+	}{
+		{
+			name: "valid request with user collaborator",
+			req: &ttnpb.CreateApplicationRequest{
+				Application: &ttnpb.Application{
+					Ids: &ttnpb.ApplicationIdentifiers{
+						ApplicationId: "test-app-1",
+					},
+				},
+				Collaborator: &ttnpb.OrganizationOrUserIdentifiers{
+					Ids: &ttnpb.OrganizationOrUserIdentifiers_UserIds{
+						UserIds: &ttnpb.UserIdentifiers{
+							UserId: "test-user",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "different app same user",
+			req: &ttnpb.CreateApplicationRequest{
+				Application: &ttnpb.Application{
+					Ids: &ttnpb.ApplicationIdentifiers{
+						ApplicationId: "test-app-2",
+					},
+				},
+				Collaborator: &ttnpb.OrganizationOrUserIdentifiers{
+					Ids: &ttnpb.OrganizationOrUserIdentifiers_UserIds{
+						UserIds: &ttnpb.UserIdentifiers{
+							UserId: "test-user",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "valid request with organization collaborator",
+			req: &ttnpb.CreateApplicationRequest{
+				Application: &ttnpb.Application{
+					Ids: &ttnpb.ApplicationIdentifiers{
+						ApplicationId: "test-app-3",
+					},
+				},
+				Collaborator: &ttnpb.OrganizationOrUserIdentifiers{
+					Ids: &ttnpb.OrganizationOrUserIdentifiers_OrganizationIds{
+						OrganizationIds: &ttnpb.OrganizationIdentifiers{
+							OrganizationId: "test-org",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "nil collaborator",
+			req: &ttnpb.CreateApplicationRequest{
+				Application: &ttnpb.Application{
+					Ids: &ttnpb.ApplicationIdentifiers{
+						ApplicationId: "test-app",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "nil request",
+			req:      &ttnpb.CreateApplicationRequest{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.req.RateLimitKey()
+			if got != tt.expected {
+				t.Errorf("RateLimitKey() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/ttnpb/client_interfaces.go
+++ b/pkg/ttnpb/client_interfaces.go
@@ -58,6 +58,11 @@ func (m *CreateClientRequest) IDString() string {
 	return m.GetClient().IDString()
 }
 
+// RateLimitKey is the implementation of the RateLimitKeyer interface.
+func (*CreateClientRequest) RateLimitKey() string {
+	return ""
+}
+
 func (m *UpdateClientRequest) IDString() string {
 	return m.GetClient().IDString()
 }

--- a/pkg/ttnpb/client_ratelimit_test.go
+++ b/pkg/ttnpb/client_ratelimit_test.go
@@ -1,0 +1,111 @@
+// Copyright © 2025 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnpb_test
+
+import (
+	"testing"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+func TestCreateClientRequest_RateLimitKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		req      *ttnpb.CreateClientRequest
+		expected string
+	}{
+		{
+			name: "valid request with user collaborator",
+			req: &ttnpb.CreateClientRequest{
+				Client: &ttnpb.Client{
+					Ids: &ttnpb.ClientIdentifiers{
+						ClientId: "test-client-1",
+					},
+				},
+				Collaborator: &ttnpb.OrganizationOrUserIdentifiers{
+					Ids: &ttnpb.OrganizationOrUserIdentifiers_UserIds{
+						UserIds: &ttnpb.UserIdentifiers{
+							UserId: "test-user",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "different client same user",
+			req: &ttnpb.CreateClientRequest{
+				Client: &ttnpb.Client{
+					Ids: &ttnpb.ClientIdentifiers{
+						ClientId: "test-client-2",
+					},
+				},
+				Collaborator: &ttnpb.OrganizationOrUserIdentifiers{
+					Ids: &ttnpb.OrganizationOrUserIdentifiers_UserIds{
+						UserIds: &ttnpb.UserIdentifiers{
+							UserId: "test-user",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "valid request with organization collaborator",
+			req: &ttnpb.CreateClientRequest{
+				Client: &ttnpb.Client{
+					Ids: &ttnpb.ClientIdentifiers{
+						ClientId: "test-client-3",
+					},
+				},
+				Collaborator: &ttnpb.OrganizationOrUserIdentifiers{
+					Ids: &ttnpb.OrganizationOrUserIdentifiers_OrganizationIds{
+						OrganizationIds: &ttnpb.OrganizationIdentifiers{
+							OrganizationId: "test-org",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "nil collaborator",
+			req: &ttnpb.CreateClientRequest{
+				Client: &ttnpb.Client{
+					Ids: &ttnpb.ClientIdentifiers{
+						ClientId: "test-client",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "nil request",
+			req:      &ttnpb.CreateClientRequest{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.req.RateLimitKey()
+			if got != tt.expected {
+				t.Errorf("RateLimitKey() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/ttnpb/end_device.go
+++ b/pkg/ttnpb/end_device.go
@@ -2990,6 +2990,11 @@ func (m *EndDevice) IDString() string {
 	return m.GetIds().IDString()
 }
 
+// RateLimitKey is the Implementation of the RateLimitKeyer interface.
+func (*CreateEndDeviceRequest) RateLimitKey() string {
+	return ""
+}
+
 // All ExtractRequestFields methods are used by github.com/grpc-ecosystem/go-grpc-middleware/tags.
 
 func (m *ResetAndGetEndDeviceRequest) ExtractRequestFields(dst map[string]interface{}) {

--- a/pkg/ttnpb/end_device_ratelimit_test.go
+++ b/pkg/ttnpb/end_device_ratelimit_test.go
@@ -1,0 +1,74 @@
+// Copyright © 2025 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnpb_test
+
+import (
+	"testing"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+func TestCreateEndDeviceRequest_RateLimitKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		req      *ttnpb.CreateEndDeviceRequest
+		expected string
+	}{
+		{
+			name: "valid request",
+			req: &ttnpb.CreateEndDeviceRequest{
+				EndDevice: &ttnpb.EndDevice{
+					Ids: &ttnpb.EndDeviceIdentifiers{
+						ApplicationIds: &ttnpb.ApplicationIdentifiers{
+							ApplicationId: "test-app",
+						},
+						DeviceId: "test-device-1",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "different device same app",
+			req: &ttnpb.CreateEndDeviceRequest{
+				EndDevice: &ttnpb.EndDevice{
+					Ids: &ttnpb.EndDeviceIdentifiers{
+						ApplicationIds: &ttnpb.ApplicationIdentifiers{
+							ApplicationId: "test-app",
+						},
+						DeviceId: "test-device-2",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "nil request",
+			req:      &ttnpb.CreateEndDeviceRequest{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.req.RateLimitKey()
+			if got != tt.expected {
+				t.Errorf("RateLimitKey() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/ttnpb/gateway_interfaces.go
+++ b/pkg/ttnpb/gateway_interfaces.go
@@ -74,6 +74,11 @@ func (m *CreateGatewayRequest) IDString() string {
 	return m.GetGateway().IDString()
 }
 
+// RateLimitKey is the implementation of the RateLimitKeyer interface.
+func (*CreateGatewayRequest) RateLimitKey() string {
+	return ""
+}
+
 func (m *UpdateGatewayRequest) IDString() string {
 	return m.GetGateway().IDString()
 }

--- a/pkg/ttnpb/gateway_ratelimit_test.go
+++ b/pkg/ttnpb/gateway_ratelimit_test.go
@@ -1,0 +1,111 @@
+// Copyright © 2025 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnpb_test
+
+import (
+	"testing"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+func TestCreateGatewayRequest_RateLimitKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		req      *ttnpb.CreateGatewayRequest
+		expected string
+	}{
+		{
+			name: "valid request with user collaborator",
+			req: &ttnpb.CreateGatewayRequest{
+				Gateway: &ttnpb.Gateway{
+					Ids: &ttnpb.GatewayIdentifiers{
+						GatewayId: "test-gateway-1",
+					},
+				},
+				Collaborator: &ttnpb.OrganizationOrUserIdentifiers{
+					Ids: &ttnpb.OrganizationOrUserIdentifiers_UserIds{
+						UserIds: &ttnpb.UserIdentifiers{
+							UserId: "test-user",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "different gateway same user",
+			req: &ttnpb.CreateGatewayRequest{
+				Gateway: &ttnpb.Gateway{
+					Ids: &ttnpb.GatewayIdentifiers{
+						GatewayId: "test-gateway-2",
+					},
+				},
+				Collaborator: &ttnpb.OrganizationOrUserIdentifiers{
+					Ids: &ttnpb.OrganizationOrUserIdentifiers_UserIds{
+						UserIds: &ttnpb.UserIdentifiers{
+							UserId: "test-user",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "valid request with organization collaborator",
+			req: &ttnpb.CreateGatewayRequest{
+				Gateway: &ttnpb.Gateway{
+					Ids: &ttnpb.GatewayIdentifiers{
+						GatewayId: "test-gateway-3",
+					},
+				},
+				Collaborator: &ttnpb.OrganizationOrUserIdentifiers{
+					Ids: &ttnpb.OrganizationOrUserIdentifiers_OrganizationIds{
+						OrganizationIds: &ttnpb.OrganizationIdentifiers{
+							OrganizationId: "test-org",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "nil collaborator",
+			req: &ttnpb.CreateGatewayRequest{
+				Gateway: &ttnpb.Gateway{
+					Ids: &ttnpb.GatewayIdentifiers{
+						GatewayId: "test-gateway",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "nil request",
+			req:      &ttnpb.CreateGatewayRequest{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.req.RateLimitKey()
+			if got != tt.expected {
+				t.Errorf("RateLimitKey() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/ttnpb/organization_interfaces.go
+++ b/pkg/ttnpb/organization_interfaces.go
@@ -74,6 +74,11 @@ func (m *CreateOrganizationRequest) IDString() string {
 	return m.GetOrganization().GetIds().IDString()
 }
 
+// RateLimitKey is the implementation of the RateLimitKeyer interface.
+func (*CreateOrganizationRequest) RateLimitKey() string {
+	return ""
+}
+
 func (m *UpdateOrganizationRequest) IDString() string {
 	return m.GetOrganization().GetIds().IDString()
 }

--- a/pkg/ttnpb/organization_ratelimit_test.go
+++ b/pkg/ttnpb/organization_ratelimit_test.go
@@ -1,0 +1,93 @@
+// Copyright © 2025 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnpb_test
+
+import (
+	"testing"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+func TestCreateOrganizationRequest_RateLimitKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		req      *ttnpb.CreateOrganizationRequest
+		expected string
+	}{
+		{
+			name: "valid request with user collaborator",
+			req: &ttnpb.CreateOrganizationRequest{
+				Organization: &ttnpb.Organization{
+					Ids: &ttnpb.OrganizationIdentifiers{
+						OrganizationId: "test-org-1",
+					},
+				},
+				Collaborator: &ttnpb.OrganizationOrUserIdentifiers{
+					Ids: &ttnpb.OrganizationOrUserIdentifiers_UserIds{
+						UserIds: &ttnpb.UserIdentifiers{
+							UserId: "test-user",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "different organization same user",
+			req: &ttnpb.CreateOrganizationRequest{
+				Organization: &ttnpb.Organization{
+					Ids: &ttnpb.OrganizationIdentifiers{
+						OrganizationId: "test-org-2",
+					},
+				},
+				Collaborator: &ttnpb.OrganizationOrUserIdentifiers{
+					Ids: &ttnpb.OrganizationOrUserIdentifiers_UserIds{
+						UserIds: &ttnpb.UserIdentifiers{
+							UserId: "test-user",
+						},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "nil collaborator",
+			req: &ttnpb.CreateOrganizationRequest{
+				Organization: &ttnpb.Organization{
+					Ids: &ttnpb.OrganizationIdentifiers{
+						OrganizationId: "test-org",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "nil request",
+			req:      &ttnpb.CreateOrganizationRequest{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.req.RateLimitKey()
+			if got != tt.expected {
+				t.Errorf("RateLimitKey() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/ttnpb/user_interfaces.go
+++ b/pkg/ttnpb/user_interfaces.go
@@ -90,6 +90,13 @@ func (m *CreateUserRequest) IDString() string {
 	return m.GetUser().GetIds().IDString()
 }
 
+// RateLimitKey is the implementation of the RateLimitKeyer interface.
+// User creation requests are rate limited at the method level only,
+// not per user, since new users don't have existing identifiers.
+func (*CreateUserRequest) RateLimitKey() string {
+	return ""
+}
+
 func (m *UpdateUserRequest) IDString() string {
 	return m.GetUser().GetIds().IDString()
 }

--- a/pkg/ttnpb/user_ratelimit_test.go
+++ b/pkg/ttnpb/user_ratelimit_test.go
@@ -1,0 +1,68 @@
+// Copyright © 2025 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnpb_test
+
+import (
+	"testing"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+func TestCreateUserRequest_RateLimitKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		req      *ttnpb.CreateUserRequest
+		expected string
+	}{
+		{
+			name: "valid request",
+			req: &ttnpb.CreateUserRequest{
+				User: &ttnpb.User{
+					Ids: &ttnpb.UserIdentifiers{
+						UserId: "test-user-1",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "different user",
+			req: &ttnpb.CreateUserRequest{
+				User: &ttnpb.User{
+					Ids: &ttnpb.UserIdentifiers{
+						UserId: "test-user-2",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "nil request",
+			req:      &ttnpb.CreateUserRequest{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.req.RateLimitKey()
+			if got != tt.expected {
+				t.Errorf("RateLimitKey() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, CreateEndDeviceRequest was rate-limited per device ID, which was ineffective since each new device has a unique ID. This allowed unlimited device creation attempts per application.

Now rate limiting is applied per application ID, properly restricting the rate of device creation requests at the application level.

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

This fixes a reported behavior where the rate-limiter does not work as intented

#### Changes

<!-- What are the changes made in this pull request? -->

- Update the key used in the rate-limit operation associated with end-device creation

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Unit tests

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

This is a bug fix


#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
