### PR TITLE
Backport of Redis webhook List operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ For details about compatibility between different releases, see the **Commitment
 - Add HSTS response headers.
 - Draft band definition for Uzbekistan 923Mhz band.
 
+### Fixed
+
+- Application Server webhook registry now uses read-only Redis client for non-paginated list operations, reducing connection holding time during high traffic.
+
 ## [3.35.1] - 2025-12-19
 
 ## [3.35.0] - 2025-11-19

--- a/pkg/applicationserver/io/web/redis/registry.go
+++ b/pkg/applicationserver/io/web/redis/registry.go
@@ -102,16 +102,19 @@ func (r WebhookRegistry) List(ctx context.Context, ids *ttnpb.ApplicationIdentif
 	appUID := unique.ID(ctx, ids)
 	uidKey := r.appKey(appUID)
 
-	opts := []ttnredis.FindProtosOption{}
+	defer trace.StartRegion(ctx, "list webhooks by application id").End()
+
 	limit, offset := ttnredis.PaginationLimitAndOffsetFromContext(ctx)
-	if limit != 0 {
-		opts = append(opts,
-			ttnredis.FindProtosSorted(true),
-			ttnredis.FindProtosWithOffsetAndCount(offset, limit),
-		)
-	}
 
 	rangeProtos := func(c redis.Cmdable) error {
+		var opts []ttnredis.FindProtosOption
+		if limit != 0 {
+			opts = append(opts,
+				ttnredis.FindProtosSorted(true),
+				ttnredis.FindProtosWithOffsetAndCount(offset, limit),
+			)
+		}
+		pbs = make([]*ttnpb.ApplicationWebhook, 0)
 		return ttnredis.FindProtos(ctx, c, uidKey, r.makeIDKeyFunc(appUID), opts...).Range(
 			func() (proto.Message, func() (bool, error)) {
 				pb := &ttnpb.ApplicationWebhook{}
@@ -126,27 +129,21 @@ func (r WebhookRegistry) List(ctx context.Context, ids *ttnpb.ApplicationIdentif
 			})
 	}
 
-	defer trace.StartRegion(ctx, "list webhooks by application id").End()
-
 	var err error
 	if limit != 0 {
-		var lockerID string
-		lockerID, err = ttnredis.GenerateLockerID()
-		if err != nil {
-			return nil, err
-		}
-		err = ttnredis.LockedWatch(ctx, r.Redis, uidKey, lockerID, r.LockTTL, func(tx *redis.Tx) (err error) {
+		// Pagination requires Watch() for consistency between SCard and SORT.
+		err = r.Redis.Watch(ctx, func(tx *redis.Tx) error {
 			total, err := tx.SCard(ctx, uidKey).Result()
 			if err != nil {
 				return err
 			}
 			ttnredis.SetPaginationTotal(ctx, total)
 			return rangeProtos(tx)
-		})
+		}, uidKey)
 	} else {
+		// No pagination - use client without Watch() to reduce connection holding time.
 		err = rangeProtos(r.Redis)
 	}
-
 	if err != nil {
 		return nil, ttnredis.ConvertError(err)
 	}

--- a/pkg/applicationserver/io/web/redis/registry_test.go
+++ b/pkg/applicationserver/io/web/redis/registry_test.go
@@ -179,6 +179,42 @@ func TestWebhookRegistry(t *testing.T) {
 		a.So(webhooks[0].Format, should.Equal, format)
 	})
 
+	t.Run("ListMultipleWithoutPagination", func(t *testing.T) {
+		t.Parallel()
+		a, ctx := test.New(t)
+
+		appID := &ttnpb.ApplicationIdentifiers{
+			ApplicationId: "myapp-list-multiple",
+		}
+
+		// Create multiple webhooks
+		for i := 1; i <= 5; i++ {
+			whIDs := &ttnpb.ApplicationWebhookIdentifiers{
+				ApplicationIds: appID,
+				WebhookId:      fmt.Sprintf("webhook-%02d", i),
+			}
+			_, err := registry.Set(ctx, whIDs, paths,
+				func(*ttnpb.ApplicationWebhook) (*ttnpb.ApplicationWebhook, []string, error) {
+					return &ttnpb.ApplicationWebhook{
+						Ids:     whIDs,
+						Format:  format,
+						BaseUrl: baseURL,
+					}, paths, nil
+				},
+			)
+			a.So(err, should.BeNil)
+		}
+
+		// List without pagination context - exercises ReadOnlyClient() path
+		webhooks, err := registry.List(ctx, appID, paths)
+		a.So(err, should.BeNil)
+		a.So(webhooks, should.HaveLength, 5)
+		for _, wh := range webhooks {
+			a.So(wh.Ids.ApplicationIds, should.Resemble, appID)
+			a.So(wh.Format, should.Equal, format)
+		}
+	})
+
 	t.Run("Pagination", func(t *testing.T) {
 		t.Parallel()
 		a, ctx := test.New(t)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

This PR contains the backport of the changes approved in https://github.com/TheThingsIndustries/lorawan-stack/pull/4793

@halimi I noticed that the implementation in this repository already had the separation between a paginated request and a get all items request. Which leads me to believe that the changes that were present here were to not propagated to the enterprise repository.

This PR only seeks to make the code consistent.
Additionally the used of the `LockedWatch` was dropped in favor of only using `Watch`. 