### PR TITLE
Fix CHANGELOG entry order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
-- Rate limiting for downlink queue operations (`DownlinkQueuePush`, `DownlinkQueueReplace`) is now applied at the application level instead of per-device. This may result in more `ResourceExhausted` (429) errors when multiple devices under the same application perform downlink queue operations concurrently.
-
 ### Deprecated
 
 ### Removed
@@ -29,6 +27,10 @@ For details about compatibility between different releases, see the **Commitment
 
 - Add HSTS response headers.
 - Draft band definition for Uzbekistan 923Mhz band.
+
+### Changed
+
+- Rate limiting for downlink queue operations (`DownlinkQueuePush`, `DownlinkQueueReplace`) is now applied at the application level instead of per-device. This may result in more `ResourceExhausted` (429) errors when multiple devices under the same application perform downlink queue operations concurrently.
 
 ### Fixed
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->
Put the entry in the CHANGELOG to be in the `3.35.2` section