### PR TITLE
Use the concentrator time to calculate the server and wait time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- The timestamp of the udp packet is now always correct when the 'Schedule downlink late' is enabled for the gateway and downlink scheduling hits the duty cycle limit.
+
 ### Security
 
 ## [3.35.2] - 2026-01-30

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -485,6 +485,11 @@ func (s *srv) handleDown(ctx context.Context, st *state) error {
 				// TODO: Report to Network Server: https://github.com/TheThingsNetwork/lorawan-stack/issues/76
 				break
 			}
+			concentratorTime, err := encoding.ConcentratorTimestampFromDownlinkMessage(down)
+			if err != nil {
+				logger.WithError(err).Warn("Failed to get concentrator timestamp from downlink message")
+				break
+			}
 			downlinkPath := st.lastDownlinkPath.Load()
 			if downlinkPath == nil {
 				logger.Debug("Received downlink message without an active downlink path")
@@ -521,7 +526,7 @@ func (s *srv) handleDown(ctx context.Context, st *state) error {
 				write()
 				break
 			}
-			serverTime := st.clock.ToServerTime(st.clock.FromTimestampTime(tx.Tmst))
+			serverTime := st.clock.ToServerTime(scheduling.ConcentratorTime(concentratorTime))
 			st.clockMu.RUnlock()
 			d := time.Until(serverTime.Add(-s.config.ScheduleLateTime))
 			logger.WithField("duration", d).Debug("Wait to schedule downlink message late")

--- a/pkg/ttnpb/udp/translation.go
+++ b/pkg/ttnpb/udp/translation.go
@@ -441,3 +441,12 @@ func FromDownlinkMessage(msg *ttnpb.DownlinkMessage) (*TxPacket, error) {
 	}
 	return tx, nil
 }
+
+// ConcentratorTimestampFromDownlinkMessage gets the concentrator timestamp from the downlink message.
+func ConcentratorTimestampFromDownlinkMessage(msg *ttnpb.DownlinkMessage) (int64, error) {
+	scheduled := msg.GetScheduled()
+	if scheduled == nil {
+		return 0, errNotScheduled.New()
+	}
+	return scheduled.ConcentratorTimestamp, nil
+}

--- a/pkg/ttnpb/udp/translation_test.go
+++ b/pkg/ttnpb/udp/translation_test.go
@@ -574,3 +574,34 @@ func TestDownlinkRoundtrip(t *testing.T) {
 
 	a.So(actual, should.HaveEmptyDiff, expected)
 }
+
+func TestConcentratorTimestampFromDownlinkMessage(t *testing.T) {
+	t.Parallel()
+	a := assertions.New(t)
+
+	msg := &ttnpb.DownlinkMessage{
+		Settings: &ttnpb.DownlinkMessage_Scheduled{
+			Scheduled: &ttnpb.TxSettings{
+				Frequency: 925700000,
+				DataRate: &ttnpb.DataRate{
+					Modulation: &ttnpb.DataRate_Lora{
+						Lora: &ttnpb.LoRaDataRate{
+							SpreadingFactor: 10,
+							Bandwidth:       500000,
+						},
+					},
+				},
+				Downlink: &ttnpb.TxSettings_Downlink{
+					TxPower:            20,
+					InvertPolarization: true,
+				},
+				Timestamp:             3427261656,
+				ConcentratorTimestamp: 11020007658000,
+			},
+		},
+		RawPayload: []byte{0x7d, 0xf3, 0x8e},
+	}
+	timestamp, err := udp.ConcentratorTimestampFromDownlinkMessage(msg)
+	a.So(err, should.BeNil)
+	a.So(timestamp, should.Equal, 11020007658000)
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

References: https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1370

Use the concentrator time instead of the packet timestamp to calculate the server and wait time when 'schedule downlink late` is enabled. The packet timestamp (microsecond timestamp) can overflow when the packet is scheduled in the future due to the duty cycle limit. 

#### Changes

<!-- What are the changes made in this pull request? -->

- Use the concentrator time to calculate the server and wait time

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

See the reproduction steps in https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1370

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

...

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
