### PR TITLE
Use separate context for Redis mutex unlock

### DIFF
--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -875,7 +875,11 @@ func LockedWatch(ctx context.Context, r WatchCmdable, k, id string, expiration t
 		return err
 	}
 	defer func() {
-		if err := UnlockMutex(ctx, r, k, id, expiration); err != nil {
+		// Use a separate context with timeout for unlocking to ensure that we attempt to unlock the mutex even if
+		// the main context is already expired.
+		unlockCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if err := UnlockMutex(unlockCtx, r, k, id, expiration); err != nil {
 			log.FromContext(ctx).WithField("key", k).WithError(err).Error("Failed to unlock mutex")
 		}
 	}()


### PR DESCRIPTION
#### Summary

Change the deferred UnlockMutex call to use context.WithoutCancel(ctx) instead of the main ctx. This ensures the unlock Redis command succeeds even if the parent context has been cancelled and the lock gets released faster than the expiration time.

#### Changes

<!-- What are the changes made in this pull request? -->

- Derive a separate context for unlocking the Redis mutex for LockedWatch.

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

...

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

...

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
