### PR TITLE
Improve GS io tracing for TTIGW & LBS LNS protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Add tracing for LBS LNS and TTIGW protocol handlers.
+
 ### Changed
 
 ### Deprecated

--- a/pkg/gatewayserver/io/semtechws/ws.go
+++ b/pkg/gatewayserver/io/semtechws/ws.go
@@ -29,6 +29,9 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.thethings.network/lorawan-stack/v3/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
@@ -37,6 +40,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/random"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
+	"go.thethings.network/lorawan-stack/v3/pkg/telemetry/tracing/tracer"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
@@ -45,7 +49,10 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-const pingIntervalJitter = 0.1
+const (
+	pingIntervalJitter = 0.1
+	tracerNamespace    = "go.thethings.network/lorawan-stack/pkg/gatewayserver/io/semtechws"
+)
 
 var (
 	errGatewayID          = errors.DefineInvalidArgument("invalid_gateway_id", "invalid gateway ID `{id}`")
@@ -69,6 +76,7 @@ func (*srv) DutyCycleStyle() scheduling.DutyCycleStyle {
 
 // New creates a new WebSocket frontend.
 func New(ctx context.Context, server io.Server, formatter Formatter, cfg Config) (*web.Server, error) {
+	ctx = tracer.NewContextWithTracer(ctx, tracerNamespace)
 	ctx = log.NewContextWithField(ctx, "namespace", "gatewayserver/io/semtechws")
 
 	s := &srv{
@@ -117,6 +125,11 @@ func (s *srv) handleConnectionInfo(w http.ResponseWriter, r *http.Request) {
 		"remote_addr", r.RemoteAddr,
 	))
 	logger := log.FromContext(ctx)
+	ctx, span := tracer.StartFromContext(ctx, "HandleConnectionInfo", trace.WithAttributes(
+		attribute.String("protocol", s.Protocol()),
+		attribute.String("remote_addr", r.RemoteAddr),
+	))
+	defer span.End()
 
 	assertAuth := func(ctx context.Context, ids *ttnpb.GatewayIdentifiers) error {
 		ctx, hasAuth := withForwardedAuth(ctx, ids, r.Header.Get("Authorization"))
@@ -131,6 +144,8 @@ func (s *srv) handleConnectionInfo(w http.ResponseWriter, r *http.Request) {
 
 	ws, err := s.upgrader.Upgrade(w, r, nil)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "upgrade request to websocket connection failed")
 		logger.WithError(err).Debug("Failed to upgrade request to websocket connection")
 		return
 	}
@@ -138,6 +153,8 @@ func (s *srv) handleConnectionInfo(w http.ResponseWriter, r *http.Request) {
 
 	_, data, err := ws.ReadMessage()
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "read message failed")
 		logger.WithError(err).Debug("Failed to read message")
 		return
 	}
@@ -168,6 +185,8 @@ func (s *srv) handleConnectionInfo(w http.ResponseWriter, r *http.Request) {
 
 	resp := s.formatter.HandleConnectionInfo(ctx, data, s.server, info, assertAuth)
 	if err := ws.WriteMessage(websocket.TextMessage, resp); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "write connection info response message failed")
 		logger.WithError(err).Warn("Failed to write connection info response message")
 		return
 	}
@@ -187,6 +206,18 @@ func (s *srv) handleTraffic(w http.ResponseWriter, r *http.Request) (err error) 
 		pongCh       = make(chan []byte, 1)
 		downstreamCh = make(chan []byte, 1)
 	)
+
+	ctx, span := tracer.StartFromContext(ctx, "HandleTraffic", trace.WithAttributes(
+		attribute.String("protocol", s.Protocol()),
+		attribute.String("remote_addr", r.RemoteAddr),
+	))
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "handle traffic failed")
+		}
+		span.End()
+	}()
 
 	ctx = log.NewContextWithFields(ctx, log.Fields(
 		"endpoint", eps.Traffic,
@@ -253,6 +284,10 @@ func (s *srv) handleTraffic(w http.ResponseWriter, r *http.Request) (err error) 
 	}
 
 	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "handle traffic failed")
+		}
 		conn.Disconnect(err)
 		err = nil // Errors are sent over the websocket connection that is established by this point.
 	}()

--- a/pkg/gatewayserver/io/ttigw/ttigw.go
+++ b/pkg/gatewayserver/io/ttigw/ttigw.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coder/websocket"
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
+	"go.opentelemetry.io/otel/codes"
 	lorav1 "go.thethings.industries/pkg/api/gen/tti/gateway/data/lora/v1"
 	ttica "go.thethings.industries/pkg/ca"
 	"go.thethings.network/lorawan-stack/v3/pkg/auth/mtls"
@@ -38,6 +39,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/random"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
 	"go.thethings.network/lorawan-stack/v3/pkg/telemetry/tracing"
+	"go.thethings.network/lorawan-stack/v3/pkg/telemetry/tracing/tracer"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
@@ -51,6 +53,7 @@ const (
 	pingIntervalJitter = 0.1
 	pingTimeout        = 30 * time.Second
 	subprotocol        = "v1.lora.data.gateway.thethings.industries"
+	tracerNamespace    = "go.thethings.network/lorawan-stack/pkg/gatewayserver/io/ttigw"
 )
 
 // Frontend implements the The Things Industries V1 gateway frontend.
@@ -64,6 +67,7 @@ var _ io.Frontend = (*Frontend)(nil)
 
 // New returns a new The Things Industries V1 gateway frontend.
 func New(ctx context.Context, server io.Server, cfg Config) (*Frontend, error) {
+	ctx = tracer.NewContextWithTracer(ctx, tracerNamespace)
 	ctx = log.NewContextWithField(ctx, "namespace", "gatewayserver/io/ttigw")
 
 	var proxyConfiguration webmiddleware.ProxyConfiguration
@@ -124,14 +128,20 @@ func (f *Frontend) handleGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := log.FromContext(ctx)
 
+	ctx, span := tracer.StartFromContext(ctx, "HandleGet")
+	defer span.End()
+
 	cert := mtls.ClientCertificateFromContext(ctx)
 	if cert == nil {
+		span.SetStatus(codes.Error, "no client certificate presented")
 		logger.Debug("No client certificate presented")
 		http.Error(w, "client certificate required", http.StatusUnauthorized)
 		return
 	}
 	ctx, ids, err := f.authenticate(ctx, cert)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "client certificate verification failed")
 		logger.WithError(err).Warn("Client certificate verification failed")
 		writeError(w, err)
 		return
@@ -142,6 +152,8 @@ func (f *Frontend) handleGet(w http.ResponseWriter, r *http.Request) {
 		Ip: remoteIP(r),
 	})
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "connect failed")
 		logger.WithError(err).Warn("Failed to connect")
 		writeError(w, err)
 		return
@@ -151,18 +163,23 @@ func (f *Frontend) handleGet(w http.ResponseWriter, r *http.Request) {
 		Subprotocols: []string{subprotocol},
 	})
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "upgrade request to websocket connection failed")
 		logger.WithError(err).Error("Failed to upgrade request to websocket connection")
 		writeError(w, err)
 		return
 	}
 	defer wsConn.CloseNow() //nolint:errcheck
 	if wsConn.Subprotocol() != subprotocol {
+		span.SetStatus(codes.Error, "subprotocol negotiation failed")
 		logger.Debug("Subprotocol negotiation failed")
 		wsConn.Close(websocket.StatusPolicyViolation, "subprotocol negotiation failed")
 		return
 	}
 
 	if err := f.handleConnection(wsConn, srvConn); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "handle connection failed")
 		logger.WithError(err).Debug("Failed to handle connection")
 	}
 }
@@ -238,9 +255,18 @@ func (f *Frontend) ping(ctx context.Context, wsConn *websocket.Conn, srvConn *io
 	}
 }
 
-func (f *Frontend) handleConnection(wsConn *websocket.Conn, srvConn *io.Connection) error {
+func (f *Frontend) handleConnection(wsConn *websocket.Conn, srvConn *io.Connection) (err error) {
 	ctx := srvConn.Context()
 	logger := log.FromContext(ctx)
+
+	ctx, span := tracer.StartFromContext(ctx, "HandleConnection")
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "handle connection failed")
+		}
+		span.End()
+	}()
 
 	gtwConfig, err := buildLoRaGatewayConfig(srvConn.PrimaryFrequencyPlan())
 	if err != nil {

--- a/pkg/telemetry/tracing/tracing.go
+++ b/pkg/telemetry/tracing/tracing.go
@@ -24,6 +24,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 	otrace "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 	"go.thethings.network/lorawan-stack/v3/pkg/version"
 )
 
@@ -49,7 +50,7 @@ func initResource(ctx context.Context) (*resource.Resource, error) {
 // If tracing is not enabled it returns a noop tracer provider instead.
 func Initialize(ctx context.Context, config *Config) (otrace.TracerProvider, func(context.Context) error, error) {
 	if !config.Enable {
-		return otrace.NewNoopTracerProvider(), func(_ context.Context) error { return nil }, nil
+		return noop.NewTracerProvider(), func(_ context.Context) error { return nil }, nil
 	}
 
 	exp, err := exporterFromConfig(ctx, config)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

Improve Gateway Server io tracing for TTIGW and LBS LNS (Semtech WebSocket) protocols by adding OpenTelemetry spans to key connection and message handling operations.

#### Changes

- Add tracing spans to TTIGW frontend: `HandleConnection`, `HandleUpMessage`, `HandleDownMessage` in `pkg/gatewayserver/io/ttigw/ttigw.go`.
- Add tracing spans to Semtech WebSocket (LBS LNS) frontend: `HandleConnectionInfo`, `HandleTraffic`, `HandleUpMessage`, `HandleDownMessage` in `pkg/gatewayserver/io/semtechws/ws.go`.
- Replace deprecated `otrace.NewNoopTracerProvider()` with `noop.NewTracerProvider()` in `pkg/telemetry/tracing/tracing.go`.

#### Testing

##### Steps

1. Start the Gateway Server with tracing enabled.
2. Connect a gateway using the TTIGW or LBS LNS protocol.
3. Send uplink/downlink messages and verify that spans are created and visible in the trace.

##### Results

Spans should appear for each connection lifecycle and message exchange, with error recording on failures.

##### Regressions

None.

#### Notes for Reviewers

None.

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.