### PR TITLE
Fix mutex lock while fetching rights on cache miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Mutex locking that caused the rights to be fetched for authorization checks sequentially. This caused gateways to reconnect slowly after Gateway Server restarts and rpcs to timeout that were asserting gateway rights.
+
 ### Security
 
 ## [3.36.0] - unreleased

--- a/pkg/auth/rights/cache.go
+++ b/pkg/auth/rights/cache.go
@@ -183,7 +183,9 @@ func (f *inMemoryCache) AuthInfo(ctx context.Context) (authInfo *ttnpb.AuthInfoR
 			cachedRes: newRes(),
 		}
 		f.authInfo[req] = res
-		go res.set(f.Fetcher.AuthInfo(ctx))
+		go func() {
+			res.set(f.Fetcher.AuthInfo(ctx))
+		}()
 	}
 	f.maybeCleanup()
 	f.mu.Unlock()
@@ -201,7 +203,9 @@ func (f *inMemoryCache) ApplicationRights(ctx context.Context, appID *ttnpb.Appl
 	if !res.valid(f.successTTL, f.errorTTL) {
 		res = newRes()
 		f.applicationRights[req] = res
-		go res.set(f.Fetcher.ApplicationRights(ctx, appID))
+		go func() {
+			res.set(f.Fetcher.ApplicationRights(ctx, appID))
+		}()
 	}
 	f.maybeCleanup()
 	f.mu.Unlock()
@@ -219,7 +223,9 @@ func (f *inMemoryCache) ClientRights(ctx context.Context, clientID *ttnpb.Client
 	if !res.valid(f.successTTL, f.errorTTL) {
 		res = newRes()
 		f.clientRights[req] = res
-		go res.set(f.Fetcher.ClientRights(ctx, clientID))
+		go func() {
+			res.set(f.Fetcher.ClientRights(ctx, clientID))
+		}()
 	}
 	f.maybeCleanup()
 	f.mu.Unlock()
@@ -237,7 +243,9 @@ func (f *inMemoryCache) GatewayRights(ctx context.Context, gtwID *ttnpb.GatewayI
 	if !res.valid(f.successTTL, f.errorTTL) {
 		res = newRes()
 		f.gatewayRights[req] = res
-		go res.set(f.Fetcher.GatewayRights(ctx, gtwID))
+		go func() {
+			res.set(f.Fetcher.GatewayRights(ctx, gtwID))
+		}()
 	}
 	f.maybeCleanup()
 	f.mu.Unlock()
@@ -255,7 +263,9 @@ func (f *inMemoryCache) OrganizationRights(ctx context.Context, orgID *ttnpb.Org
 	if !res.valid(f.successTTL, f.errorTTL) {
 		res = newRes()
 		f.organizationRights[req] = res
-		go res.set(f.Fetcher.OrganizationRights(ctx, orgID))
+		go func() {
+			res.set(f.Fetcher.OrganizationRights(ctx, orgID))
+		}()
 	}
 	f.maybeCleanup()
 	f.mu.Unlock()
@@ -273,7 +283,9 @@ func (f *inMemoryCache) UserRights(ctx context.Context, userID *ttnpb.UserIdenti
 	if !res.valid(f.successTTL, f.errorTTL) {
 		res = newRes()
 		f.userRights[req] = res
-		go res.set(f.Fetcher.UserRights(ctx, userID))
+		go func() {
+			res.set(f.Fetcher.UserRights(ctx, userID))
+		}()
 	}
 	f.maybeCleanup()
 	f.mu.Unlock()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/issues/4839 (obsolete)
References https://github.com/TheThingsIndustries/lorawan-stack/issues/4838 (obsolete)
References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1417

#### Changes

<!-- What are the changes made in this pull request? -->

On a cache miss of the in-memory rights cache, the rights were fetched while the mutex was held. This is because function arguments are evaluated before the goroutine is spawned.

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Load testing, @vlasebian to verify

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

This should no longer block the rights assertion

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

None

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
