### PR TITLE
is: Configure user session expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Add tracing for LBS LNS and TTIGW protocol handlers.
 - TTGC LBS Root CUPS claiming support.
+- Configurable Identity Server user login session TTL via `is.user-login.session-ttl`. Defaults to `0` (no expiry, matching previous behavior). When set, the auth cookie becomes persistent with a matching `Max-Age`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ For details about compatibility between different releases, see the **Commitment
 
 - Add tracing for LBS LNS and TTIGW protocol handlers.
 - TTGC LBS Root CUPS claiming support.
-- Configurable Identity Server user login session TTL via `is.user-login.session-ttl`. Defaults to `0` (no expiry, matching previous behavior). When set, the auth cookie becomes persistent with a matching `Max-Age`, and OAuth access tokens linked to a session are rejected once the session has expired — covering the Console API path.
+- Configurable Identity Server user login session TTL via `is.user-login.session-ttl`:
+  - Defaults to `0` (no expiry, matching previous behavior).
+  - When set, the auth cookie becomes persistent with a matching `Max-Age`, and OAuth access tokens linked to a session are rejected once the session has expired.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Add tracing for LBS LNS and TTIGW protocol handlers.
 - TTGC LBS Root CUPS claiming support.
-- Configurable Identity Server user login session TTL via `is.user-login.session-ttl`. Defaults to `0` (no expiry, matching previous behavior). When set, the auth cookie becomes persistent with a matching `Max-Age`.
+- Configurable Identity Server user login session TTL via `is.user-login.session-ttl`. Defaults to `0` (no expiry, matching previous behavior). When set, the auth cookie becomes persistent with a matching `Max-Age`, and OAuth access tokens linked to a session are rejected once the session has expired — covering the Console API path.
 
 ### Changed
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -8846,6 +8846,15 @@
       "file": "oauth.go"
     }
   },
+  "error:pkg/oauth:session_expired": {
+    "translations": {
+      "en": "session expired"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "storage.go"
+    }
+  },
   "error:pkg/oauth:token": {
     "translations": {
       "en": "invalid token"

--- a/pkg/account/server.go
+++ b/pkg/account/server.go
@@ -63,10 +63,13 @@ func (s *sessionStore) Transact(ctx context.Context, f func(ctx context.Context,
 // NewServer returns a new account app on top of the given store.
 func NewServer(c *component.Component, store account_store.TransactionalInterface, config oauth.Config, cspFunc func(config *oauth.Config, nonce string) string) (Server, error) {
 	s := &server{
-		c:             c,
-		config:        config,
-		store:         store,
-		session:       sess.Session{Store: &sessionStore{store}},
+		c:      c,
+		config: config,
+		store:  store,
+		session: sess.Session{
+			Store:        &sessionStore{store},
+			CookieMaxAge: config.Login.SessionTTL,
+		},
 		generateCSP:   cspFunc,
 		schemaDecoder: schema.NewDecoder(),
 	}

--- a/pkg/account/server_test.go
+++ b/pkg/account/server_test.go
@@ -397,3 +397,83 @@ func TestAuthentication(t *testing.T) {
 		})
 	}
 }
+
+func TestAuthenticationWithSessionTTL(t *testing.T) {
+	const sessionTTL = time.Hour
+
+	store := &mockStore{}
+	c := componenttest.NewComponent(t, &component.Config{
+		ServiceBase: config.ServiceBase{
+			HTTP: config.HTTP{
+				Cookie: config.Cookie{
+					HashKey:  []byte("12345678123456781234567812345678"),
+					BlockKey: []byte("12345678123456781234567812345678"),
+				},
+			},
+		},
+	})
+	s, err := account.NewServer(c, store, oauth.Config{
+		Mount:       "/oauth",
+		CSRFAuthKey: []byte("12345678123456781234567812345678"),
+		UI: oauth.UIConfig{
+			TemplateData: webui.TemplateData{
+				SiteName:     "The Things Network",
+				Title:        "Account",
+				CanonicalURL: "https://example.com/oauth",
+			},
+		},
+		Login: oauth.LoginConfig{SessionTTL: sessionTTL},
+	}, identityserver.GenerateCSPString)
+	if err != nil {
+		panic(err)
+	}
+	c.RegisterWeb(s)
+	componenttest.StartComponent(t, c)
+
+	// Obtain CSRF token.
+	req := httptest.NewRequest("GET", "/oauth/login", nil)
+	req.URL.Scheme, req.URL.Host = "http", req.Host
+	rr := httptest.NewRecorder()
+	c.ServeHTTP(rr, req)
+	csrfToken := rr.Header().Get("X-CSRF-Token")
+	csrfCookies := rr.Result().Cookies()
+
+	store.res.user = mockUser
+	store.res.session = mockSession
+
+	body, _ := json.Marshal(loginFormData{"json", "user", "pass"})
+	loginReq := httptest.NewRequest("POST", "/oauth/api/auth/login", bytes.NewBuffer(body))
+	loginReq.URL.Scheme, loginReq.URL.Host = "http", loginReq.Host
+	loginReq.Header.Set("Content-Type", "application/json")
+	loginReq.Header.Set("X-CSRF-Token", csrfToken)
+	for _, c := range csrfCookies {
+		loginReq.AddCookie(c)
+	}
+
+	before := time.Now()
+	loginRes := httptest.NewRecorder()
+	c.ServeHTTP(loginRes, loginReq)
+	after := time.Now()
+
+	a := assertions.New(t)
+	a.So(loginRes.Code, should.Equal, http.StatusNoContent)
+
+	if a.So(store.req.session, should.NotBeNil) {
+		expiresAt := ttnpb.StdTime(store.req.session.ExpiresAt)
+		if a.So(expiresAt, should.NotBeNil) {
+			a.So(expiresAt.After(before.Add(sessionTTL-time.Minute)), should.BeTrue)
+			a.So(expiresAt.Before(after.Add(sessionTTL+time.Minute)), should.BeTrue)
+		}
+	}
+
+	var authCookie *http.Cookie
+	for _, c := range loginRes.Result().Cookies() {
+		if c.Name == "_session" {
+			authCookie = c
+			break
+		}
+	}
+	if a.So(authCookie, should.NotBeNil) {
+		a.So(authCookie.MaxAge, should.Equal, int(sessionTTL.Seconds()))
+	}
+}

--- a/pkg/account/server_test.go
+++ b/pkg/account/server_test.go
@@ -399,6 +399,7 @@ func TestAuthentication(t *testing.T) {
 }
 
 func TestAuthenticationWithSessionTTL(t *testing.T) {
+	t.Parallel()
 	const sessionTTL = time.Hour
 
 	store := &mockStore{}

--- a/pkg/account/session/session.go
+++ b/pkg/account/session/session.go
@@ -35,6 +35,10 @@ var errIncorrectPasswordOrUserID = errors.DefineInvalidArgument("no_user_id_pass
 // Session is the session helper.
 type Session struct {
 	Store TransactionalStore
+
+	// CookieMaxAge sets the Max-Age of the auth cookie. Zero means a
+	// browser-session cookie (cleared when the browser closes).
+	CookieMaxAge time.Duration
 }
 
 // Store used by the account app server.
@@ -57,6 +61,7 @@ func (s *Session) authCookie() *cookie.Cookie {
 		Name:     authCookieName,
 		Path:     "/",
 		HTTPOnly: true,
+		MaxAge:   s.CookieMaxAge,
 	}
 }
 

--- a/pkg/account/user.go
+++ b/pkg/account/user.go
@@ -30,6 +30,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/oauth"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/webhandlers"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var tokenHashSettings auth.HashValidator = pbkdf2.PBKDF2{
@@ -190,12 +191,16 @@ func (s *server) CreateUserSession(w http.ResponseWriter, r *http.Request, userI
 	if err != nil {
 		return err
 	}
+	newSession := &ttnpb.UserSession{
+		UserIds:       userIDs,
+		SessionSecret: hashedSecret,
+	}
+	if ttl := s.configFromContext(ctx).Login.SessionTTL; ttl > 0 {
+		newSession.ExpiresAt = timestamppb.New(time.Now().Add(ttl))
+	}
 	var session *ttnpb.UserSession
 	err = s.store.Transact(ctx, func(ctx context.Context, st store.Interface) error {
-		session, err = st.CreateSession(ctx, &ttnpb.UserSession{
-			UserIds:       userIDs,
-			SessionSecret: hashedSecret,
-		})
+		session, err = st.CreateSession(ctx, newSession)
 		return err
 	})
 	if err != nil {

--- a/pkg/identityserver/bunstore/oauth_store.go
+++ b/pkg/identityserver/bunstore/oauth_store.go
@@ -713,7 +713,9 @@ func (s *oauthStore) GetAccessTokenWithSession(
 		Relation("Client", func(q *bun.SelectQuery) *bun.SelectQuery {
 			return q.Column("client_id")
 		}).
-		Relation("UserSession")
+		Relation("UserSession", func(q *bun.SelectQuery) *bun.SelectQuery {
+			return q.ExcludeColumn("session_secret")
+		})
 
 	if err := selectQuery.Scan(ctx); err != nil {
 		err = storeutil.WrapDriverError(err)

--- a/pkg/identityserver/bunstore/oauth_store.go
+++ b/pkg/identityserver/bunstore/oauth_store.go
@@ -698,6 +698,54 @@ func (s *oauthStore) GetAccessToken(ctx context.Context, id string) (*ttnpb.OAut
 	return pb, nil
 }
 
+func (s *oauthStore) GetAccessTokenWithSession(
+	ctx context.Context, id string,
+) (*ttnpb.OAuthAccessToken, *ttnpb.UserSession, error) {
+	ctx, span := tracer.StartFromContext(ctx, "GetAccessTokenWithSession")
+	defer span.End()
+
+	model := &AccessToken{}
+	selectQuery := s.newSelectModel(ctx, model).
+		Where("token_id = ?", id).
+		Relation("User", func(q *bun.SelectQuery) *bun.SelectQuery {
+			return q.Column("account_uid")
+		}).
+		Relation("Client", func(q *bun.SelectQuery) *bun.SelectQuery {
+			return q.Column("client_id")
+		}).
+		Relation("UserSession")
+
+	if err := selectQuery.Scan(ctx); err != nil {
+		err = storeutil.WrapDriverError(err)
+		if errors.IsNotFound(err) {
+			return nil, nil, store.ErrAccessTokenNotFound.WithAttributes(
+				"access_token_id", id,
+			)
+		}
+		return nil, nil, err
+	}
+
+	// NOTE: This imposes a limitation on the client's rights if the token's user is the unique support user.
+	if model.User.Account.UID == ttnpb.SupportUserID {
+		model.Rights = convertIntSlice[ttnpb.Right, int](ttnpb.AllReadAdminRights.GetRights())
+	}
+
+	pb, err := accessTokenToPB(model, nil, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var sessionPB *ttnpb.UserSession
+	if model.UserSession != nil {
+		sessionPB, err = userSessionToPB(model.UserSession, pb.UserIds)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return pb, sessionPB, nil
+}
+
 func (s *oauthStore) DeleteAccessToken(ctx context.Context, id string) error {
 	ctx, span := tracer.StartFromContext(ctx, "DeleteAccessToken")
 	defer span.End()

--- a/pkg/identityserver/config.go
+++ b/pkg/identityserver/config.go
@@ -91,6 +91,9 @@ type Config struct {
 		Enabled  bool          `name:"enabled" description:"enable users requesting login tokens"`
 		TokenTTL time.Duration `name:"token-ttl" description:"TTL of login tokens"`
 	} `name:"login-tokens"`
+	UserLogin struct {
+		SessionTTL time.Duration `name:"session-ttl" description:"TTL of user login sessions; zero means sessions never expire"` // nolint:lll
+	} `name:"user-login"`
 	Email struct {
 		email.Config `name:",squash"`
 		Provider     string               `name:"provider" description:"Email provider to use"`

--- a/pkg/identityserver/entity_access.go
+++ b/pkg/identityserver/entity_access.go
@@ -178,7 +178,7 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 		}
 	case auth.AccessToken:
 		fetch = func(ctx context.Context, st store.Store) error {
-			accessToken, err := st.GetAccessToken(ctx, tokenID)
+			accessToken, session, err := st.GetAccessTokenWithSession(ctx, tokenID)
 			if err != nil {
 				if errors.IsNotFound(err) {
 					return errTokenNotFound.WithCause(err)
@@ -198,12 +198,8 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 				return errTokenExpired.New()
 			}
 			if accessToken.UserSessionId != "" {
-				session, err := st.GetSession(ctx, accessToken.UserIds, accessToken.UserSessionId)
-				if err != nil {
-					if errors.IsNotFound(err) {
-						return errTokenExpired.WithCause(err)
-					}
-					return err
+				if session == nil {
+					return errTokenExpired.New()
 				}
 				if expiresAt := ttnpb.StdTime(session.ExpiresAt); expiresAt != nil && expiresAt.Before(time.Now()) {
 					return errTokenExpired.New()

--- a/pkg/identityserver/entity_access.go
+++ b/pkg/identityserver/entity_access.go
@@ -197,6 +197,18 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 			if expiresAt := ttnpb.StdTime(accessToken.ExpiresAt); expiresAt != nil && expiresAt.Before(time.Now()) {
 				return errTokenExpired.New()
 			}
+			if accessToken.UserSessionId != "" {
+				session, err := st.GetSession(ctx, accessToken.UserIds, accessToken.UserSessionId)
+				if err != nil {
+					if errors.IsNotFound(err) {
+						return errTokenExpired.WithCause(err)
+					}
+					return err
+				}
+				if expiresAt := ttnpb.StdTime(session.ExpiresAt); expiresAt != nil && expiresAt.Before(time.Now()) {
+					return errTokenExpired.New()
+				}
+			}
 			accessToken.AccessToken, accessToken.RefreshToken = "", ""
 			accessToken.Rights = ttnpb.RightsFrom(accessToken.Rights...).Implied().GetRights()
 			res.AccessMethod = &ttnpb.AuthInfoResponse_OauthAccessToken{

--- a/pkg/identityserver/entity_access_test.go
+++ b/pkg/identityserver/entity_access_test.go
@@ -15,11 +15,15 @@
 package identityserver
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/auth"
+	"go.thethings.network/lorawan-stack/v3/pkg/auth/pbkdf2"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/storetest"
+	"go.thethings.network/lorawan-stack/v3/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
@@ -64,7 +68,86 @@ func TestEntityAccess(t *testing.T) {
 	storedKey.ExpiresAt = timestamppb.New(time.Now().Add(-10 * time.Minute))
 	expiredCreds := rpcCreds(expiredKey)
 
+	oauthUsr := p.NewUser()
+	oauthClient := p.NewClient(oauthUsr.GetOrganizationOrUserIdentifiers())
+	oauthClient.Rights = []ttnpb.Right{ttnpb.Right_RIGHT_USER_ALL}
+
+	// Session that is already expired.
+	expiredSession := p.NewUserSession(oauthUsr.GetIds())
+	p.UserSessions[len(p.UserSessions)-1].ExpiresAt = timestamppb.New(time.Now().Add(-10 * time.Minute))
+
+	// Session that is still valid.
+	validSession := p.NewUserSession(oauthUsr.GetIds())
+	p.UserSessions[len(p.UserSessions)-1].ExpiresAt = timestamppb.New(time.Now().Add(10 * time.Minute))
+
+	// Generate access token bearer strings. The stored AccessToken is the hashed key.
+	newBearerAccessToken := func() (bearer, tokenID, hashed string) {
+		t.Helper()
+		raw, err := auth.AccessToken.Generate(context.Background(), "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, tokenID, key, err := auth.SplitToken(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		hashValidator := pbkdf2.Default()
+		hashValidator.Iterations = 10
+		hashed, err = auth.Hash(auth.NewContextWithHashValidator(context.Background(), hashValidator), key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return raw, tokenID, hashed
+	}
+
+	expiredSessionToken, expiredSessionTokenID, expiredSessionTokenHash := newBearerAccessToken()
+	missingSessionToken, missingSessionTokenID, missingSessionTokenHash := newBearerAccessToken()
+	validSessionToken, validSessionTokenID, validSessionTokenHash := newBearerAccessToken()
+
+	bearerCreds := func(bearer string) grpc.CallOption {
+		return grpc.PerRPCCredentials(rpcmetadata.MD{
+			AuthType:      "bearer",
+			AuthValue:     bearer,
+			AllowInsecure: true,
+		})
+	}
+
 	testWithIdentityServer(t, func(is *IdentityServer, cc *grpc.ClientConn) {
+		ctx := test.Context()
+		if _, err := is.store.CreateAccessToken(ctx, &ttnpb.OAuthAccessToken{
+			UserIds:       oauthUsr.GetIds(),
+			ClientIds:     oauthClient.GetIds(),
+			UserSessionId: expiredSession.GetSessionId(),
+			Id:            expiredSessionTokenID,
+			AccessToken:   expiredSessionTokenHash,
+			Rights:        oauthClient.GetRights(),
+			ExpiresAt:     timestamppb.New(time.Now().Add(time.Hour)),
+		}, ""); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := is.store.CreateAccessToken(ctx, &ttnpb.OAuthAccessToken{
+			UserIds:       oauthUsr.GetIds(),
+			ClientIds:     oauthClient.GetIds(),
+			UserSessionId: "00000000-0000-0000-0000-000000000000",
+			Id:            missingSessionTokenID,
+			AccessToken:   missingSessionTokenHash,
+			Rights:        oauthClient.GetRights(),
+			ExpiresAt:     timestamppb.New(time.Now().Add(time.Hour)),
+		}, ""); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := is.store.CreateAccessToken(ctx, &ttnpb.OAuthAccessToken{
+			UserIds:       oauthUsr.GetIds(),
+			ClientIds:     oauthClient.GetIds(),
+			UserSessionId: validSession.GetSessionId(),
+			Id:            validSessionTokenID,
+			AccessToken:   validSessionTokenHash,
+			Rights:        oauthClient.GetRights(),
+			ExpiresAt:     timestamppb.New(time.Now().Add(time.Hour)),
+		}, ""); err != nil {
+			t.Fatal(err)
+		}
+
 		is.config.UserRegistration.ContactInfoValidation.Required = true
 
 		cli := ttnpb.NewEntityAccessClient(cc)
@@ -162,6 +245,30 @@ func TestEntityAccess(t *testing.T) {
 			a, ctx := test.New(t)
 			var md metadata.MD
 			_, err := cli.AuthInfo(ctx, ttnpb.Empty, expiredCreds, grpc.Header(&md))
+			if a.So(err, should.NotBeNil) {
+				a.So(errors.IsUnauthenticated(err), should.BeTrue)
+			}
+		})
+
+		t.Run("Access Token with Valid Session", func(t *testing.T) {
+			a, ctx := test.New(t)
+			authInfo, err := cli.AuthInfo(ctx, ttnpb.Empty, bearerCreds(validSessionToken))
+			if a.So(err, should.BeNil) && a.So(authInfo, should.NotBeNil) {
+				a.So(authInfo.GetOauthAccessToken(), should.NotBeNil)
+			}
+		})
+
+		t.Run("Access Token with Expired Session", func(t *testing.T) {
+			a, ctx := test.New(t)
+			_, err := cli.AuthInfo(ctx, ttnpb.Empty, bearerCreds(expiredSessionToken))
+			if a.So(err, should.NotBeNil) {
+				a.So(errors.IsUnauthenticated(err), should.BeTrue)
+			}
+		})
+
+		t.Run("Access Token with Missing Session", func(t *testing.T) {
+			a, ctx := test.New(t)
+			_, err := cli.AuthInfo(ctx, ttnpb.Empty, bearerCreds(missingSessionToken))
 			if a.So(err, should.NotBeNil) {
 				a.So(errors.IsUnauthenticated(err), should.BeTrue)
 			}

--- a/pkg/identityserver/entity_access_test.go
+++ b/pkg/identityserver/entity_access_test.go
@@ -72,13 +72,17 @@ func TestEntityAccess(t *testing.T) {
 	oauthClient := p.NewClient(oauthUsr.GetOrganizationOrUserIdentifiers())
 	oauthClient.Rights = []ttnpb.Right{ttnpb.Right_RIGHT_USER_ALL}
 
-	// Session that is already expired.
-	expiredSession := p.NewUserSession(oauthUsr.GetIds())
-	p.UserSessions[len(p.UserSessions)-1].ExpiresAt = timestamppb.New(time.Now().Add(-10 * time.Minute))
+	// Session that is already expired. CreateSession assigns the session ID,
+	// so we reference the population slice entry to read the actual ID after
+	// Populate runs.
+	p.NewUserSession(oauthUsr.GetIds())
+	expiredSession := p.UserSessions[len(p.UserSessions)-1]
+	expiredSession.ExpiresAt = timestamppb.New(time.Now().Add(-10 * time.Minute))
 
 	// Session that is still valid.
-	validSession := p.NewUserSession(oauthUsr.GetIds())
-	p.UserSessions[len(p.UserSessions)-1].ExpiresAt = timestamppb.New(time.Now().Add(10 * time.Minute))
+	p.NewUserSession(oauthUsr.GetIds())
+	validSession := p.UserSessions[len(p.UserSessions)-1]
+	validSession.ExpiresAt = timestamppb.New(time.Now().Add(10 * time.Minute))
 
 	// Generate access token bearer strings. The stored AccessToken is the hashed key.
 	newBearerAccessToken := func() (bearer, tokenID, hashed string) {
@@ -250,7 +254,7 @@ func TestEntityAccess(t *testing.T) {
 			}
 		})
 
-		t.Run("Access Token with Valid Session", func(t *testing.T) {
+		t.Run("Access Token with Valid Session", func(t *testing.T) { // nolint:paralleltest
 			a, ctx := test.New(t)
 			authInfo, err := cli.AuthInfo(ctx, ttnpb.Empty, bearerCreds(validSessionToken))
 			if a.So(err, should.BeNil) && a.So(authInfo, should.NotBeNil) {
@@ -258,7 +262,7 @@ func TestEntityAccess(t *testing.T) {
 			}
 		})
 
-		t.Run("Access Token with Expired Session", func(t *testing.T) {
+		t.Run("Access Token with Expired Session", func(t *testing.T) { // nolint:paralleltest
 			a, ctx := test.New(t)
 			_, err := cli.AuthInfo(ctx, ttnpb.Empty, bearerCreds(expiredSessionToken))
 			if a.So(err, should.NotBeNil) {
@@ -266,7 +270,7 @@ func TestEntityAccess(t *testing.T) {
 			}
 		})
 
-		t.Run("Access Token with Missing Session", func(t *testing.T) {
+		t.Run("Access Token with Missing Session", func(t *testing.T) { // nolint:paralleltest
 			a, ctx := test.New(t)
 			_, err := cli.AuthInfo(ctx, ttnpb.Empty, bearerCreds(missingSessionToken))
 			if a.So(err, should.NotBeNil) {

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -160,6 +160,12 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 
 	is.config.OAuth.CSRFAuthKey = is.GetBaseConfig(is.Context()).HTTP.Cookie.HashKey
 	is.config.OAuth.UI.FrontendConfig.EnableUserRegistration = is.config.UserRegistration.Enabled
+	if is.config.UserLogin.SessionTTL < 0 {
+		log.FromContext(is.Context()).WithField("session_ttl", is.config.UserLogin.SessionTTL).Warn(
+			"Negative is.user-login.session-ttl; resetting to 0 (sessions never expire)",
+		)
+		is.config.UserLogin.SessionTTL = 0
+	}
 	is.config.OAuth.Login.SessionTTL = is.config.UserLogin.SessionTTL
 	is.oauth, err = oauth.NewServer(c, &oauthAppStore{is.store}, is.config.OAuth, GenerateCSPString)
 	if err != nil {

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -160,6 +160,7 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 
 	is.config.OAuth.CSRFAuthKey = is.GetBaseConfig(is.Context()).HTTP.Cookie.HashKey
 	is.config.OAuth.UI.FrontendConfig.EnableUserRegistration = is.config.UserRegistration.Enabled
+	is.config.OAuth.Login.SessionTTL = is.config.UserLogin.SessionTTL
 	is.oauth, err = oauth.NewServer(c, &oauthAppStore{is.store}, is.config.OAuth, GenerateCSPString)
 	if err != nil {
 		return nil, err

--- a/pkg/identityserver/store/store_interfaces.go
+++ b/pkg/identityserver/store/store_interfaces.go
@@ -310,6 +310,9 @@ type OAuthStore interface {
 		ctx context.Context, userIDs *ttnpb.UserIdentifiers, clientIDs *ttnpb.ClientIdentifiers,
 	) ([]*ttnpb.OAuthAccessToken, error)
 	GetAccessToken(ctx context.Context, id string) (*ttnpb.OAuthAccessToken, error)
+	// GetAccessTokenWithSession returns the access token and its linked user session.
+	// The returned session is nil if the token is not linked to a session or the session no longer exists.
+	GetAccessTokenWithSession(ctx context.Context, id string) (*ttnpb.OAuthAccessToken, *ttnpb.UserSession, error)
 	DeleteAccessToken(ctx context.Context, id string) error
 }
 

--- a/pkg/oauth/config.go
+++ b/pkg/oauth/config.go
@@ -15,6 +15,8 @@
 package oauth
 
 import (
+	"time"
+
 	"go.thethings.network/lorawan-stack/v3/pkg/webui"
 )
 
@@ -39,9 +41,17 @@ type FrontendConfig struct {
 	ConsoleURL             string `json:"console_url" name:"console-url" description:"The URL that points to the root of the Console"`
 }
 
+// LoginConfig holds user login settings shared between the OAuth and Account
+// servers. Values here are populated by the Identity Server from its own
+// config and are not part of the user-facing OAuth config surface.
+type LoginConfig struct {
+	SessionTTL time.Duration `name:"-"`
+}
+
 // Config is the configuration for the OAuth server.
 type Config struct {
-	Mount       string   `name:"mount" description:"Path on the server where the Account application and OAuth services will be served"`
-	UI          UIConfig `name:"ui"`
-	CSRFAuthKey []byte   `name:"-"`
+	Mount       string      `name:"mount" description:"Path on the server where the Account application and OAuth services will be served"`
+	UI          UIConfig    `name:"ui"`
+	CSRFAuthKey []byte      `name:"-"`
+	Login       LoginConfig `name:"-"`
 }

--- a/pkg/oauth/config.go
+++ b/pkg/oauth/config.go
@@ -50,7 +50,7 @@ type LoginConfig struct {
 
 // Config is the configuration for the OAuth server.
 type Config struct {
-	Mount       string      `name:"mount" description:"Path on the server where the Account application and OAuth services will be served"`
+	Mount       string      `name:"mount" description:"Path on the server where the Account application and OAuth services will be served"` //nolint:lll
 	UI          UIConfig    `name:"ui"`
 	CSRFAuthKey []byte      `name:"-"`
 	Login       LoginConfig `name:"-"`

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -66,10 +66,13 @@ func (s *sessionStore) Transact(ctx context.Context, f func(ctx context.Context,
 // NewServer returns a new OAuth server on top of the given store.
 func NewServer(c *component.Component, store oauth_store.TransactionalInterface, config Config, cspFunc func(config *Config, nonce string) string) (Server, error) {
 	s := &server{
-		c:             c,
-		config:        config,
-		store:         store,
-		session:       session.Session{Store: &sessionStore{store}},
+		c:      c,
+		config: config,
+		store:  store,
+		session: session.Session{
+			Store:        &sessionStore{store},
+			CookieMaxAge: config.Login.SessionTTL,
+		},
 		generateCSP:   cspFunc,
 		schemaDecoder: schema.NewDecoder(),
 	}

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -753,6 +753,7 @@ func TestTokenExchange(t *testing.T) {
 			Name: "Exchange Refresh Token",
 			StoreSetup: func(s *mockStore) {
 				s.res.client = mockClient
+				s.res.session = mockSession
 				s.res.accessToken = &ttnpb.OAuthAccessToken{
 					UserIds:       mockUser.GetIds(),
 					ClientIds:     mockClient.GetIds(),
@@ -786,6 +787,43 @@ func TestTokenExchange(t *testing.T) {
 				a.So(s.req.token.RefreshToken, should.NotBeEmpty)
 				a.So(s.req.token.UserSessionId, should.Equal, mockSession.SessionId)
 				a.So(s.req.previousID, should.Equal, "IBTFXELDVVT64Y26IZZFFNSL7GWZY2Y3ALQQI3A")
+			},
+		},
+		{
+			Name: "Exchange Refresh Token with Expired Session",
+			StoreSetup: func(s *mockStore) {
+				s.res.client = mockClient
+				s.res.session = &ttnpb.UserSession{
+					UserIds:   mockUser.GetIds(),
+					SessionId: mockSession.SessionId,
+					CreatedAt: timestamppb.New(now.Add(-2 * time.Hour)),
+					ExpiresAt: timestamppb.New(now.Add(-time.Hour)),
+				}
+				s.res.accessToken = &ttnpb.OAuthAccessToken{
+					UserIds:       mockUser.GetIds(),
+					ClientIds:     mockClient.GetIds(),
+					UserSessionId: mockSession.SessionId,
+					Id:            "SFUBFRKYTGULGPAXXM4SHIBYMKCPTIMQBM63ZGQ",
+					RefreshToken:  "PBKDF2$sha256$20000$IGAiKs46xX_M64E5$4xpyqnQT8SOa_Vf4xhEPk6WOZnhmAjG2mqGQiYBhm2s",
+					Rights:        mockClient.Rights,
+					CreatedAt:     timestamppb.New(now),
+					ExpiresAt:     timestamppb.New(anHourFromNow),
+				}
+			},
+			Method: "POST",
+			Path:   "/oauth/token",
+			Body: map[string]string{
+				"grant_type":    "refresh_token",
+				"refresh_token": "OJSWM.IBTFXELDVVT64Y26IZZFFNSL7GWZY2Y3ALQQI3A.GCPIASDUP7UZJ6YL5OP2ESZB7CKRFV4JJQYTMDOSDIOE7O75IAMQ",
+				"client_id":     "client",
+				"client_secret": "secret",
+			},
+			ExpectedCode: http.StatusUnauthorized,
+			StoreCheck: func(t *testing.T, s *mockStore) {
+				a := assertions.New(t)
+				a.So(s.calls, should.Contain, "GetAccessToken")
+				a.So(s.calls, should.Contain, "GetSession")
+				a.So(s.calls, should.NotContain, "CreateAccessToken")
 			},
 		},
 	} {

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -813,13 +813,15 @@ func TestTokenExchange(t *testing.T) {
 			Method: "POST",
 			Path:   "/oauth/token",
 			Body: map[string]string{
-				"grant_type":    "refresh_token",
-				"refresh_token": "OJSWM.IBTFXELDVVT64Y26IZZFFNSL7GWZY2Y3ALQQI3A.GCPIASDUP7UZJ6YL5OP2ESZB7CKRFV4JJQYTMDOSDIOE7O75IAMQ",
+				"grant_type": "refresh_token",
+				"refresh_token": "OJSWM.IBTFXELDVVT64Y26IZZFFNSL7GWZY2Y3ALQQI3A" +
+					".GCPIASDUP7UZJ6YL5OP2ESZB7CKRFV4JJQYTMDOSDIOE7O75IAMQ",
 				"client_id":     "client",
 				"client_secret": "secret",
 			},
 			ExpectedCode: http.StatusUnauthorized,
 			StoreCheck: func(t *testing.T, s *mockStore) {
+				t.Helper()
 				a := assertions.New(t)
 				a.So(s.calls, should.Contain, "GetAccessToken")
 				a.So(s.calls, should.Contain, "GetSession")

--- a/pkg/oauth/storage.go
+++ b/pkg/oauth/storage.go
@@ -179,6 +179,8 @@ var errNoRefreshToken = errors.DefineInvalidArgument(
 
 var errInvalidToken = errors.DefineInvalidArgument("token", "invalid token")
 
+var errSessionExpired = errors.DefineUnauthenticated("session_expired", "session expired")
+
 func (s *storage) SaveAccess(data *osin.AccessData) error {
 	var accessHash, refreshHash string
 	tokenType, accessID, accessKey, err := auth.SplitToken(data.AccessToken)
@@ -312,6 +314,24 @@ func (s *storage) LoadRefresh(token string) (*osin.AccessData, error) {
 	valid, err := auth.Validate(data.RefreshToken, tokenKey)
 	if !valid || err != nil {
 		return nil, errInvalidToken.New()
+	}
+	if userSessionIDs := data.UserData.(userData).UserSessionIdentifiers; userSessionIDs.GetSessionId() != "" {
+		err = s.store.Transact(s.ctx, func(ctx context.Context, st oauth_store.Interface) error {
+			session, err := st.GetSession(ctx, userSessionIDs.GetUserIds(), userSessionIDs.GetSessionId())
+			if err != nil {
+				if errors.IsNotFound(err) {
+					return errSessionExpired.WithCause(err)
+				}
+				return err
+			}
+			if expiresAt := ttnpb.StdTime(session.ExpiresAt); expiresAt != nil && expiresAt.Before(time.Now()) {
+				return errSessionExpired.New()
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 	return data, nil
 }

--- a/pkg/webui/locales/ja.json
+++ b/pkg/webui/locales/ja.json
@@ -2871,6 +2871,7 @@
   "error:pkg/oauth:no_access_token": "提供されたトークンはアクセストークンではありません",
   "error:pkg/oauth:no_refresh_token": "提供されたトークンは更新トークンではありません",
   "error:pkg/oauth:parse": "リクエストボディの解析",
+  "error:pkg/oauth:session_expired": "",
   "error:pkg/oauth:token": "無効なトークン",
   "error:pkg/oauth:token_mismatch": "更新トークンID `{refresh_token_id}` はアクセストークンID `{access_token_id}` と一致しません",
   "error:pkg/oauth:unauthorized_client": "クライアントがこの手段でトークンを要求することは認証されていません",


### PR DESCRIPTION
#### Summary

- Adds configurable user session TTL on the Identity Server via `is.user-login.session-ttl`. Default `0` preserves the current "never expire" behavior.

When set to a non-zero duration:
- sessions created at login persist with `ExpiresAt = now + TTL`
- the auth cookie is issued with a matching `Max-Age`
- **OAuth access tokens (and refresh requests) linked to a session are rejected once the session has expired** — closing the Console API path that would otherwise stay usable for up to the 1 h access-token TTL.

#### Testing

##### Steps

1. Start the stack with `TTN_LW_IS_USER_LOGIN_SESSION_TTL=1h` (or `is.user-login.session-ttl: 1h` in the config).
2. Log in via the Console or `/oauth/api/auth/login`. Inspect the `_session` cookie — `Max-Age` should be 3600.
3. Query the DB: `SELECT expires_at FROM user_sessions ORDER BY created_at DESC LIMIT 1;` — should be ≈ `now() + 1h`.
4. Advance the clock past expiry (or wait / shorten TTL to a few seconds) and retry a request using the same cookie — expect `session_expired`.
5. Restart with TTL unset / `0` and confirm new sessions persist `expires_at = NULL` and the cookie has no `Max-Age` (browser-session cookie). This matches pre-PR behavior.

##### Regressions

- Login flows (password, token-login) for Console and OAuth: unchanged when TTL=0 (default).
- OAuth authorize/logout paths: continue to read the same session cookie; both servers now produce cookies with identical `Max-Age` to avoid drift.
- Existing long-lived sessions created before rollout remain valid indefinitely.

#### Notes for Reviewers

None.

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated. (Follow-up in `lorawan-stack-docs`.)
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [x] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.