### PR TITLE
Add missing MAC settings profile ID path fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Applying the MAC settings profile values to the device's MAC state during the join procedure (OTAA) or factory reset (ABP).
+
 ### Security
 
 ## [3.36.1] - 2026-06-24

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -1533,6 +1533,7 @@ func (ns *NetworkServer) ResetFactoryDefaults(ctx context.Context, req *ttnpb.Re
 		"lorawan_phy_version",
 		"lorawan_version",
 		"mac_settings",
+		"mac_settings_profile_ids",
 		"multicast",
 		"session.dev_addr",
 		"session.keys",

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -1019,9 +1019,23 @@ func TestDeviceRegistryResetFactoryDefaults(t *testing.T) {
 	macSettings := test.Must(DefaultConfig.DefaultMACSettings.Parse())
 	activateOpt := EndDeviceOptions.Activate(macSettings, true, activeSessionOpts)
 
+	macSettingsProfileID := &ttnpb.MACSettingsProfileIdentifiers{
+		ApplicationIds: &ttnpb.ApplicationIdentifiers{
+			ApplicationId: "test-app-id",
+		},
+		ProfileId: "test-mac-settings-profile-id",
+	}
+	macSettingsProfile := &ttnpb.MACSettingsProfile{
+		Ids: macSettingsProfileID,
+		MacSettings: &ttnpb.MACSettings{
+			Rx1Delay: &ttnpb.RxDelayValue{Value: ttnpb.RxDelay_RX_DELAY_2},
+		},
+	}
+
 	// TODO: Refactor into same structure as Set
 	for _, tc := range []struct {
 		CreateDevice *SetDeviceRequest
+		Profile      *ttnpb.MACSettingsProfile
 	}{
 		{},
 
@@ -1058,6 +1072,12 @@ func TestDeviceRegistryResetFactoryDefaults(t *testing.T) {
 				EndDeviceOptions.WithLorawanVersion(ttnpb.MACVersion_MAC_V1_0_3),
 				EndDeviceOptions.WithLorawanPhyVersion(ttnpb.PHYVersion_RP001_V1_0_3_REV_A),
 			}),
+		},
+		{
+			CreateDevice: MakeABPSetDeviceRequest(macSettings, activeSessionOpts, nil, []test.EndDeviceOption{
+				EndDeviceOptions.WithMacSettingsProfileIds(macSettingsProfileID),
+			}),
+			Profile: macSettingsProfile,
 		},
 	} {
 		for _, conf := range []struct {
@@ -1134,22 +1154,24 @@ func TestDeviceRegistryResetFactoryDefaults(t *testing.T) {
 					if tc.CreateDevice == nil {
 						return "no device"
 					}
-					return MakeTestCaseName(
-						fmt.Sprintf("paths:[%s]", strings.Join(conf.Paths, ",")),
-						func() string {
-							if tc.CreateDevice.EndDevice.SupportsJoin {
-								return "OTAA"
-							}
-							if tc.CreateDevice.EndDevice.Session == nil {
-								return MakeTestCaseName("ABP", "no session")
-							}
-							return fmt.Sprintf(MakeTestCaseName("ABP", "dev_addr:%s", "queue_len:%d", "session_keys:%v"),
-								types.MustDevAddr(tc.CreateDevice.Session.DevAddr).OrZero(),
-								len(tc.CreateDevice.EndDevice.Session.QueuedApplicationDownlinks),
-								tc.CreateDevice.Session.Keys,
-							)
-						}(),
-					)
+					nameParts := []string{fmt.Sprintf("paths:[%s]", strings.Join(conf.Paths, ","))}
+					switch {
+					case tc.CreateDevice.SupportsJoin:
+						nameParts = append(nameParts, "OTAA")
+					case tc.CreateDevice.Session == nil:
+						nameParts = append(nameParts, MakeTestCaseName("ABP", "no session"))
+					default:
+						nameParts = append(nameParts, fmt.Sprintf(
+							MakeTestCaseName("ABP", "dev_addr:%s", "queue_len:%d", "session_keys:%v"),
+							types.MustDevAddr(tc.CreateDevice.Session.DevAddr).OrZero(),
+							len(tc.CreateDevice.Session.QueuedApplicationDownlinks),
+							tc.CreateDevice.Session.Keys,
+						))
+						if tc.Profile != nil {
+							nameParts = append(nameParts, "with_profile")
+						}
+					}
+					return MakeTestCaseName(nameParts...)
 				}(),
 				Parallel: true,
 				Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
@@ -1182,6 +1204,16 @@ func TestDeviceRegistryResetFactoryDefaults(t *testing.T) {
 
 					clock := test.NewMockClock(time.Now().UTC())
 					defer SetMockClock(clock)()
+
+					if tc.Profile != nil {
+						_, err := env.MACSettingsProfileRegistry.Set(ctx, tc.Profile.Ids, []string{"ids", "mac_settings"},
+							func(context.Context, *ttnpb.MACSettingsProfile) (*ttnpb.MACSettingsProfile, []string, error) {
+								return tc.Profile, []string{"ids", "mac_settings"}, nil
+							})
+						if !a.So(err, should.BeNil) {
+							return
+						}
+					}
 
 					req := &ttnpb.ResetAndGetEndDeviceRequest{
 						EndDeviceIds: test.MakeEndDeviceIdentifiers(),
@@ -1244,7 +1276,7 @@ func TestDeviceRegistryResetFactoryDefaults(t *testing.T) {
 						}
 						var newErr error
 						defaultMACSettings := test.Must(DefaultConfig.DefaultMACSettings.Parse())
-						macState, newErr = mac.NewState(created, fps, defaultMACSettings, nil)
+						macState, newErr = mac.NewState(created, fps, defaultMACSettings, tc.Profile.GetMacSettings())
 						if newErr != nil {
 							a.So(err, should.NotBeNil)
 							a.So(err, should.HaveSameErrorDefinitionAs, newErr)

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -840,11 +840,13 @@ func appendRecentUplink(
 }
 
 var handleDataUplinkGetPaths = [...]string{
+	"battery_percentage",
 	"frequency_plan_id",
 	"last_dev_status_received_at",
 	"lorawan_phy_version",
 	"lorawan_version",
 	"mac_settings",
+	"mac_settings_profile_ids",
 	"mac_state",
 	"multicast",
 	"pending_mac_state",
@@ -853,7 +855,6 @@ var handleDataUplinkGetPaths = [...]string{
 	"supports_class_b",
 	"supports_class_c",
 	"supports_join",
-	"battery_percentage",
 }
 
 // mergeMetadata merges the metadata collected for up.
@@ -1264,6 +1265,7 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 			"lorawan_phy_version",
 			"lorawan_version",
 			"mac_settings",
+			"mac_settings_profile_ids",
 			"session.dev_addr",
 			"supports_class_b",
 			"supports_class_c",

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -157,6 +157,8 @@ type OTAAFlowTestConfig struct {
 	CreateDevice *ttnpb.SetEndDeviceRequest
 	Func         func(context.Context, TestEnvironment, *ttnpb.EndDevice)
 
+	Profile *ttnpb.MACSettingsProfile
+
 	UplinkMACCommanders       []MACCommander
 	UplinkEventBuilders       []events.Builder
 	DownlinkHeadMACCommanders []MACCommander
@@ -170,6 +172,18 @@ func makeOTAAFlowTest(conf OTAAFlowTestConfig) func(context.Context, TestEnviron
 		t, a := test.MustNewTFromContext(ctx)
 
 		start := time.Now()
+
+		if conf.Profile != nil {
+			profilePaths := []string{"ids", "mac_settings"} // nolint: goconst
+			_, err := env.MACSettingsProfileRegistry.Set(ctx, conf.Profile.Ids, profilePaths,
+				func(context.Context, *ttnpb.MACSettingsProfile) (*ttnpb.MACSettingsProfile, []string, error) {
+					return conf.Profile, profilePaths, nil
+				})
+			if !a.So(err, should.BeNil) {
+				t.Error("Failed to register MAC settings profile")
+				return
+			}
+		}
 
 		dev, err, ok := env.AssertSetDevice(ctx, true, conf.CreateDevice,
 			ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
@@ -201,6 +215,8 @@ func makeOTAAFlowTest(conf OTAAFlowTestConfig) func(context.Context, TestEnviron
 				"GsNs-join-1",
 				"GsNs-join-2",
 			},
+
+			Profile: conf.Profile,
 
 			ClusterResponse: &NsJsHandleJoinResponse{
 				Response: &ttnpb.JoinResponse{
@@ -432,11 +448,51 @@ func makeClassCOTAAFlowTest(macVersion ttnpb.MACVersion, phyVersion ttnpb.PHYVer
 	})
 }
 
+func makeOTAAFlowTestWithMACSettingsProfile( // nolint: lll
+	macVersion ttnpb.MACVersion, phyVersion ttnpb.PHYVersion, fpID string,
+) func(context.Context, TestEnvironment) {
+	const testProfileID = "test-mac-settings-profile-id"
+	profileID := &ttnpb.MACSettingsProfileIdentifiers{
+		ApplicationIds: test.DefaultApplicationIdentifiers,
+		ProfileId:      testProfileID,
+	}
+	profile := &ttnpb.MACSettingsProfile{
+		Ids: profileID,
+		MacSettings: &ttnpb.MACSettings{
+			Rx1Delay: &ttnpb.RxDelayValue{Value: ttnpb.RxDelay_RX_DELAY_2},
+		},
+	}
+	return makeOTAAFlowTest(OTAAFlowTestConfig{
+		Profile: profile,
+		CreateDevice: &ttnpb.SetEndDeviceRequest{
+			EndDevice: MakeOTAAEndDevice(
+				EndDeviceOptions.WithFrequencyPlanId(fpID),
+				EndDeviceOptions.WithLorawanVersion(macVersion),
+				EndDeviceOptions.WithLorawanPhyVersion(phyVersion),
+				EndDeviceOptions.WithMacSettingsProfileIds(profileID),
+			),
+			FieldMask: ttnpb.FieldMask(
+				"frequency_plan_id",
+				"lorawan_phy_version",
+				"lorawan_version",
+				"mac_settings_profile_ids",
+				"supports_join",
+			),
+		},
+		DownlinkTailMACCommanders: []MACCommander{ttnpb.MACCommandIdentifier_CID_DEV_STATUS},
+		DownlinkTailEventBuilders: []events.Builder{mac.EvtEnqueueDevStatusRequest},
+		Func:                      func(context.Context, TestEnvironment, *ttnpb.EndDevice) {},
+	})
+}
+
 func TestFlow(t *testing.T) {
 	ForEachFrequencyPlanLoRaWANVersionPair(t, func(makeName func(...string) string, fpID string, _ *frequencyplans.FrequencyPlan, phy *band.Band, macVersion ttnpb.MACVersion, phyVersion ttnpb.PHYVersion) {
 		for flowName, handleFlowTest := range map[string]func(context.Context, TestEnvironment){
 			MakeTestCaseName("Class A", "OTAA"): makeClassAOTAAFlowTest(macVersion, phyVersion, fpID),
 			MakeTestCaseName("Class C", "OTAA"): makeClassCOTAAFlowTest(macVersion, phyVersion, fpID),
+			MakeTestCaseName("Class A", "OTAA", "with profile"): makeOTAAFlowTestWithMACSettingsProfile( // nolint: lll
+				macVersion, phyVersion, fpID,
+			),
 		} {
 			test.RunSubtest(t, test.SubtestConfig{
 				Name:     makeName(flowName),

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -1560,6 +1560,8 @@ type JoinAssertionConfig struct {
 	RxMetadatas    [][]*ttnpb.RxMetadata
 	CorrelationIDs []string
 
+	Profile *ttnpb.MACSettingsProfile
+
 	ClusterResponse *NsJsHandleJoinResponse
 	InteropResponse *InteropClientHandleJoinRequestResponse
 }
@@ -1600,7 +1602,7 @@ func (env TestEnvironment) AssertJoin(ctx context.Context, conf JoinAssertionCon
 			t, a := test.MustNewTFromContext(ctx)
 			t.Helper()
 
-			var profileMACSettings *ttnpb.MACSettings
+			profileMACSettings := conf.Profile.GetMacSettings()
 			defaultMACSettings := test.Must(env.Config.DefaultMACSettings.Parse())
 
 			defaultLoRaWANVersion := mac.DeviceDefaultLoRaWANVersion(conf.Device)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

References: https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1467
References: https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1477

This fixes a bug when the MAC settings profile config values are not applied to the new MAC state during the join procedure (OTAA) or during the factory reset (ABP).

#### Changes

<!-- What are the changes made in this pull request? -->

- Adds missing MAC settings profile ID path fields

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

1. Create a MAC settings profile with a desired max EIRP value 30
2. Assign this profile to an OTAA device
3. Re-join the device
4. Check that the device's MAC state desired parameters has the max eirp value 30
5. Assign the profile to an ABP device
6. Do a factory reset on the device
7. Check that the device's MAC state desired parameters has the max eirp value 30

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

Create a MAC settings profile with a desired max EIRP value 30
```
curl --request POST \
  --url http://localhost:1885/api/v3/ns/applications/myapp/mac_settings_profiles \
  --header 'authorization: Bearer <token>' \
  --header 'content-type: application/json' \
  --data '{
  "mac_settings_profile": {
    "ids": {
      "application_ids": {
        "application_id": "myapp"
      },
      "profile_id": "maxeirp"
    },
    "mac_settings": {
      "desired_max_eirp": "DEVICE_EIRP_30"
    }
  }
}'
```

Check that the device's MAC state desired parameters has the max eirp value 30
```
curl --request GET \
  --url 'http://localhost:1885/api/v3/ns/applications/myapp/devices/<device id>?field_mask=version_ids,frequency_plan_id,mac_settings,supports_class_b,supports_class_c,supports_join,lorawan_version,lorawan_phy_version,multicast,session,pending_session,mac_settings_profile_ids,mac_state' \
  --header 'authorization: Bearer <token>'
```

Response:
```
.
.
 "mac_state": {
    "current_parameters": {
      "max_eirp": 16,
      "adr_nb_trans": 1,
      "rx1_delay": 1,
      "rx2_frequency": "869525000",
      "ping_slot_frequency": "869525000",
      "beacon_frequency": "869525000",
.
.
   "desired_parameters": {
      "max_eirp": 30,
      "adr_nb_trans": 1,
      "rx1_delay": 5,
      "rx2_data_rate_index": 3,
      "rx2_frequency": "869525000",
      "ping_slot_frequency": "869525000",
      "beacon_frequency": "869525000",
.
.
```

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

...

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
