### PR TITLE
dev: Adopt mjml 5 for email template generation

### DIFF
--- a/pkg/email/templates/DEVELOPMENT.md
+++ b/pkg/email/templates/DEVELOPMENT.md
@@ -16,6 +16,8 @@ Each of these email templates gets rendered together with the base template that
 
 We use [MJML](https://mjml.io/) to generate the HTML base template `base.html.tmpl` from `base.mjml`. Do not edit `base.html.tmpl` directly. If you want to edit the HTML base template, edit the `.mjml` files and run `go generate ./pkg/email/templates` to update `base.html.tmpl`.
 
+`base.mjml` composes the repo-local partials `_attributes.mjml`, `_header.mjml` and `_footer.mjml` via `mj-include`. MJML v5+ disables `mj-include` by default, so `generate.sh` passes `--config.allowIncludes true`. This is safe here because the included files are trusted and committed to this repository.
+
 The HTML base template contains three blocks: **title**, **preview** and **body**. The **title** is typically not visible in emails, but would be visible if we start supporting "view this email online" functionality. The **preview** is a short text that many email clients render in the list view, next to the subject.
 
 ## Testing

--- a/pkg/email/templates/base.html.tmpl
+++ b/pkg/email/templates/base.html.tmpl
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   <!--[if mso]>
     <noscript>
@@ -61,7 +60,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   <!--<![endif]-->
   <style type="text/css">
@@ -71,14 +69,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -90,7 +86,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -100,13 +95,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">{{ block "preview" . }}{{ end }}</div>
-  <div aria-label="{{ block "title" . }}{{ end }}" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="{{ block "title" . }}{{ end }}" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/generate.sh
+++ b/pkg/email/templates/generate.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
+# MJML v5+ disables mj-include by default; our base template composes trusted,
+# repo-local partials (_attributes/_header/_footer), so includes are enabled here.
 for template in $(find . -name '*.mjml' -not -name '_*.mjml')
 do
-  yarn run mjml $PWD/$template -o $PWD/${template%.mjml}.html.tmpl
+  yarn run mjml --config.allowIncludes true $PWD/$template -o $PWD/${template%.mjml}.html.tmpl
+  # mjml v5 omits the trailing newline; append one to keep a POSIX-clean file.
+  printf '\n' >> $PWD/${template%.mjml}.html.tmpl
 done

--- a/pkg/email/templates/testdata/api_key_changed.body.golden.html
+++ b/pkg/email/templates/testdata/api_key_changed.body.golden.html
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   
   
@@ -48,7 +47,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   
   <style type="text/css">
@@ -58,14 +56,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -77,7 +73,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -87,13 +82,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">An API key of your application "foo-app" has been changed.</div>
-  <div aria-label="API Key Changed" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="API Key Changed" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/api_key_created.body.with_sender_ids.golden.html
+++ b/pkg/email/templates/testdata/api_key_created.body.with_sender_ids.golden.html
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   
   
@@ -48,7 +47,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   
   <style type="text/css">
@@ -58,14 +56,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -77,7 +73,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -87,13 +82,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">A new API key has just been created for your application "foo-app".</div>
-  <div aria-label="API Key Created" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="API Key Created" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/client_requested.body.golden.html
+++ b/pkg/email/templates/testdata/client_requested.body.golden.html
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   
   
@@ -48,7 +47,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   
   <style type="text/css">
@@ -58,14 +56,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -77,7 +73,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -87,13 +82,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Your review is required for a newly registered OAuth client.</div>
-  <div aria-label="Client Requested" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="Client Requested" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/client_requested.body.with_api_key_id.golden.html
+++ b/pkg/email/templates/testdata/client_requested.body.with_api_key_id.golden.html
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   
   
@@ -48,7 +47,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   
   <style type="text/css">
@@ -58,14 +56,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -77,7 +73,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -87,13 +82,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Your review is required for a newly registered OAuth client.</div>
-  <div aria-label="Client Requested" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="Client Requested" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/client_requested.body.with_api_key_name.golden.html
+++ b/pkg/email/templates/testdata/client_requested.body.with_api_key_name.golden.html
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   
   
@@ -48,7 +47,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   
   <style type="text/css">
@@ -58,14 +56,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -77,7 +73,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -87,13 +82,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Your review is required for a newly registered OAuth client.</div>
-  <div aria-label="Client Requested" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="Client Requested" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/collaborator_changed.body.golden.html
+++ b/pkg/email/templates/testdata/collaborator_changed.body.golden.html
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   
   
@@ -48,7 +47,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   
   <style type="text/css">
@@ -58,14 +56,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -77,7 +73,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -87,13 +82,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">A collaborator of your application "foo-app" has been added or updated.</div>
-  <div aria-label="Collaborator Changed" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="Collaborator Changed" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/entity_state_changed.body.golden.html
+++ b/pkg/email/templates/testdata/entity_state_changed.body.golden.html
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   
   
@@ -48,7 +47,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   
   <style type="text/css">
@@ -58,14 +56,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -77,7 +73,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -87,13 +82,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">The state of your client "foo-cli" has been changed.</div>
-  <div aria-label="Entity State Changed" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="Entity State Changed" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/invitation.body.golden.html
+++ b/pkg/email/templates/testdata/invitation.body.golden.html
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   
   
@@ -48,7 +47,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   
   <style type="text/css">
@@ -58,14 +56,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -77,7 +73,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -87,13 +82,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">You have been invited to join The Things Network.</div>
-  <div aria-label="Invitation" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="Invitation" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/login_token.body.golden.html
+++ b/pkg/email/templates/testdata/login_token.body.golden.html
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   
   
@@ -48,7 +47,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   
   <style type="text/css">
@@ -58,14 +56,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -77,7 +73,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -87,13 +82,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">A login token was requested for your user "john-doe".</div>
-  <div aria-label="Login Token" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="Login Token" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/password_changed.body.golden.html
+++ b/pkg/email/templates/testdata/password_changed.body.golden.html
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   
   
@@ -48,7 +47,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   
   <style type="text/css">
@@ -58,14 +56,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -77,7 +73,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -87,13 +82,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">The password of your user "foo-usr" has just been changed.</div>
-  <div aria-label="Password Changed" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="Password Changed" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/temporary_password.body.golden.html
+++ b/pkg/email/templates/testdata/temporary_password.body.golden.html
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   
   
@@ -48,7 +47,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   
   <style type="text/css">
@@ -58,14 +56,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -77,7 +73,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -87,13 +82,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">A temporary password was requested for your user "john-doe".</div>
-  <div aria-label="Temporary Password" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="Temporary Password" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/user_requested.body.golden.html
+++ b/pkg/email/templates/testdata/user_requested.body.golden.html
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   
   
@@ -48,7 +47,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   
   <style type="text/css">
@@ -58,14 +56,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -77,7 +73,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -87,13 +82,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Your review is required for a newly registered user.</div>
-  <div aria-label="User Requested" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="User Requested" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>

--- a/pkg/email/templates/testdata/validate.body.golden.html
+++ b/pkg/email/templates/testdata/validate.body.golden.html
@@ -40,7 +40,6 @@
       display: block;
       margin: 13px 0;
     }
-
   </style>
   
   
@@ -48,7 +47,6 @@
   <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
   <style type="text/css">
     @import url(https://fonts.googleapis.com/css?family=Lato);
-
   </style>
   
   <style type="text/css">
@@ -58,14 +56,12 @@
         max-width: 100%;
       }
     }
-
   </style>
   <style media="screen and (min-width:480px)">
     .moz-text-html .mj-column-per-100 {
       width: 100% !important;
       max-width: 100%;
     }
-
   </style>
   <style type="text/css">
     @media only screen and (max-width:479px) {
@@ -77,7 +73,6 @@
         width: auto !important;
       }
     }
-
   </style>
   <style type="text/css">
     code {
@@ -87,13 +82,12 @@
       background-color: #E7E7E7;
       border-radius: 6px;
     }
-
   </style>
 </head>
 
 <body style="word-spacing:normal;background-color:#E7E7E7;">
   <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Please confirm your email address for The Things Network.</div>
-  <div aria-label="Validate" aria-roledescription="email" style="background-color:#E7E7E7;" role="article" lang="und" dir="auto">
+  <div aria-label="Validate" aria-roledescription="email" role="article" lang="und" dir="auto" style="word-spacing:normal;background-color:#E7E7E7;">
     <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
       <tbody>
         <tr>


### PR DESCRIPTION
> **Alternative to #7978.** That PR reverts `mjml` to 4.18.0 to unblock CI immediately; this PR instead adopts MJML v5. Pick one — merging this makes the revert unnecessary.

## Summary

MJML v5 [disabled `mj-include` by default](https://documentation.mjml.io/#mj-include) for security, which is what broke the generated-template CI check: `generate.sh` didn't pass `--config.allowIncludes true`, so the `_attributes`/`_header`/`_footer` partials were dropped and `base.html.tmpl` regenerated with MJML's default Ubuntu config.

This PR keeps the v5 bump and makes generation v5-compatible instead of reverting it.

## Changes

- `generate.sh`: pass `--config.allowIncludes true`; append the trailing newline v5 no longer emits
- `base.html.tmpl`: regenerated under v5 — functionally identical to v4 (6 blank lines removed inside `<style>` blocks + one attribute-order change on the article `<div>`; header/footer/body/fonts/styles all unchanged)
- `testdata/*.body.golden.html` (13 files): regenerated via `go test -write-golden` to reflect the base-template change
- `DEVELOPMENT.md`: document why includes are enabled
- No `package.json`/`yarn.lock` changes — v3.36 already pins `mjml@^5.4.0`

## Test plan

- [x] `go generate ./pkg/email/templates` reproduces `base.html.tmpl` with no diff
- [x] `go test ./pkg/email/templates` passes (golden-file comparison)
- [ ] CI generated-file check passes

## Notes for reviewers

The rendered HTML is equivalent to v4 — no email-client-visible change is expected. `allowIncludes` is safe here because the included `.mjml` files are trusted and committed to this repo.