### PR TITLE
Send UDP Packet Forwarder ACKs after connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- In the Semtech UDP Packet Forwarder protocol, `PUSH_ACK` and `PULL_ACK` are only sent after the gateway has connected to the Gateway Server and the gateway's `PUSH_DATA` or `PULL_DATA` respectively has been accepted.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -263,13 +263,6 @@ func (s *srv) handlePacket(ctx context.Context, packet encoding.Packet) {
 	ctx = log.NewContextWithField(ctx, "gateway_eui", eui)
 	logger := log.FromContext(ctx)
 
-	switch packet.PacketType {
-	case encoding.PullData, encoding.PushData:
-		if err := s.writeAckFor(packet); err != nil {
-			logger.WithError(err).Warn("Failed to write acknowledgment")
-		}
-	}
-
 	cs, err := s.connect(ctx, eui, packet.GatewayAddr)
 	if err != nil {
 		logger.WithError(err).Warn("Failed to connect")
@@ -278,6 +271,13 @@ func (s *srv) handlePacket(ctx context.Context, packet encoding.Packet) {
 
 	if err := s.handleUp(cs.io.Context(), cs, packet); err != nil {
 		logger.WithError(err).Warn("Failed to handle upstream packet")
+	}
+
+	switch packet.PacketType {
+	case encoding.PullData, encoding.PushData:
+		if err := s.writeAckFor(packet); err != nil {
+			logger.WithError(err).Warn("Failed to write acknowledgment")
+		}
 	}
 }
 

--- a/pkg/gatewayserver/io/udp/udp_test.go
+++ b/pkg/gatewayserver/io/udp/udp_test.go
@@ -34,7 +34,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/iotest"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/mock"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/udp"
-	. "go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/udp"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/scheduling"
 	mockis "go.thethings.network/lorawan-stack/v3/pkg/identityserver/mock"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -47,7 +46,7 @@ import (
 func TestConnection(t *testing.T) {
 	var (
 		timeout    = (1 << 4) * test.Delay
-		testConfig = Config{
+		testConfig = udp.Config{
 			PacketHandlers:      2,
 			PacketBuffer:        10,
 			DownlinkPathExpires: 8 * timeout,
@@ -81,7 +80,7 @@ func TestConnection(t *testing.T) {
 		t.FailNow()
 	}
 
-	go Serve(ctx, gs, lis, testConfig)
+	go udp.Serve(ctx, gs, lis, testConfig)
 
 	connections := &sync.Map{}
 	eui := types.EUI64{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}
@@ -212,7 +211,7 @@ func TestScheduleLateCancel(t *testing.T) {
 	var (
 		registeredGatewayID = ttnpb.GatewayIdentifiers{GatewayId: "test-gateway"}
 		timeout             = (1 << 4) * test.Delay
-		testConfig          = Config{
+		testConfig          = udp.Config{
 			PacketHandlers:      2,
 			PacketBuffer:        10,
 			DownlinkPathExpires: 8 * timeout,
@@ -246,7 +245,7 @@ func TestScheduleLateCancel(t *testing.T) {
 		t.FailNow()
 	}
 
-	go Serve(ctx, gs, lis, testConfig) // nolint:errcheck
+	go udp.Serve(ctx, gs, lis, testConfig) // nolint:errcheck
 
 	connections := &sync.Map{}
 	eui := types.EUI64{0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05, 0x05}
@@ -368,7 +367,7 @@ func TestScheduleLateDownlinkPathExpired(t *testing.T) {
 	var (
 		registeredGatewayID = ttnpb.GatewayIdentifiers{GatewayId: "test-gateway"}
 		timeout             = (1 << 4) * test.Delay
-		testConfig          = Config{
+		testConfig          = udp.Config{
 			PacketHandlers:      2,
 			PacketBuffer:        10,
 			DownlinkPathExpires: 8 * timeout,
@@ -402,7 +401,7 @@ func TestScheduleLateDownlinkPathExpired(t *testing.T) {
 		t.FailNow()
 	}
 
-	go Serve(ctx, gs, lis, testConfig) // nolint:errcheck
+	go udp.Serve(ctx, gs, lis, testConfig) // nolint:errcheck
 
 	connections := &sync.Map{}
 	eui := types.EUI64{0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06}
@@ -690,7 +689,7 @@ func TestRawData(t *testing.T) {
 	var (
 		registeredGatewayID = ttnpb.GatewayIdentifiers{GatewayId: "test-gateway"}
 		timeout             = (1 << 4) * test.Delay
-		testConfig          = Config{
+		testConfig          = udp.Config{
 			PacketHandlers: 2,
 			PacketBuffer:   10,
 			// DownlinkPathExpires must exceed the ~300*test.Delay late-schedule timer
@@ -726,7 +725,7 @@ func TestRawData(t *testing.T) {
 		t.FailNow()
 	}
 
-	go Serve(ctx, gs, lis, testConfig)
+	go udp.Serve(ctx, gs, lis, testConfig)
 
 	connections := &sync.Map{}
 	eui1 := types.EUI64{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

Send `PUSH_ACK` and `PULL_ACK` after connect and parsing the frames.

#### Changes

<!-- What are the changes made in this pull request? -->

- Move sending the packet acknowledgment after setting up the connection and parsing the frame
- Fix duplicate import in test

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Connect a Semtech UDP Packet Forwarder with a gateway EUI unknown to The Things Stack.

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

No acknowledgments should be received.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

`PUSH_ACK` and `PULL_ACK` no longer indicate that The Things Stack is reachable. The gateway must now be registered and connected.

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Note that `handleUp()` returns an error if the frame is invalid (parse fails), but returns no error if the packet could otherwise not be handled. Those are the correct conditions for sending an acknowledgment to the gateway: the gateway receives an ACK if the gateway is connected (i.e. the EUI is registered) and if the frame is valid.

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
