### PR TITLE
Fix mac settings profiles

### DIFF
--- a/pkg/webui/console/containers/mac-settings-profile-form/index.js
+++ b/pkg/webui/console/containers/mac-settings-profile-form/index.js
@@ -659,7 +659,7 @@ const MACSettingsProfileForm = ({ edit, macSettingsProfile, macSettingsProfileId
 
   const handleEdit = useCallback(
     async (_, { setSubmitting }, cleanedValues) => {
-      const profileDiff = diff(macSettingsProfile, cleanedValues)
+      const profileDiff = diff(parsedInitialValues, cleanedValues)
       try {
         if (!isEmpty(profileDiff)) {
           profileDiff.ids = {
@@ -686,7 +686,7 @@ const MACSettingsProfileForm = ({ edit, macSettingsProfile, macSettingsProfileId
         setError(error)
       }
     },
-    [appId, dispatch, macSettingsProfile, macSettingsProfileId],
+    [appId, dispatch, parsedInitialValues, macSettingsProfileId],
   )
 
   return (

--- a/pkg/webui/console/containers/mac-settings-profile-form/index.js
+++ b/pkg/webui/console/containers/mac-settings-profile-form/index.js
@@ -622,8 +622,10 @@ const MACSettingsProfileForm = ({ edit, macSettingsProfile, macSettingsProfileId
             }
           : Boolean(macSettingsProfile?.mac_settings?.adr?.static)
             ? {
-                ...initialValues.mac_settings.adr,
-                ...macSettingsProfile.mac_settings.adr,
+                static: {
+                  ...initialValues.mac_settings.adr.static,
+                  ...macSettingsProfile.mac_settings.adr.static,
+                },
               }
             : {
                 disabled: {},

--- a/sdk/js/src/service/network-server-mac-settings-profiles.js
+++ b/sdk/js/src/service/network-server-mac-settings-profiles.js
@@ -57,6 +57,13 @@ class NsMACSettingsProfiles {
   }
 
   async update(applicationId, macSettingsProfileId, patch) {
+    const fieldMaskPaths = Marshaler.fieldMaskFromPatch(
+      patch,
+      this._api.UpdateAllowedFieldMaskPaths,
+    )
+    const fieldMaskPathsWithoutAncestors = fieldMaskPaths.filter(
+      path => !fieldMaskPaths.some(other => other !== path && other.startsWith(`${path}.`)),
+    )
     const result = await this._api.Update(
       {
         routeParams: {
@@ -66,6 +73,7 @@ class NsMACSettingsProfiles {
       },
       {
         mac_settings_profile: patch,
+        field_mask: { paths: fieldMaskPathsWithoutAncestors },
       },
     )
     return Marshaler.payloadSingleResponse(result)

--- a/sdk/js/src/service/network-server-mac-settings-profiles.js
+++ b/sdk/js/src/service/network-server-mac-settings-profiles.js
@@ -57,6 +57,8 @@ class NsMACSettingsProfiles {
   }
 
   async update(applicationId, macSettingsProfileId, patch) {
+    const fieldMaskPaths = Marshaler.fieldMaskFromPatch(patch)
+
     const result = await this._api.Update(
       {
         routeParams: {
@@ -65,11 +67,8 @@ class NsMACSettingsProfiles {
         },
       },
       {
-        mac_settings_profile_ids: {
-          application_ids: { application_id: applicationId },
-          profile_id: macSettingsProfileId,
-        },
         mac_settings_profile: patch,
+        field_mask: { paths: fieldMaskPaths },
       },
     )
     return Marshaler.payloadSingleResponse(result)

--- a/sdk/js/src/service/network-server-mac-settings-profiles.js
+++ b/sdk/js/src/service/network-server-mac-settings-profiles.js
@@ -57,8 +57,6 @@ class NsMACSettingsProfiles {
   }
 
   async update(applicationId, macSettingsProfileId, patch) {
-    const fieldMaskPaths = Marshaler.fieldMaskFromPatch(patch)
-
     const result = await this._api.Update(
       {
         routeParams: {
@@ -68,7 +66,6 @@ class NsMACSettingsProfiles {
       },
       {
         mac_settings_profile: patch,
-        field_mask: { paths: fieldMaskPaths },
       },
     )
     return Marshaler.payloadSingleResponse(result)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

References [https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1499](https://github.com/TheThingsIndustries/lorawan-stack-support/issues/1499)

#### Changes

<!-- What are the changes made in this pull request? -->

- Fix diff
- Remove redundant ids
- add field masks

#### Testing

##### Steps

<!--
Explain the detailed steps to test this feature.
Please note that these steps may be used by others to test this feature.
Describe pre-requisites and/or assumptions made about the testing environment.
-->

Repeat the process shown in the support issue.

##### Results

<!--
Please add screenshots, command outputs, and/or relevant screen captures of the tests.
-->

https://github.com/user-attachments/assets/ebf22832-0ff4-4800-944b-e2eeaa2072ba

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
