### PR TITLE
gs: Fix rctx field name in LBS LNS upstream messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Parsing of the `rctx` field in the `upinfo` object of upstream messages received via the LoRa Basics Station LNS protocol. The field name was misspelled as `rtcx`, so the radio context reported by gateways was ignored. The antenna index in the uplink metadata now reflects the reported radio context and is echoed back in class A downlinks, instead of always being 0.
+
 ### Security
 
 ## [3.36.2] - 2026-08-17

--- a/pkg/gatewayserver/io/semtechws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/semtechws/lbslns/upstream.go
@@ -44,7 +44,7 @@ var (
 // UpInfo provides additional metadata on each upstream message.
 type UpInfo struct {
 	RxTime  float64 `json:"rxtime"`
-	RCtx    int64   `json:"rtcx"`
+	RCtx    int64   `json:"rctx"`
 	XTime   int64   `json:"xtime"`
 	GPSTime int64   `json:"gpstime"`
 	RSSI    float32 `json:"rssi"`

--- a/pkg/gatewayserver/io/semtechws/lbslns/upstream_test.go
+++ b/pkg/gatewayserver/io/semtechws/lbslns/upstream_test.go
@@ -61,7 +61,7 @@ func TestMarshalJSON(t *testing.T) {
 					},
 				},
 			},
-			Expected: []byte(`{"msgtype":"jreq","MHdr":0,"JoinEui":"2222:2222:2222:2222","DevEui":"1111:1111:1111:1111","DevNonce":18000,"MIC":12345678,"RefTime":0,"DR":1,"Freq":868300000,"upinfo":{"rxtime":1548059982,"rtcx":0,"xtime":12666373963464220,"gpstime":0,"rssi":89,"snr":9.25}}`), //nolint: lll
+			Expected: []byte(`{"msgtype":"jreq","MHdr":0,"JoinEui":"2222:2222:2222:2222","DevEui":"1111:1111:1111:1111","DevNonce":18000,"MIC":12345678,"RefTime":0,"DR":1,"Freq":868300000,"upinfo":{"rxtime":1548059982,"rctx":0,"xtime":12666373963464220,"gpstime":0,"rssi":89,"snr":9.25}}`), //nolint:lll
 		},
 		{
 			Name: "UplinkDataFrame",
@@ -85,7 +85,7 @@ func TestMarshalJSON(t *testing.T) {
 					},
 				},
 			},
-			Expected: []byte(`{"msgtype":"updf","MHdr":64,"DevAddr":287454020,"FCtrl":48,"Fcnt":25,"FOpts":"FD","FPort":0,"FRMPayload":"Ymxhamthc25kJ3M=","MIC":12345678,"RefTime":0,"DR":1,"Freq":868300000,"upinfo":{"rxtime":1548059982,"rtcx":0,"xtime":12666373963464220,"gpstime":0,"rssi":89,"snr":9.25}}`), //nolint: lll
+			Expected: []byte(`{"msgtype":"updf","MHdr":64,"DevAddr":287454020,"FCtrl":48,"Fcnt":25,"FOpts":"FD","FPort":0,"FRMPayload":"Ymxhamthc25kJ3M=","MIC":12345678,"RefTime":0,"DR":1,"Freq":868300000,"upinfo":{"rxtime":1548059982,"rctx":0,"xtime":12666373963464220,"gpstime":0,"rssi":89,"snr":9.25}}`), //nolint:lll
 		},
 		{
 			Name: "TxConfirmation",


### PR DESCRIPTION
#### Summary

The Gateway Server parsed the `rctx` field in the `upinfo` object of upstream messages of the LoRa Basics Station LNS protocol using a misspelled JSON tag (`rtcx`). Since Basics Station gateways send `rctx` (per the LNS protocol), the radio context they reported was silently ignored and the antenna index was always 0. This PR fixes the field name so the value is actually consumed.

#### Changes

- Fix the JSON tag of `UpInfo.RCtx` from `rtcx` to `rctx`.
- Update test expectations accordingly.
- Add a CHANGELOG entry.

#### Testing

##### Steps

Run the package tests:

```
go test ./pkg/gatewayserver/io/semtechws/lbslns/
```

##### Results

```
ok  go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/semtechws/lbslns  2.732s
```

##### Regressions

Behaviour changes on multi-radio Basics Station gateways.

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.