### PR TITLE
Downlink support for multiple antennas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Parsing of the `rctx` field in the `upinfo` object of upstream messages received via the LoRa Basics Station LNS protocol. The field name was misspelled as `rtcx`, so the radio context reported by gateways was ignored. The antenna index in the uplink metadata now reflects the reported radio context and is echoed back in class A downlinks, instead of always being 0.
+- The antenna gain sent to LoRa Basics Station gateways in the router configuration. Each board's radio configuration now uses the gain of its own antenna instead of applying the first antenna's gain to all boards, and fractional gains are no longer truncated.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For details about compatibility between different releases, see the **Commitment
 - `gs_gateways_disconnected_total` metric, counting gateway disconnections by protocol and by the error the connection was disconnected with. This makes disconnection reasons (such as gateways disappearing without a close handshake, or missing too many pongs) observable as a rate, instead of only through logs.
 - `ttgc.managed-gateway-euis` configuration option: Gateway EUI prefixes of managed gateways, defaulting to the EUI prefix of The Things Industries managed gateways. Gateways outside these prefixes are reported as not managed in the claiming info.
 - `ttgc.lbscups.lns-port` configuration option: the LoRa Basics Station LNS port of the Gateway Server, defaulting to `8887`.
+- Downlink scheduling on all antennas of a gateway. Previously, only the first antenna could be used as a downlink path, and uplinks received on any other antenna had their downlink path disabled.
 
 ### Changed
 

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -116,6 +116,7 @@ type Connection struct {
 	gateway          *ttnpb.Gateway
 	gatewayPrimaryFP *frequencyplans.FrequencyPlan
 	gatewayFPs       []*frequencyplans.FrequencyPlan
+	antennaGains     []float32
 	band             *band.Band
 	fps              *frequencyplans.Store
 	scheduler        *scheduling.Scheduler
@@ -216,6 +217,25 @@ func NewConnection(
 		}
 	}
 
+	var fallbackAntennaGain float32
+	if len(gateway.Antennas) > 0 && gateway.Antennas[0] != nil {
+		fallbackAntennaGain = gateway.Antennas[0].Gain
+	}
+
+	// antennaGains is aligned index-for-index with gatewayFPs: antennaGains[i] is the gain for the
+	// board configured by gatewayFPs[i]. Physically each board carries exactly one antenna, but the
+	// registry does not enforce that the antennas and frequency plans of a gateway are registered
+	// consistently, so a gateway may have fewer antennas registered than frequency plans. In that
+	// case the gain of the first antenna is used as a fallback.
+	antennaGains := make([]float32, len(gatewayFPs))
+	for i := range gatewayFPs {
+		if i < len(gateway.Antennas) && gateway.Antennas[i] != nil {
+			antennaGains[i] = gateway.Antennas[i].Gain
+			continue
+		}
+		antennaGains[i] = fallbackAntennaGain
+	}
+
 	ctx, cancelCtx := errorcontext.New(ctx)
 	scheduler, err := scheduling.NewScheduler(
 		ctx, gatewayFPs, enforceDutyCycle, frontend.DutyCycleStyle(), scheduleAnytimeDelay, nil,
@@ -232,6 +252,7 @@ func NewConnection(
 		gateway:          gateway,
 		gatewayPrimaryFP: fp0,
 		gatewayFPs:       gatewayFPs,
+		antennaGains:     antennaGains,
 		band:             &phy,
 		fps:              fps,
 		scheduler:        scheduler,
@@ -871,6 +892,12 @@ func (c *Connection) PrimaryFrequencyPlan() *frequencyplans.FrequencyPlan { retu
 // BandID returns the common band ID for the frequency plans in this connection.
 // TODO: Handle mixed bands (https://github.com/TheThingsNetwork/lorawan-stack/issues/1394)
 func (c *Connection) BandID() string { return c.band.ID }
+
+// AntennaGains returns the antenna gains of the gateway, aligned index-for-index with the
+// frequency plans returned by FrequencyPlans(). When the gateway has fewer registered antennas
+// than frequency plans, the first antenna's gain (or 0 when there are no antennas) is used for
+// the remaining entries.
+func (c *Connection) AntennaGains() []float32 { return c.antennaGains }
 
 // SyncWithGatewayConcentrator synchronizes the clock with the given concentrator timestamp, the server time and the
 // relative gateway time that corresponds to the given timestamp.

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -342,11 +342,6 @@ func (c *Connection) HandleUp(up *ttnpb.UplinkMessage, frontendSync *FrontendClo
 	for _, md := range up.RxMetadata {
 		md.ReceivedAt = timestamppb.New(receivedAtGateway)
 
-		if md.AntennaIndex != 0 {
-			// TODO: Support downlink path to multiple antennas (https://github.com/TheThingsNetwork/lorawan-stack/issues/48)
-			md.DownlinkPathConstraint = ttnpb.DownlinkPathConstraint_DOWNLINK_PATH_CONSTRAINT_NEVER
-			continue
-		}
 		buf, err := UplinkToken(
 			&ttnpb.GatewayAntennaIdentifiers{
 				GatewayIds:   c.gateway.GetIds(),

--- a/pkg/gatewayserver/io/io_test.go
+++ b/pkg/gatewayserver/io/io_test.go
@@ -548,6 +548,8 @@ func TestFlow(t *testing.T) {
 }
 
 func TestNewConnectionAntennaGains(t *testing.T) {
+	t.Parallel()
+
 	ctx := test.Context()
 	frontend := &mock.Frontend{}
 	addr := &ttnpb.GatewayRemoteAddress{Ip: "127.0.0.1"}
@@ -587,6 +589,8 @@ func TestNewConnectionAntennaGains(t *testing.T) {
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			a := assertions.New(t)
 			gtw := &ttnpb.Gateway{
 				Ids:              &ttnpb.GatewayIdentifiers{GatewayId: "antenna-gain-test"},

--- a/pkg/gatewayserver/io/io_test.go
+++ b/pkg/gatewayserver/io/io_test.go
@@ -547,6 +547,62 @@ func TestFlow(t *testing.T) {
 	}
 }
 
+func TestNewConnectionAntennaGains(t *testing.T) {
+	ctx := test.Context()
+	frontend := &mock.Frontend{}
+	addr := &ttnpb.GatewayRemoteAddress{Ip: "127.0.0.1"}
+
+	for _, tc := range []struct {
+		Name          string
+		Antennas      []*ttnpb.GatewayAntenna
+		ExpectedGains []float32
+	}{
+		{
+			Name: "MatchesFrequencyPlans",
+			Antennas: []*ttnpb.GatewayAntenna{
+				{Gain: 3},
+				{Gain: 5},
+			},
+			ExpectedGains: []float32{3, 5},
+		},
+		{
+			Name: "FewerAntennasThanFrequencyPlans",
+			Antennas: []*ttnpb.GatewayAntenna{
+				{Gain: 3},
+			},
+			ExpectedGains: []float32{3, 3},
+		},
+		{
+			Name: "NilAntennaFallsBackToFirst",
+			Antennas: []*ttnpb.GatewayAntenna{
+				{Gain: 3},
+				nil,
+			},
+			ExpectedGains: []float32{3, 3},
+		},
+		{
+			Name:          "NoAntennas",
+			Antennas:      nil,
+			ExpectedGains: []float32{0, 0},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			a := assertions.New(t)
+			gtw := &ttnpb.Gateway{
+				Ids:              &ttnpb.GatewayIdentifiers{GatewayId: "antenna-gain-test"},
+				FrequencyPlanId:  "EU_863_870",
+				FrequencyPlanIds: []string{"EU_863_870", "EU_863_870"},
+				Antennas:         tc.Antennas,
+			}
+			conn, err := io.NewConnection(ctx, frontend, gtw, test.FrequencyPlanStore, true, nil, addr)
+			if !a.So(err, should.BeNil) {
+				t.FailNow()
+			}
+			a.So(conn.AntennaGains(), should.Resemble, tc.ExpectedGains)
+		})
+	}
+}
+
 func TestSubBandEIRPOverride(t *testing.T) {
 	a := assertions.New(t)
 	ctx := log.NewContext(test.Context(), test.GetLogger(t))

--- a/pkg/gatewayserver/io/semtechws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/semtechws/lbslns/upstream.go
@@ -560,16 +560,9 @@ func (f *lbsLNS) HandleUp( // nolint:gocyclo
 
 	switch typ {
 	case TypeUpstreamVersion:
-		var antennaGain int
-		antennas := conn.Gateway().Antennas
-		if len(antennas) != 0 && antennas[0] != nil {
-			// TODO: Support downlink path to multiple antennas (https://github.com/TheThingsNetwork/lorawan-stack/issues/48).
-			// Need to set different gain value to each `SX1301_conf` object as per https://doc.sm.tc/station/gw_v1.5.html#multi-board-sample-configuration.
-			// Currently we support downlink to only one antenna so the gain of the first antenna is applied to all (though the latter ones are not used).
-			// FPs and Antennas need to be synchronized. See https://github.com/TheThingsNetwork/lorawan-stack/issues/48#issuecomment-983412639.
-			antennaGain = int(antennas[0].Gain)
-		}
-		ctx, msg, stat, err := f.GetRouterConfig(ctx, raw, conn.BandID(), conn.FrequencyPlans(), antennaGain, receivedAt)
+		ctx, msg, stat, err := f.GetRouterConfig(
+			ctx, raw, conn.BandID(), conn.FrequencyPlans(), conn.AntennaGains(), receivedAt,
+		)
 		if err != nil {
 			logger.WithError(err).Warn("Failed to generate router configuration")
 			return nil, err

--- a/pkg/gatewayserver/io/semtechws/lbslns/version.go
+++ b/pkg/gatewayserver/io/semtechws/lbslns/version.go
@@ -64,7 +64,7 @@ func (*lbsLNS) GetRouterConfig(
 	msg []byte,
 	bandID string,
 	fps []*frequencyplans.FrequencyPlan,
-	antennaGain int,
+	antennaGains []float32,
 	receivedAt time.Time,
 ) (context.Context, []byte, *ttnpb.GatewayStatus, error) {
 	var version Version
@@ -76,7 +76,7 @@ func (*lbsLNS) GetRouterConfig(
 	// to gateways that signal the presence of a PPS.
 	// References https://github.com/lorabasics/basicstation/issues/135.
 	semtechws.UpdateSessionTimeSync(ctx, true)
-	cfg, err := pfconfig.GetRouterConfig(ctx, bandID, fps, version, time.Now(), antennaGain)
+	cfg, err := pfconfig.GetRouterConfig(ctx, bandID, fps, version, time.Now(), antennaGains)
 	if err != nil {
 		return ctx, nil, nil, err
 	}

--- a/pkg/pfconfig/lbslns/lbslbs_test.go
+++ b/pkg/pfconfig/lbslns/lbslbs_test.go
@@ -271,7 +271,7 @@ func TestGetRouterConfig(t *testing.T) {
 
 			a, ctx := test.New(t)
 			fps := []*frequencyplans.FrequencyPlan{&tc.FrequencyPlan}
-			cfg, err := GetRouterConfig(ctx, tc.FrequencyPlan.BandID, fps, tc.Features, time.Now(), 0)
+			cfg, err := GetRouterConfig(ctx, tc.FrequencyPlan.BandID, fps, tc.Features, time.Now(), nil)
 			if err != nil {
 				if tc.ErrorAssertion == nil || !a.So(tc.ErrorAssertion(err), should.BeTrue) {
 					t.Fatalf("Unexpected error: %v", err)
@@ -295,13 +295,15 @@ func TestGetRouterConfigWithMultipleFP(t *testing.T) {
 		Name           string
 		BandID         string
 		FrequencyPlans []*frequencyplans.FrequencyPlan
+		AntennaGains   []float32
 		Cfg            RouterConfig
 		Features       TestFeatures
 		ErrorAssertion func(err error) bool
 	}{
 		{
-			Name:   "ValidFrequencyPlan",
-			BandID: "US_902_928",
+			Name:         "ValidFrequencyPlan",
+			BandID:       "US_902_928",
+			AntennaGains: []float32{3, 3},
 			FrequencyPlans: []*frequencyplans.FrequencyPlan{
 				{
 					BandID: "US_902_928",
@@ -463,12 +465,177 @@ func TestGetRouterConfigWithMultipleFP(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:         "DistinctAntennaGains",
+			BandID:       "US_902_928",
+			AntennaGains: []float32{3, 6},
+			FrequencyPlans: []*frequencyplans.FrequencyPlan{
+				{
+					BandID: "US_902_928",
+					Radios: []frequencyplans.Radio{
+						{
+							Enable:    true,
+							ChipType:  "SX1257",
+							Frequency: 924300000,
+							TxConfiguration: &frequencyplans.RadioTxConfiguration{
+								MinFrequency: 909000000,
+								MaxFrequency: 927000000,
+							},
+						},
+						{
+							Enable:    false,
+							ChipType:  "SX1257",
+							Frequency: 925000000,
+						},
+					},
+				},
+				{
+					BandID: "US_902_928",
+					Radios: []frequencyplans.Radio{
+						{
+							Enable:    true,
+							ChipType:  "SX1257",
+							Frequency: 924300000,
+							TxConfiguration: &frequencyplans.RadioTxConfiguration{
+								MinFrequency: 900000000,
+								MaxFrequency: 925000000,
+							},
+						},
+						{
+							Enable:    false,
+							ChipType:  "SX1257",
+							Frequency: 925000000,
+						},
+					},
+				},
+			},
+			Cfg: RouterConfig{
+				Region:         "US902",
+				HardwareSpec:   "sx1301/2",
+				FrequencyRange: []int{900000000, 927000000},
+				DataRates: DataRates{
+					[3]int{10, 125, 0},
+					[3]int{9, 125, 0},
+					[3]int{8, 125, 0},
+					[3]int{7, 125, 0},
+					[3]int{8, 500, 0},
+					[3]int{0, 0, 0},
+					[3]int{0, 0, 0},
+					[3]int{0, 0, 0},
+					[3]int{12, 500, 0},
+					[3]int{11, 500, 0},
+					[3]int{10, 500, 0},
+					[3]int{9, 500, 0},
+					[3]int{8, 500, 0},
+					[3]int{7, 500, 0},
+				},
+				NoCCA:       true,
+				NoDutyCycle: true,
+				NoDwellTime: true,
+				SX1301Config: []LBSSX1301Config{
+					{
+						Radios: []LBSRFConfig{
+							{
+								Enable:      true,
+								Frequency:   924300000,
+								AntennaGain: 3,
+							},
+							{
+								Enable:      false,
+								Frequency:   925000000,
+								AntennaGain: 3,
+							},
+						},
+						Channels: []shared.IFConfig{
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+						},
+						LoRaStandardChannel: &shared.IFConfig{
+							Enable:       false,
+							Radio:        0,
+							IFValue:      0,
+							Bandwidth:    0,
+							SpreadFactor: 0,
+							Datarate:     0,
+						},
+						FSKChannel: &shared.IFConfig{
+							Enable:       false,
+							Radio:        0,
+							IFValue:      0,
+							Bandwidth:    0,
+							SpreadFactor: 0,
+							Datarate:     0,
+						},
+					},
+					{
+						Radios: []LBSRFConfig{
+							{
+								Enable:      true,
+								Frequency:   924300000,
+								AntennaGain: 6,
+							},
+							{
+								Enable:      false,
+								Frequency:   925000000,
+								AntennaGain: 6,
+							},
+						},
+						Channels: []shared.IFConfig{
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+							{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
+						},
+						LoRaStandardChannel: &shared.IFConfig{
+							Enable:       false,
+							Radio:        0,
+							IFValue:      0,
+							Bandwidth:    0,
+							SpreadFactor: 0,
+							Datarate:     0,
+						},
+						FSKChannel: &shared.IFConfig{
+							Enable:       false,
+							Radio:        0,
+							IFValue:      0,
+							Bandwidth:    0,
+							SpreadFactor: 0,
+							Datarate:     0,
+						},
+					},
+				},
+				Beacon: &BeaconingConfig{
+					DR:     ttnpb.DataRateIndex_DATA_RATE_8,
+					Layout: [3]int{5, 11, 23},
+					Freqs: []uint64{
+						923300000,
+						923900000,
+						924500000,
+						925100000,
+						925700000,
+						926300000,
+						926900000,
+						927500000,
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
 			a, ctx := test.New(t)
-			cfg, err := GetRouterConfig(ctx, tc.BandID, tc.FrequencyPlans, tc.Features, time.Now(), 3)
+			cfg, err := GetRouterConfig(ctx, tc.BandID, tc.FrequencyPlans, tc.Features, time.Now(), tc.AntennaGains)
 			if err != nil {
 				if tc.ErrorAssertion == nil || !a.So(tc.ErrorAssertion(err), should.BeTrue) {
 					t.Fatalf("Unexpected error: %v", err)

--- a/pkg/pfconfig/lbslns/lbslns.go
+++ b/pkg/pfconfig/lbslns/lbslns.go
@@ -141,7 +141,7 @@ func (c LBSSX1301Config) MarshalJSON() ([]byte, error) {
 }
 
 // fromSX1301Conf updates fields from shared.SX1301Config.
-func (c *LBSSX1301Config) fromSX1301Conf(sx1301Conf shared.SX1301Config, antennaGain int) {
+func (c *LBSSX1301Config) fromSX1301Conf(sx1301Conf shared.SX1301Config, antennaGain float32) {
 	c.LoRaStandardChannel = sx1301Conf.LoRaStandardChannel
 	c.FSKChannel = sx1301Conf.FSKChannel
 	c.LBTConfig = sx1301Conf.LBTConfig
@@ -150,7 +150,7 @@ func (c *LBSSX1301Config) fromSX1301Conf(sx1301Conf shared.SX1301Config, antenna
 		c.Radios = append(c.Radios, LBSRFConfig{
 			Enable:      radio.Enable,
 			Frequency:   radio.Frequency,
-			AntennaGain: antennaGain,
+			AntennaGain: int(antennaGain),
 		})
 	}
 
@@ -271,13 +271,14 @@ type RouterFeatures interface {
 // GetRouterConfig returns the routerconfig message to be sent to the gateway.
 // Currently as per the LBS docs, all frequency plans have to be from the same region (band).
 // https://doc.sm.tc/station/tcproto.html#router-config-message.
+// antennaGains is aligned index-for-index with fps, and missing entries default to 0.
 func GetRouterConfig(
 	ctx context.Context,
 	bandID string,
 	fps []*frequencyplans.FrequencyPlan,
 	features RouterFeatures,
 	dlTime time.Time,
-	antennaGain int,
+	antennaGains []float32,
 ) (RouterConfig, error) {
 	for _, fp := range fps {
 		if err := fp.Validate(); err != nil {
@@ -324,13 +325,17 @@ func GetRouterConfig(
 	conf.NoDutyCycle = !production
 	conf.NoDwellTime = !production
 
-	for _, fp := range fps {
+	for i, fp := range fps {
 		if len(fp.Radios) == 0 {
 			continue
 		}
 		sx1301Conf, err := shared.BuildSX1301Config(fp)
 		if err != nil {
 			return RouterConfig{}, err
+		}
+		var antennaGain float32
+		if i < len(antennaGains) {
+			antennaGain = antennaGains[i]
 		}
 		var lbsSX1301Config LBSSX1301Config
 		lbsSX1301Config.fromSX1301Conf(*sx1301Conf, antennaGain)


### PR DESCRIPTION
References: https://github.com/TheThingsNetwork/lorawan-stack/issues/48.

#### Summary



#### Changes

<!-- What are the changes made in this pull request? -->

- Drop the `DOWNLINK_PATH_CONSTRAINT_NEVER` constraint to allow using other antennas for the downlink path, not only antenna 0.
- Align the antenna gains with the frequency plans and set them in the LBS `router_config`. Fallback on the gain of the first antenna if fewer antennas are registered than frequency plans.

#### Testing

Using a local running instance of The Things Stack, I've used the examples in the https://github.com/lorabasics/basicstation repository to simulate a gateway.

##### Steps

Test setup:

<details><summary>station.conf</summary>
<p>

```
{
    /* If slave-X.conf present this acts as default settings */
    "SX1301_conf": {                 /* Actual channel plan is controlled by server */
        "lorawan_public": true,      /* is default */
        "clksrc": 1,                 /* radio_1 provides clock to concentrator */
        "device": "spidev",
        "radio_0": {
            /* freq/enable provided by LNS - only HW specific settings listed here */
            "type": "SX1257",
            "rssi_offset": -166.0,
            "tx_enable": true,
            "antenna_gain": 0,
            "antenna_type": "sector"
        },
        "radio_1": {
            "type": "SX1257",
            "rssi_offset": -166.0,
            "tx_enable": false
        }
        /* chan_multiSF_X, chan_Lora_std, chan_FSK provided by LNS */
    },
    "station_conf": {
        "routerid": "AA:A0:CB:FF:FE:80:0D:B1",
        /* "log_file":  "station.log", */
        "log_file":  "stderr",
        "log_level": "XDEBUG",  /* XDEBUG,DEBUG,VERBOSE,INFO,NOTICE,WARNING,ERROR,CRITICAL */
        "log_size":  10000000,
        "log_rotate":  3,
        /* required for success checks of tests */
        "nodc": true,
        "CLASS_C_BACKOFF_BY": "100ms",
        "CLASS_C_BACKOFF_MAX": 10
    }
}
```

</p>
</details>

<details><summary>Gateway Setup</summary>
<p>

```bash
ttn-lw-cli gateways create sim2ant --user-id admin --gateway-eui "AAA0CBFFFE800DB1" --frequency-plan-ids EU_863_870,EU_863_870
ttn-lw-cli gateways set sim-2ant --antenna.gain 3 --antenna.add
ttn-lw-cli gateways set sim-2ant --antenna.index 1 --antenna.gain 6 --antenna.add
```

</p>
</details> 

I started the gateway and watched the requests between TTS and the simulated LBS.

##### Results

These can be seen in the station logs:

- "hwspec":"sx1301/2" — the GS declared two boards
- sx1301_conf[0] carries "antenna_gain": 3 and sx1301_conf[1] carries "antenna_gain": 6, on each board's radios
- The station's master accepted the config:

```
2026-09-04 13:21:21.020 [RAL:INFO] Region plan hwspec 'sx1301/2' mapped to 2 slaves 'sx1301/1'
2026-09-04 13:21:21.020 [RAL:INFO] Master sending 713 bytes of JSON sx1301conf to slave (0)
2026-09-04 13:21:21.020 [RAL:INFO] Master sending 573 bytes of JSON sx1301conf to slave (1)
2026-09-04 13:21:21.020 [S2E:INFO] Configuring for region: EU868 -- 863.0MHz..870.0MHz
```

<details><summary>Full logs.</summary>
<p>

```
2026-09-04 13:21:21.017 [AIO:XDEB] [5|WS] > {"msgtype":"version","station":"2.0.6(linux/testms)","firmware":null,"package":null,"model":"linux","protocol":2,"features":"rmtsh"}
2026-09-04 13:21:21.017 [AIO:XDEB] [5] socket write bytes=140
2026-09-04 13:21:21.018 [AIO:XDEB] [5] socket read  bytes=1712
2026-09-04 13:21:21.018 [AIO:XDEB] [5|WS] < {"msgtype":"router_config","NetID":null,"JoinEui":null,"region":"EU863","hwspec":"sx1301/2","freq_range":[863000000,870000000],"DRs":[[12,125,0],[11,125,0],[10,125,0],[9,125,0],[8,125,0],[7,125,0],[7,250,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0]],"sx1301_conf":[{"radio_0":{"enable":true,"freq":867500000,"antenna_gain":3},"radio_1":{"enable":true,"freq":868500000,"antenna_gain":3},"chan_multiSF_0":{"enable":true,"radio":1,"if"
2026-09-04 13:21:21.019 [AIO:XDEB] [5|WS] . :-400000},"chan_multiSF_1":{"enable":true,"radio":1,"if":-200000},"chan_multiSF_2":{"enable":true,"radio":1,"if":0},"chan_multiSF_3":{"enable":true,"radio":0,"if":-400000},"chan_multiSF_4":{"enable":true,"radio":0,"if":-200000},"chan_multiSF_5":{"enable":true,"radio":0,"if":0},"chan_multiSF_6":{"enable":true,"radio":0,"if":200000},"chan_multiSF_7":{"enable":true,"radio":0,"if":400000},"chan_Lora_std":{"enable":true,"radio":1,"if":-200000,"bandwidth":250000,"
2026-09-04 13:21:21.019 [AIO:XDEB] [5|WS] . spread_factor":7},"chan_FSK":{"enable":true,"radio":1,"if":300000,"datarate":50000}},{"radio_0":{"enable":true,"freq":867500000,"antenna_gain":6},"radio_1":{"enable":true,"freq":868500000,"antenna_gain":6},"chan_multiSF_0":{"enable":true,"radio":1,"if":-400000},"chan_multiSF_1":{"enable":false},"chan_multiSF_2":{"enable":false},"chan_multiSF_3":{"enable":false},"chan_multiSF_4":{"enable":false},"chan_multiSF_5":{"enable":false},"chan_multiSF_6":{"enable":fal
2026-09-04 13:21:21.019 [AIO:XDEB] [5|WS] . se},"chan_multiSF_7":{"enable":false},"chan_Lora_std":{"enable":true,"radio":1,"if":-200000,"bandwidth":250000,"spread_factor":7},"chan_FSK":{"enable":true,"radio":1,"if":300000,"datarate":50000}}],"nocca":true,"nodc":true,"nodwell":true,"MuxTime":1788528081.019047,"bcning":{"DR":3,"layout":[2,8,17],"freqs":[869525000]}}
2026-09-04 13:21:21.020 [RAL:INFO] Region plan hwspec 'sx1301/2' mapped to 2 slaves 'sx1301/1'
2026-09-04 13:21:21.020 [RAL:INFO] Master sending 713 bytes of JSON sx1301conf to slave (0)
2026-09-04 13:21:21.020 [RAL:INFO] Master sending 573 bytes of JSON sx1301conf to slave (1)
2026-09-04 13:21:21.020 [S2E:INFO] Configuring for region: EU868 -- 863.0MHz..870.0MHz
```

</p>
</details> 

These can be seen in the live data of the gateway for simulated uplinks.

This uplink does not have any antenna index because because proto3 JSON omits the zero-valued:
```json
"rx_metadata": [
  {
    "gateway_ids": {
      "gateway_id": "sim-2ant",
      "eui": "AAA0CBFFFE800DB1"
    },
    "time": "2026-09-04T12:21:11.046260118Z",
    "timestamp": 388669041,
    "rssi": -50,
    "channel_rssi": -50,
    "snr": 9,
    "uplink_token": "ChYKFAoIc2ltLTJhbnQSCKqgy//+gA2xEPG8qrkBGgsIt+/q1AYQkLCzHCDo0uvzpws=",
    "received_at": "2026-09-04T12:21:11.055968989Z"
  }
]
```

But this uplink has the antenna index, the uplink token and there is no DOWNLINK_PATH_CONSTRAINT_NEVER:
```json
"rx_metadata": [
  {
    "gateway_ids": {
      "gateway_id": "sim-2ant",
      "eui": "AAA0CBFFFE800DB1"
    },
    "antenna_index": 1, // antenna_index appears here.
    "time": "2026-09-04T12:21:21.061058044Z",
    "timestamp": 398691101,
    "rssi": -50,
    "channel_rssi": -50,
    "snr": 9,
    "uplink_token": "ChgKFAoIc2ltLTJhbnQSCKqgy//+gA2xEAEQnZaOvgEaCwjB7+rUBhDg9L8gIMjS3Z7NCw==",
    "received_at": "2026-09-04T12:21:21.064577973Z"
  }
]
```

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

...

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
