### PR TITLE
util: Fix flaky timeout case in rpcretry unary interceptor test

### DIFF
--- a/pkg/rpcmiddleware/rpcretry/client_interceptors_test.go
+++ b/pkg/rpcmiddleware/rpcretry/client_interceptors_test.go
@@ -17,6 +17,7 @@ package rpcretry_test
 import (
 	"context"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -40,13 +41,13 @@ type unaryService struct {
 	rpctest.FooBarServer
 	md metadata.MD
 
-	counter uint
+	counter atomic.Int64
 	err     error
 	sleep   time.Duration
 }
 
 func (fs *unaryService) Unary(ctx context.Context, foo *rpctest.Foo) (*rpctest.Bar, error) {
-	fs.counter++
+	fs.counter.Add(1)
 	time.Sleep(fs.sleep)
 
 	if err := grpc.SendHeader(ctx, fs.md); err != nil {
@@ -74,7 +75,7 @@ func Test_UnaryClientInterceptor(t *testing.T) {
 		service           Service
 		client            Client
 		errAssertion      func(error) bool
-		expectedReqAmount int
+		expectedReqAmount int64
 	}{
 		{
 			name:              "no error",
@@ -106,7 +107,7 @@ func Test_UnaryClientInterceptor(t *testing.T) {
 					return ctx
 				},
 			},
-			service:           Service{sleep: 5 * test.Delay},
+			service:           Service{sleep: 8 * test.Delay},
 			errAssertion:      errors.IsDeadlineExceeded,
 			expectedReqAmount: 1,
 		},
@@ -168,7 +169,7 @@ func Test_UnaryClientInterceptor(t *testing.T) {
 				a.So(err, should.BeNil)
 				a.So(resp.Message, should.Equal, "bar")
 			}
-			a.So(testService.counter, should.Equal, tt.expectedReqAmount)
+			a.So(testService.counter.Load(), should.Equal, tt.expectedReqAmount)
 		})
 	}
 }


### PR DESCRIPTION
#### Summary

<!--
A short summary, referencing related issues:
References #0000, etc.
Pull requests may close issues (using Closes #0000) only for minor changes not needing tests on a staging environment.
Typically, issues should be closed manually after validation.
-->

Fix flaky timeout test.

#### Changes

<!-- What are the changes made in this pull request? -->

- The client context deadline and the mock server's sleep were both five test delays:
  - Increase the server sleep to 8 test delays
- Make the counter atomic

#### Testing

Unit tests.

##### Regressions

<!--
Please indicate features that this change could affect and how that was tested.
Also describe the steps required for others to test these regressions.
-->

...

#### Notes for Reviewers

<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist

<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Testing: The steps/process to test this feature are clearly explained including testing for regressions.
- [ ] Infrastructure: If infrastructural changes (e.g., new RPC, configuration) are needed, a separate issue is created in the infrastructural repositories.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
